### PR TITLE
Change AlbumResource label to labels due to the change metadata

### DIFF
--- a/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/AlbumResource.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/AlbumResource.cs
@@ -20,7 +20,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook.Resource
         public string Title { get; set; }
         public string Overview { get; set; }
         public List<string> Genres { get; set; }
-        public List<string> Label { get; set; }
+        public List<string> Labels { get; set; }
         public string Type { get; set; }
         public List<MediumResource> Media { get; set; }
         public List<TrackResource> Tracks { get; set; }

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -156,7 +156,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             album.CleanTitle = Parser.Parser.CleanArtistName(album.Title);
             album.AlbumType = resource.Type;
             album.Images = resource.Images.Select(MapImage).ToList();
-            album.Label = resource.Label;
+            album.Label = resource.Labels;
 
             album.Media = resource.Media.Select(MapMedium).ToList();
             album.Tracks = resource.Tracks.Select(MapTrack).ToList();


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Change `AlbumResource.Label` to `AlbumResource.Labels` due to the change in lidarr/lidarrapi.metadata#13.

#### Todos


#### Issues Fixed or Closed by this PR
None
