### PR TITLE
Fixed: Change AlbumSearchCommand to public to resolve error when searching

### DIFF
--- a/src/NzbDrone.Core/IndexerSearch/AlbumSearchCommand.cs
+++ b/src/NzbDrone.Core/IndexerSearch/AlbumSearchCommand.cs
@@ -3,7 +3,7 @@ using NzbDrone.Core.Messaging.Commands;
 
 namespace NzbDrone.Core.IndexerSearch
 {
-    class AlbumSearchCommand : Command
+    public class AlbumSearchCommand : Command
     {
         public List<int> AlbumIds { get; set; }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Change `AlbumSearchCommand` to public visibility. This was missed before and caused an issue with searching for albums.

#### Todos
- [ ] ~Tests~
- [ ] ~Documentation~


#### Issues Fixed or Closed by this PR

* Unreported: Error when searching for album.
