### PR TITLE
Fixed: Remove redundant IE meta tag as we use http header instead

### DIFF
--- a/src/UI/index.html
+++ b/src/UI/index.html
@@ -2,7 +2,6 @@
 <html>
 <head>
     <title>Lidarr</title>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta name="mobile-web-app-capable" content="yes"/>
     <meta name="apple-mobile-web-app-capable" content="yes"/>

--- a/src/UI/login.html
+++ b/src/UI/login.html
@@ -2,7 +2,6 @@
 <html>
 <head>
     <title>Lidarr - Login</title>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">


### PR DESCRIPTION
Remove redundant IE meta tag as we use http header instead

#### Database Migration
NO

#### Description

Radarr/Radarr@b1c5dd8
Sonarr/Sonarr@2ae41a3