### PR TITLE
Add Paging to Waffles Requests

### DIFF
--- a/src/NzbDrone.Core/Indexers/Waffles/WafflesRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Waffles/WafflesRequestGenerator.cs
@@ -10,12 +10,18 @@ namespace NzbDrone.Core.Indexers.Waffles
     public class WafflesRequestGenerator : IIndexerRequestGenerator
     {
         public WafflesSettings Settings { get; set; }
-        
+        public int MaxPages { get; set; }
+
+        public WafflesRequestGenerator()
+        {
+            MaxPages = 5;
+        }
+
         public virtual IndexerPageableRequestChain GetRecentRequests()
         {
             var pageableRequests = new IndexerPageableRequestChain();
 
-            pageableRequests.Add(GetPagedRequests(null));
+            pageableRequests.Add(GetPagedRequests(MaxPages, null));
 
             return pageableRequests;
         }
@@ -54,7 +60,7 @@ namespace NzbDrone.Core.Indexers.Waffles
         {
             var pageableRequests = new IndexerPageableRequestChain();
 
-            pageableRequests.Add(GetPagedRequests(string.Format("&q=artist:{0} album:{1}",searchCriteria.Artist.Name,searchCriteria.AlbumTitle)));
+            pageableRequests.Add(GetPagedRequests(MaxPages, string.Format("&q=artist:{0} album:{1}",searchCriteria.Artist.Name,searchCriteria.AlbumTitle)));
 
             return pageableRequests;
         }
@@ -63,12 +69,12 @@ namespace NzbDrone.Core.Indexers.Waffles
         {
             var pageableRequests = new IndexerPageableRequestChain();
 
-            pageableRequests.Add(GetPagedRequests(string.Format("&q=artist:{0}", searchCriteria.Artist.Name)));
+            pageableRequests.Add(GetPagedRequests(MaxPages, string.Format("&q=artist:{0}", searchCriteria.Artist.Name)));
 
             return pageableRequests;
         }
 
-        private IEnumerable<IndexerRequest> GetPagedRequests(string query)
+        private IEnumerable<IndexerRequest> GetPagedRequests(int maxPages, string query)
         { 
 
             var url = new StringBuilder();
@@ -80,7 +86,7 @@ namespace NzbDrone.Core.Indexers.Waffles
                 url.AppendFormat(query);
             }
 
-            for (var page = 0; page < 5; page++)
+            for (var page = 0; page < maxPages; page++)
             {
                 yield return new IndexerRequest(string.Format("{0}&p={1}", url, page), HttpAccept.Rss);
             }

--- a/src/NzbDrone.Core/Indexers/Waffles/WafflesRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Waffles/WafflesRequestGenerator.cs
@@ -80,7 +80,10 @@ namespace NzbDrone.Core.Indexers.Waffles
                 url.AppendFormat(query);
             }
 
-            yield return new IndexerRequest(url.ToString(), HttpAccept.Rss);
+            for (var page = 0; page < 5; page++)
+            {
+                yield return new IndexerRequest(string.Format("{0}&p={1}", url, page), HttpAccept.Rss);
+            }
         }
     }
 }


### PR DESCRIPTION
Add Paging to Waffles Requests

#### Database Migration
NO

#### Description
Adds paging to waffles requests. Returns 75 results now instead of 15. 

