### PR TITLE
Create Orphaned Albums Housekeeper

### DIFF
--- a/src/NzbDrone.Core.Test/Housekeeping/Housekeepers/CleanupOrphanedAlbumsFixture.cs
+++ b/src/NzbDrone.Core.Test/Housekeeping/Housekeepers/CleanupOrphanedAlbumsFixture.cs
@@ -1,0 +1,43 @@
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Housekeeping.Housekeepers;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Music;
+
+namespace NzbDrone.Core.Test.Housekeeping.Housekeepers
+{
+    [TestFixture]
+    public class CleanupOrphanedAlbumsFixture : DbTest<CleanupOrphanedAlbums, Album>
+    {
+        [Test]
+        public void should_delete_orphaned_albums()
+        {
+            var album = Builder<Album>.CreateNew()
+                                          .BuildNew();
+
+            Db.Insert(album);
+            Subject.Clean();
+            AllStoredModels.Should().BeEmpty();
+        }
+
+        [Test]
+        public void should_not_delete_unorphaned_albums()
+        {
+            var artist = Builder<Artist>.CreateNew()
+                                        .BuildNew();
+
+            Db.Insert(artist);
+
+            var albums = Builder<Album>.CreateListOfSize(2)
+                                          .TheFirst(1)
+                                          .With(e => e.ArtistId = artist.Id)
+                                          .BuildListOfNew();
+
+            Db.InsertMany(albums);
+            Subject.Clean();
+            AllStoredModels.Should().HaveCount(1);
+            AllStoredModels.Should().Contain(e => e.ArtistId == artist.Id);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -235,6 +235,7 @@
     <Compile Include="Housekeeping\Housekeepers\CleanupAdditionalNamingSpecsFixture.cs" />
     <Compile Include="Housekeeping\Housekeepers\CleanupAbsolutePathMetadataFilesFixture.cs" />
     <Compile Include="Housekeeping\Housekeepers\CleanupDuplicateMetadataFilesFixture.cs" />
+    <Compile Include="Housekeeping\Housekeepers\CleanupOrphanedAlbumsFixture.cs" />
     <Compile Include="Housekeeping\Housekeepers\CleanupOrphanedBlacklistFixture.cs" />
     <Compile Include="Housekeeping\Housekeepers\CleanupOrphanedTrackFilesFixture.cs" />
     <Compile Include="Housekeeping\Housekeepers\CleanupOrphanedTracksFixture.cs" />

--- a/src/NzbDrone.Core/Housekeeping/Housekeepers/CleanupOrphanedAlbums.cs
+++ b/src/NzbDrone.Core/Housekeeping/Housekeepers/CleanupOrphanedAlbums.cs
@@ -1,0 +1,26 @@
+using NzbDrone.Core.Datastore;
+
+namespace NzbDrone.Core.Housekeeping.Housekeepers
+{
+    public class CleanupOrphanedAlbums : IHousekeepingTask
+    {
+        private readonly IMainDatabase _database;
+
+        public CleanupOrphanedAlbums(IMainDatabase database)
+        {
+            _database = database;
+        }
+
+        public void Clean()
+        {
+            var mapper = _database.GetDataMapper();
+
+            mapper.ExecuteNonQuery(@"DELETE FROM Albums
+                                     WHERE Id IN (
+                                     SELECT Albums.Id FROM Albums
+                                     LEFT OUTER JOIN Artists
+                                     ON Albums.ArtistId = Artists.Id
+                                     WHERE Artists.Id IS NULL)");
+        }
+    }
+}

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -589,6 +589,7 @@
     <Compile Include="Housekeeping\Housekeepers\CleanupCommandQueue.cs" />
     <Compile Include="Housekeeping\Housekeepers\CleanupAbsolutePathMetadataFiles.cs" />
     <Compile Include="Housekeeping\Housekeepers\CleanupDuplicateMetadataFiles.cs" />
+    <Compile Include="Housekeeping\Housekeepers\CleanupOrphanedAlbums.cs" />
     <Compile Include="Housekeeping\Housekeepers\CleanupOrphanedBlacklist.cs" />
     <Compile Include="Housekeeping\Housekeepers\CleanupOrphanedTrackFiles.cs" />
     <Compile Include="Housekeeping\Housekeepers\CleanupOrphanedTracks.cs" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Create a housekeeper for albums leftover in DB that have no valid artist association. 

#### Todos
- [x] Tests


#### Issues Fixed or Closed by this PR
#64 
* 
