### PR TITLE
Fixed: Album Folder Toggle/Artist Name in Edit Artist Popup

### DIFF
--- a/src/UI/Artist/Edit/EditArtistViewTemplate.hbs
+++ b/src/UI/Artist/Edit/EditArtistViewTemplate.hbs
@@ -1,7 +1,7 @@
 <div class="modal-content">
     <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-        <h3>{{title}}</h3>
+        <h3>{{name}}</h3>
     </div>
     <div class="modal-body edit-artist-modal">
         <div class="row">
@@ -27,7 +27,7 @@
                                 </label>
 
                                 <span class="help-inline-checkbox">
-                                    <i class="icon-lidarr-form-info" title="Should Lidarr download tracks for this artist?"/>
+                                    <i class="icon-lidarr-form-info" title="Should Lidarr download albums for this artist?"/>
                                 </span>
                             </div>
                         </div>
@@ -39,7 +39,7 @@
                         <div class="col-sm-8">
                             <div class="input-group">
                                 <label class="checkbox toggle well">
-                                    <input type="checkbox" name="seasonFolder"/>
+                                    <input type="checkbox" name="albumFolder"/>
                                     <p>
                                         <span>Yes</span>
                                         <span>No</span>
@@ -49,7 +49,7 @@
                                 </label>
 
                                 <span class="help-inline-checkbox">
-                                    <i class="icon-lidarr-form-info" title="Should downloaded tracks be stored in album folders?"/>
+                                    <i class="icon-lidarr-form-info" title="Should downloaded albums be stored in album folders?"/>
                                 </span>
                             </div>
                         </div>


### PR DESCRIPTION
Fixed: Album Folder Toggle/Artist Name in Edit Artist Popup

#### Database Migration
NO

#### Description
Fixes the AlbumFolder toggle switch and the Artist Name not showing in the Artist Edit Popup Window
