### PR TITLE
Fixed: Ensure an API Key is set when starting Lidarr

### DIFF
--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -142,7 +142,21 @@ namespace NzbDrone.Core.Configuration
 
         public bool LaunchBrowser => GetValueBoolean("LaunchBrowser", true);
 
-        public string ApiKey => GetValue("ApiKey", GenerateApiKey());
+        public string ApiKey
+        {
+            get
+            {
+                var apiKey = GetValue("ApiKey", GenerateApiKey());
+
+                if (apiKey.IsNullOrWhiteSpace())
+                {
+                    apiKey = GenerateApiKey();
+                    SetValue("ApiKey", apiKey);
+                }
+
+                return apiKey;
+            }
+        }
 
         public AuthenticationType AuthenticationMethod
         {


### PR DESCRIPTION
Fixed: Ensure an API Key is set when starting Lidarr

#### Database Migration
NO

#### Description

Reference Sonarr/Sonarr@6bbe4ce
Reference Radarr/Radarr@7af8803


