### PR TITLE
Fixed: Artist Delete, Track Delete when Artist Delete

### DIFF
--- a/src/NzbDrone.Core/Music/TrackRepository.cs
+++ b/src/NzbDrone.Core/Music/TrackRepository.cs
@@ -48,7 +48,7 @@ namespace NzbDrone.Core.Music
 
         public List<Track> GetTracks(int artistId)
         {
-            return Query.Join<Track, Artist>(JoinType.Inner, s => s.Artist, (track, artist) => track.ArtistId == artist.Id).ToList();
+            return Query.Where(s => s.ArtistId == artistId).ToList();
         }
 
         public List<Track> GetTracks(int artistId, int albumId)

--- a/src/UI/Artist/Delete/DeleteArtistTemplate.hbs
+++ b/src/UI/Artist/Delete/DeleteArtistTemplate.hbs
@@ -1,7 +1,7 @@
 <div class="modal-content">
     <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-        <h3>Delete {{title}}</h3>
+        <h3>Delete {{name}}</h3>
     </div>
     <div class="modal-body delete-artist-modal">
 
@@ -36,7 +36,7 @@
                         </div>
                     </div>
                     <div class="col-md-offset-1 col-md-5 delete-files-info x-delete-files-info">
-                        {{episodeFileCount}} track files will be deleted
+                        {{trackFileCount}} track files will be deleted
                     </div>
                 </div>
             </div>

--- a/src/UI/Artist/Delete/DeleteArtistView.js
+++ b/src/UI/Artist/Delete/DeleteArtistView.js
@@ -2,7 +2,7 @@ var vent = require('vent');
 var Marionette = require('marionette');
 
 module.exports = Marionette.ItemView.extend({
-    template : 'Series/Delete/DeleteSeriesTemplate',
+    template : 'Artist/Delete/DeleteArtistTemplate',
 
     events : {
         'click .x-confirm-delete' : 'removeSeries',


### PR DESCRIPTION
Fixed: Artist Delete, Track Delete when Artist Delete

#### Database Migration
NO

#### Description

- Fixes Artist Delete template now shows correct template.
- Tracks are now deleted from DB during artist delete. (When using the join query, we can never find artist during a delete as its deleted first. Thus no tracks were returned in query. Changing this to left join will also work if we absolutely need Artist returned with results.)
