### PR TITLE
Fix Headphones Download Auth, Add Special Parsing

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerTests/HeadphonesTests/HeadphonesFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/HeadphonesTests/HeadphonesFixture.cs
@@ -24,7 +24,9 @@ namespace NzbDrone.Core.Test.IndexerTests.HeadphonesTests
                     Name = "Headphones VIP",
                     Settings = new HeadphonesSettings()
                         {
-                            Categories = new int[] { 3000 }
+                            Categories = new int[] { 3000 },
+                            Username = "user",
+                            Password = "pass"
                         }
                 };
 
@@ -53,6 +55,7 @@ namespace NzbDrone.Core.Test.IndexerTests.HeadphonesTests
             releaseInfo.Title.Should().Be("Lady Gaga Born This Way 2CD FLAC 2011 WRE");
             releaseInfo.DownloadProtocol.Should().Be(DownloadProtocol.Usenet);
             releaseInfo.DownloadUrl.Should().Be("https://indexer.codeshy.com/api?t=g&guid=123456&apikey=123456789");
+            releaseInfo.BasicAuthString.Should().Be("dXNlcjpwYXNz");
             releaseInfo.Indexer.Should().Be(Subject.Definition.Name);
             releaseInfo.PublishDate.Should().Be(DateTime.Parse("2013/06/02 08:58:54"));
             releaseInfo.Size.Should().Be(917347414);

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
@@ -62,6 +62,12 @@ namespace NzbDrone.Core.DecisionEngine
                 {
                     var parsedAlbumInfo = Parser.Parser.ParseAlbumTitle(report.Title);
 
+                    if (parsedAlbumInfo == null && searchCriteria != null)
+                    {
+                        parsedAlbumInfo = Parser.Parser.ParseAlbumTitleWithSearchCriteria(report.Title,
+                            searchCriteria.Artist, searchCriteria.Albums);
+                    }
+
                     if (parsedAlbumInfo != null)
                     {
                         // TODO: Artist Data Augment without calling to parse title again

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
@@ -6,6 +6,7 @@ using NzbDrone.Common.Cache;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.History;
 using NzbDrone.Core.Messaging.Events;
+using NzbDrone.Core.Music;
 using NzbDrone.Core.Parser;
 
 namespace NzbDrone.Core.Download.TrackedDownloads
@@ -116,11 +117,31 @@ namespace NzbDrone.Core.Download.TrackedDownloads
                     {
                         // Try parsing the original source title and if that fails, try parsing it as a special
                         // TODO: Pass the TVDB ID and TVRage IDs in as well so we have a better chance for finding the item
+                        var historyArtist = firstHistoryItem.Artist;
+                        var historyAlbums = new List<Album> { firstHistoryItem.Album };
+
                         parsedAlbumInfo = Parser.Parser.ParseAlbumTitle(firstHistoryItem.SourceTitle);
 
                         if (parsedAlbumInfo != null)
                         {
-                            trackedDownload.RemoteAlbum = _parsingService.Map(parsedAlbumInfo, firstHistoryItem.ArtistId, historyItems.Where(v => v.EventType == HistoryEventType.Grabbed).Select(h => h.AlbumId).Distinct());
+                            trackedDownload.RemoteAlbum = _parsingService.Map(parsedAlbumInfo,
+                                firstHistoryItem.ArtistId,
+                                historyItems.Where(v => v.EventType == HistoryEventType.Grabbed).Select(h => h.AlbumId)
+                                    .Distinct());
+                        }
+                        else
+                        {
+                            parsedAlbumInfo =
+                                Parser.Parser.ParseAlbumTitleWithSearchCriteria(firstHistoryItem.SourceTitle,
+                                    historyArtist, historyAlbums);
+
+                            if (parsedAlbumInfo != null)
+                            {
+                                trackedDownload.RemoteAlbum = _parsingService.Map(parsedAlbumInfo,
+                                    firstHistoryItem.ArtistId,
+                                    historyItems.Where(v => v.EventType == HistoryEventType.Grabbed).Select(h => h.AlbumId)
+                                        .Distinct());
+                            }
                         }
                     }
                 }

--- a/src/NzbDrone.Core/Download/UsenetClientBase.cs
+++ b/src/NzbDrone.Core/Download/UsenetClientBase.cs
@@ -8,6 +8,7 @@ using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Configuration;
 using NLog;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.RemotePathMappings;
 
 namespace NzbDrone.Core.Download
@@ -43,7 +44,15 @@ namespace NzbDrone.Core.Download
 
             try
             {
-                nzbData = _httpClient.Get(new HttpRequest(url)).ResponseData;
+                var nzbDataRequest = new HttpRequest(url);
+
+                // TODO: Look into moving download request handling to indexer
+                if (remoteAlbum.Release.BasicAuthString.IsNotNullOrWhiteSpace())
+                {
+                    nzbDataRequest.Headers.Set("Authorization", "Basic " + remoteAlbum.Release.BasicAuthString);
+                }
+                
+                nzbData = _httpClient.Get(nzbDataRequest).ResponseData;
 
                 _logger.Debug("Downloaded nzb for release '{0}' finished ({1} bytes from {2})", remoteAlbum.Release.Title, nzbData.Length, url);
             }

--- a/src/NzbDrone.Core/History/HistoryRepository.cs
+++ b/src/NzbDrone.Core/History/HistoryRepository.cs
@@ -47,7 +47,9 @@ namespace NzbDrone.Core.History
 
         public List<History> FindByDownloadId(string downloadId)
         {
-            return Query.Where(h => h.DownloadId == downloadId);
+            return Query.Join<History, Artist>(JoinType.Left, h => h.Artist, (h, a) => h.ArtistId == a.Id)
+                        .Join<History, Album>(JoinType.Left, h => h.Album, (h, r) => h.AlbumId == r.Id)
+                        .Where(h => h.DownloadId == downloadId);
         }
 
         public List<History> GetByArtist(int artistId, HistoryEventType? eventType)

--- a/src/NzbDrone.Core/Indexers/Headphones/Headphones.cs
+++ b/src/NzbDrone.Core/Indexers/Headphones/Headphones.cs
@@ -32,7 +32,10 @@ namespace NzbDrone.Core.Indexers.Headphones
 
         public override IParseIndexerResponse GetParser()
         {
-            return new NewznabRssParser();
+            return new HeadphonesRssParser
+            {
+                Settings = Settings
+            };
         }
 
         public Headphones(IHeadphonesCapabilitiesProvider capabilitiesProvider, IHttpClient httpClient, IIndexerStatusService indexerStatusService, IConfigService configService, IParsingService parsingService, Logger logger)

--- a/src/NzbDrone.Core/Indexers/Headphones/HeadphonesRssParser.cs
+++ b/src/NzbDrone.Core/Indexers/Headphones/HeadphonesRssParser.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Text;
+using NzbDrone.Core.Indexers.Newznab;
+
+namespace NzbDrone.Core.Indexers.Headphones
+{
+    public class HeadphonesRssParser : NewznabRssParser
+    {
+        public const string ns = "{http://www.newznab.com/DTD/2010/feeds/attributes/}";
+        public HeadphonesSettings Settings { get; set; }
+
+        public HeadphonesRssParser()
+        {
+            PreferredEnclosureMimeTypes = UsenetEnclosureMimeTypes;
+            UseEnclosureUrl = true;
+        }
+
+        protected override string GetBasicAuth()
+        {
+            return Convert.ToBase64String(Encoding.GetEncoding("ISO-8859-1").GetBytes($"{Settings.Username}:{Settings.Password}")); ;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Indexers/RssParser.cs
+++ b/src/NzbDrone.Core/Indexers/RssParser.cs
@@ -156,6 +156,7 @@ namespace NzbDrone.Core.Indexers
             releaseInfo.Title = GetTitle(item);
             releaseInfo.PublishDate = GetPublishDate(item);
             releaseInfo.DownloadUrl = GetDownloadUrl(item);
+            releaseInfo.BasicAuthString = GetBasicAuth();
             releaseInfo.InfoUrl = GetInfoUrl(item);
             releaseInfo.CommentUrl = GetCommentUrl(item);
 
@@ -196,6 +197,11 @@ namespace NzbDrone.Core.Indexers
             }
 
             return XElementExtensions.ParseDate(dateString);
+        }
+
+        protected virtual string GetBasicAuth()
+        {
+            return null;
         }
 
         protected virtual string GetDownloadUrl(XElement item)

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -526,6 +526,7 @@
     <Compile Include="Indexers\Headphones\HeadphonesCapabilitiesProvider.cs" />
     <Compile Include="Indexers\Headphones\HeadphonesCapabilities.cs" />
     <Compile Include="Indexers\Headphones\HeadphonesRequestGenerator.cs" />
+    <Compile Include="Indexers\Headphones\HeadphonesRssParser.cs" />
     <Compile Include="Indexers\IIndexerSettings.cs" />
     <Compile Include="Indexers\IndexerDefaults.cs" />
     <Compile Include="Indexers\ITorrentIndexerSettings.cs" />

--- a/src/NzbDrone.Core/Parser/Model/ReleaseInfo.cs
+++ b/src/NzbDrone.Core/Parser/Model/ReleaseInfo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text;
 using NzbDrone.Core.Indexers;
 
@@ -10,6 +10,7 @@ namespace NzbDrone.Core.Parser.Model
         public string Title { get; set; }
         public long Size { get; set; }
         public string DownloadUrl { get; set; }
+        public string BasicAuthString { get; set; }
         public string InfoUrl { get; set; }
         public string CommentUrl { get; set; }
         public int IndexerId { get; set; }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fix Headphones Download Auth by storing auth string in releaseInfo for use by client base to grab the nzb. 

Adds secondary parsing by comparing search criteria to release title. 

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR
#149 
* 
