### PR TITLE
Fix Double Quote and AlbumId variable for Search

### DIFF
--- a/src/UI/Artist/Details/AlbumLayout.js
+++ b/src/UI/Artist/Details/AlbumLayout.js
@@ -154,7 +154,7 @@ module.exports = Marionette.Layout.extend({
             command : {
                 name         : 'albumSearch',
                 artistId     : this.artist.id,
-                albumId : this.model.get('albumId')
+                albumId : this.model.get('id')
             }
         });
 
@@ -163,7 +163,7 @@ module.exports = Marionette.Layout.extend({
             command : {
                 name         : 'renameFiles',
                 artistId     : this.artist.id,
-                albumId : this.model.get('albumId')
+                albumId : this.model.get('id')
             }
         });
     },
@@ -182,14 +182,14 @@ module.exports = Marionette.Layout.extend({
         CommandController.Execute('albumSearch', {
             name         : 'albumSearch',
             artistId     : this.artist.id,
-            albumId : this.model.get('albumId')
+            albumId : this.model.get('id')
         });
     },
 
     _albumRename : function() {
         vent.trigger(vent.Commands.ShowRenamePreview, {
             artist       : this.artist,
-            albumId : this.model.get('albumId')
+            albumId : this.model.get('id')
         });
     },
 

--- a/src/UI/Cells/ArtistMonitoredCell.js
+++ b/src/UI/Cells/ArtistMonitoredCell.js
@@ -21,7 +21,7 @@ module.exports = ToggleCell.extend({
             this.$('i').addClass(this.column.get('falseClass'));
         }
 
-        var link = "/artist/" + this.model.get('nameSlug');
+        var link = '/artist/' + this.model.get('nameSlug');
         var artistName = this.model.get('name');
 
         this.$('a').attr('href', link );


### PR DESCRIPTION
Fix Double Quote and AlbumID variable for Search

#### Database Migration
NO

#### Description
Fixes a JS double quote codacy issue and passes correct albumId variable on search call. 
