### PR TITLE
Added: Add Release Status to Metadata Profile, Default to Official Only

### DIFF
--- a/frontend/src/Settings/Profiles/Metadata/EditMetadataProfileModalContent.js
+++ b/frontend/src/Settings/Profiles/Metadata/EditMetadataProfileModalContent.js
@@ -14,6 +14,7 @@ import FormLabel from 'Components/Form/FormLabel';
 import FormInputGroup from 'Components/Form/FormInputGroup';
 import PrimaryTypeItems from './PrimaryTypeItems';
 import SecondaryTypeItems from './SecondaryTypeItems';
+import ReleaseStatusItems from './ReleaseStatusItems';
 import styles from './EditMetadataProfileModalContent.css';
 
 function EditMetadataProfileModalContent(props) {
@@ -37,7 +38,8 @@ function EditMetadataProfileModalContent(props) {
     id,
     name,
     primaryAlbumTypes: itemPrimaryAlbumTypes,
-    secondaryAlbumTypes: itemSecondaryAlbumTypes
+    secondaryAlbumTypes: itemSecondaryAlbumTypes,
+    releaseStatuses: itemReleaseStatuses
   } = item;
 
   return (
@@ -89,6 +91,14 @@ function EditMetadataProfileModalContent(props) {
                 {...otherProps}
               />
 
+              <ReleaseStatusItems
+                metadataProfileItems={itemReleaseStatuses.value}
+                errors={itemReleaseStatuses.errors}
+                warnings={itemReleaseStatuses.warnings}
+                formLabel="Release Statuses"
+                {...otherProps}
+              />
+
             </Form>
         }
       </ModalBody>
@@ -134,6 +144,7 @@ EditMetadataProfileModalContent.propTypes = {
   saveError: PropTypes.object,
   primaryAlbumTypes: PropTypes.arrayOf(PropTypes.object).isRequired,
   secondaryAlbumTypes: PropTypes.arrayOf(PropTypes.object).isRequired,
+  releaseStatuses: PropTypes.arrayOf(PropTypes.object).isRequired,
   item: PropTypes.object.isRequired,
   isInUse: PropTypes.bool.isRequired,
   onInputChange: PropTypes.func.isRequired,

--- a/frontend/src/Settings/Profiles/Metadata/EditMetadataProfileModalContentConnector.js
+++ b/frontend/src/Settings/Profiles/Metadata/EditMetadataProfileModalContentConnector.js
@@ -54,16 +54,41 @@ function createSecondaryAlbumTypesSelector() {
   );
 }
 
+function createReleaseStatusesSelector() {
+  return createSelector(
+    createProviderSettingsSelector(),
+    (metadataProfile) => {
+      const releaseStatuses = metadataProfile.item.releaseStatuses;
+      if (!releaseStatuses || !releaseStatuses.value) {
+        return [];
+      }
+
+      return _.reduceRight(releaseStatuses.value, (result, { allowed, releaseStatus }) => {
+        if (allowed) {
+          result.push({
+            key: releaseStatus.id,
+            value: releaseStatus.name
+          });
+        }
+
+        return result;
+      }, []);
+    }
+  );
+}
+
 function createMapStateToProps() {
   return createSelector(
     createProviderSettingsSelector(),
     createPrimaryAlbumTypesSelector(),
     createSecondaryAlbumTypesSelector(),
+    createReleaseStatusesSelector(),
     createProfileInUseSelector('metadataProfileId'),
-    (metadataProfile, primaryAlbumTypes, secondaryAlbumTypes, isInUse) => {
+    (metadataProfile, primaryAlbumTypes, secondaryAlbumTypes, releaseStatuses, isInUse) => {
       return {
         primaryAlbumTypes,
         secondaryAlbumTypes,
+        releaseStatuses,
         ...metadataProfile,
         isInUse
       };
@@ -138,6 +163,18 @@ class EditMetadataProfileModalContentConnector extends Component {
     });
   }
 
+  onMetadataReleaseStatusItemAllowedChange = (id, allowed) => {
+    const metadataProfile = _.cloneDeep(this.props.item);
+
+    const item = _.find(metadataProfile.releaseStatuses.value, (i) => i.releaseStatus.id === id);
+    item.allowed = allowed;
+
+    this.props.setMetadataProfileValue({
+      name: 'releaseStatuses',
+      value: metadataProfile.releaseStatuses.value
+    });
+  }
+
   //
   // Render
 
@@ -154,6 +191,7 @@ class EditMetadataProfileModalContentConnector extends Component {
         onInputChange={this.onInputChange}
         onMetadataPrimaryTypeItemAllowedChange={this.onMetadataPrimaryTypeItemAllowedChange}
         onMetadataSecondaryTypeItemAllowedChange={this.onMetadataSecondaryTypeItemAllowedChange}
+        onMetadataReleaseStatusItemAllowedChange={this.onMetadataReleaseStatusItemAllowedChange}
       />
     );
   }

--- a/frontend/src/Settings/Profiles/Metadata/ReleaseStatusItem.js
+++ b/frontend/src/Settings/Profiles/Metadata/ReleaseStatusItem.js
@@ -1,0 +1,60 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import classNames from 'classnames';
+import CheckInput from 'Components/Form/CheckInput';
+import styles from './TypeItem.css';
+
+class ReleaseStatusItem extends Component {
+
+  //
+  // Listeners
+
+  onAllowedChange = ({ value }) => {
+    const {
+      albumTypeId,
+      onMetadataReleaseStatusItemAllowedChange
+    } = this.props;
+
+    onMetadataReleaseStatusItemAllowedChange(albumTypeId, value);
+  }
+
+  //
+  // Render
+
+  render() {
+    const {
+      name,
+      allowed
+    } = this.props;
+
+    return (
+      <div
+        className={classNames(
+          styles.metadataProfileItem
+        )}
+      >
+        <label
+          className={styles.albumTypeName}
+        >
+          <CheckInput
+            containerClassName={styles.checkContainer}
+            name={name}
+            value={allowed}
+            onChange={this.onAllowedChange}
+          />
+          {name}
+        </label>
+      </div>
+    );
+  }
+}
+
+ReleaseStatusItem.propTypes = {
+  albumTypeId: PropTypes.number.isRequired,
+  name: PropTypes.string.isRequired,
+  allowed: PropTypes.bool.isRequired,
+  sortIndex: PropTypes.number.isRequired,
+  onMetadataReleaseStatusItemAllowedChange: PropTypes.func
+};
+
+export default ReleaseStatusItem;

--- a/frontend/src/Settings/Profiles/Metadata/ReleaseStatusItems.js
+++ b/frontend/src/Settings/Profiles/Metadata/ReleaseStatusItems.js
@@ -3,10 +3,10 @@ import React, { Component } from 'react';
 import FormGroup from 'Components/Form/FormGroup';
 import FormLabel from 'Components/Form/FormLabel';
 import FormInputHelpText from 'Components/Form/FormInputHelpText';
-import SecondaryTypeItem from './SecondaryTypeItem';
+import ReleaseStatusItem from './ReleaseStatusItem';
 import styles from './TypeItems.css';
 
-class SecondaryTypeItems extends Component {
+class ReleaseStatusItems extends Component {
 
   //
   // Render
@@ -21,7 +21,7 @@ class SecondaryTypeItems extends Component {
 
     return (
       <FormGroup>
-        <FormLabel>Secondary Types</FormLabel>
+        <FormLabel>Release Statuses</FormLabel>
         <div>
 
           {
@@ -52,12 +52,12 @@ class SecondaryTypeItems extends Component {
 
           <div className={styles.albumTypes}>
             {
-              metadataProfileItems.map(({ allowed, albumType }, index) => {
+              metadataProfileItems.map(({ allowed, releaseStatus }, index) => {
                 return (
-                  <SecondaryTypeItem
-                    key={albumType.id}
-                    albumTypeId={albumType.id}
-                    name={albumType.name}
+                  <ReleaseStatusItem
+                    key={releaseStatus.id}
+                    albumTypeId={releaseStatus.id}
+                    name={releaseStatus.name}
                     allowed={allowed}
                     sortIndex={index}
                     {...otherProps}
@@ -72,16 +72,16 @@ class SecondaryTypeItems extends Component {
   }
 }
 
-SecondaryTypeItems.propTypes = {
+ReleaseStatusItems.propTypes = {
   metadataProfileItems: PropTypes.arrayOf(PropTypes.object).isRequired,
   errors: PropTypes.arrayOf(PropTypes.object),
   warnings: PropTypes.arrayOf(PropTypes.object),
   formLabel: PropTypes.string
 };
 
-SecondaryTypeItems.defaultProps = {
+ReleaseStatusItems.defaultProps = {
   errors: [],
   warnings: []
 };
 
-export default SecondaryTypeItems;
+export default ReleaseStatusItems;

--- a/src/Lidarr.Api.V1/Profiles/Metadata/MetadataProfileModule.cs
+++ b/src/Lidarr.Api.V1/Profiles/Metadata/MetadataProfileModule.cs
@@ -15,6 +15,7 @@ namespace Lidarr.Api.V1.Profiles.Metadata
             SharedValidator.RuleFor(c => c.Name).NotEmpty();
             SharedValidator.RuleFor(c => c.PrimaryAlbumTypes).MustHaveAllowedPrimaryType();
             SharedValidator.RuleFor(c => c.SecondaryAlbumTypes).MustHaveAllowedSecondaryType();
+            SharedValidator.RuleFor(c => c.ReleaseStatuses).MustHaveAllowedReleaseStatus();
 
             GetResourceAll = GetAll;
             GetResourceById = GetById;

--- a/src/Lidarr.Api.V1/Profiles/Metadata/MetadataProfileResource.cs
+++ b/src/Lidarr.Api.V1/Profiles/Metadata/MetadataProfileResource.cs
@@ -10,6 +10,7 @@ namespace Lidarr.Api.V1.Profiles.Metadata
         public string Name { get; set; }
         public List<ProfilePrimaryAlbumTypeItemResource> PrimaryAlbumTypes { get; set; }
         public List<ProfileSecondaryAlbumTypeItemResource> SecondaryAlbumTypes { get; set; }
+        public List<ProfileReleaseStatusItemResource> ReleaseStatuses { get; set; }
     }
 
     public class ProfilePrimaryAlbumTypeItemResource : RestResource
@@ -24,6 +25,12 @@ namespace Lidarr.Api.V1.Profiles.Metadata
         public bool Allowed { get; set; }
     }
 
+    public class ProfileReleaseStatusItemResource : RestResource
+    {
+        public NzbDrone.Core.Music.ReleaseStatus ReleaseStatus { get; set; }
+        public bool Allowed { get; set; }
+    }
+
     public static class MetadataProfileResourceMapper
     {
         public static MetadataProfileResource ToResource(this MetadataProfile model)
@@ -35,7 +42,8 @@ namespace Lidarr.Api.V1.Profiles.Metadata
                 Id = model.Id,
                 Name = model.Name,
                 PrimaryAlbumTypes = model.PrimaryAlbumTypes.ConvertAll(ToResource),
-                SecondaryAlbumTypes = model.SecondaryAlbumTypes.ConvertAll(ToResource)
+                SecondaryAlbumTypes = model.SecondaryAlbumTypes.ConvertAll(ToResource),
+                ReleaseStatuses = model.ReleaseStatuses.ConvertAll(ToResource)
             };
         }
 
@@ -64,6 +72,20 @@ namespace Lidarr.Api.V1.Profiles.Metadata
             };
         }
 
+        public static ProfileReleaseStatusItemResource ToResource(this ProfileReleaseStatusItem model)
+        {
+            if (model == null)
+            {
+                return null;
+            }
+
+            return new ProfileReleaseStatusItemResource
+            {
+                ReleaseStatus = model.ReleaseStatus,
+                Allowed = model.Allowed
+            };
+        }
+
         public static MetadataProfile ToModel(this MetadataProfileResource resource)
         {
             if (resource == null)
@@ -76,7 +98,8 @@ namespace Lidarr.Api.V1.Profiles.Metadata
                 Id = resource.Id,
                 Name = resource.Name,
                 PrimaryAlbumTypes = resource.PrimaryAlbumTypes.ConvertAll(ToModel),
-                SecondaryAlbumTypes = resource.SecondaryAlbumTypes.ConvertAll(ToModel)
+                SecondaryAlbumTypes = resource.SecondaryAlbumTypes.ConvertAll(ToModel),
+                ReleaseStatuses = resource.ReleaseStatuses.ConvertAll(ToModel)
             };
         }
 
@@ -102,7 +125,18 @@ namespace Lidarr.Api.V1.Profiles.Metadata
             };
         }
 
-        public static List<MetadataProfileResource> ToResource(this IEnumerable<MetadataProfile> models)
+        public static ProfileReleaseStatusItem ToModel(this ProfileReleaseStatusItemResource resource)
+        {
+            if (resource == null) return null;
+
+            return new ProfileReleaseStatusItem
+            {
+                ReleaseStatus = (NzbDrone.Core.Music.ReleaseStatus)resource.ReleaseStatus.Id,
+                Allowed = resource.Allowed
+            };
+        }
+
+    public static List<MetadataProfileResource> ToResource(this IEnumerable<MetadataProfile> models)
         {
             return models.Select(ToResource).ToList();
         }

--- a/src/Lidarr.Api.V1/Profiles/Metadata/MetadataValidator.cs
+++ b/src/Lidarr.Api.V1/Profiles/Metadata/MetadataValidator.cs
@@ -20,6 +20,13 @@ namespace Lidarr.Api.V1.Profiles.Metadata
 
             return ruleBuilder.SetValidator(new SecondaryTypeValidator<T>());
         }
+
+        public static IRuleBuilderOptions<T, IList<ProfileReleaseStatusItemResource>> MustHaveAllowedReleaseStatus<T>(this IRuleBuilder<T, IList<ProfileReleaseStatusItemResource>> ruleBuilder)
+        {
+            ruleBuilder.SetValidator(new NotEmptyValidator(null));
+
+            return ruleBuilder.SetValidator(new ReleaseStatusValidator<T>());
+        }
     }
 
 
@@ -58,6 +65,31 @@ namespace Lidarr.Api.V1.Profiles.Metadata
         protected override bool IsValid(PropertyValidatorContext context)
         {
             var list = context.PropertyValue as IList<ProfileSecondaryAlbumTypeItemResource>;
+
+            if (list == null)
+            {
+                return false;
+            }
+
+            if (!list.Any(c => c.Allowed))
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    public class ReleaseStatusValidator<T> : PropertyValidator
+    {
+        public ReleaseStatusValidator()
+            : base("Must have at least one allowed release status")
+        {
+        }
+
+        protected override bool IsValid(PropertyValidatorContext context)
+        {
+            var list = context.PropertyValue as IList<ProfileReleaseStatusItemResource>;
 
             if (list == null)
             {

--- a/src/NzbDrone.Core.Test/Profiles/Metadata/MetadataProfileRepositoryFixture.cs
+++ b/src/NzbDrone.Core.Test/Profiles/Metadata/MetadataProfileRepositoryFixture.cs
@@ -27,16 +27,22 @@ namespace NzbDrone.Core.Test.Profiles.Metadata
                     Allowed = l == SecondaryAlbumType.Studio
                 }).ToList(),
 
+                ReleaseStatuses = ReleaseStatus.All.OrderByDescending(l => l.Name).Select(l => new ProfileReleaseStatusItem
+                {
+                    ReleaseStatus = l,
+                    Allowed = l == ReleaseStatus.Official
+                }).ToList(),
+
                 Name = "TestProfile"
             };
 
             Subject.Insert(profile);
 
-
             StoredModel.Name.Should().Be(profile.Name);
 
             StoredModel.PrimaryAlbumTypes.Should().Equal(profile.PrimaryAlbumTypes, (a, b) => a.PrimaryAlbumType == b.PrimaryAlbumType && a.Allowed == b.Allowed);
             StoredModel.SecondaryAlbumTypes.Should().Equal(profile.SecondaryAlbumTypes, (a, b) => a.SecondaryAlbumType == b.SecondaryAlbumType && a.Allowed == b.Allowed);
+            StoredModel.ReleaseStatuses.Should().Equal(profile.ReleaseStatuses, (a, b) => a.ReleaseStatus == b.ReleaseStatus && a.Allowed == b.Allowed);
         }
     }
 }

--- a/src/NzbDrone.Core/Datastore/Converters/ReleaseStatusIntConverter.cs
+++ b/src/NzbDrone.Core/Datastore/Converters/ReleaseStatusIntConverter.cs
@@ -1,0 +1,63 @@
+using Marr.Data.Converters;
+using Marr.Data.Mapping;
+using Newtonsoft.Json;
+using NzbDrone.Core.Music;
+using System;
+
+namespace NzbDrone.Core.Datastore.Converters
+{
+    public class ReleaseStatusIntConverter : JsonConverter, IConverter
+    {
+        public object FromDB(ConverterContext context)
+        {
+            if (context.DbValue == DBNull.Value)
+            {
+                return ReleaseStatus.Official;
+            }
+
+            var val = Convert.ToInt32(context.DbValue);
+
+            return (ReleaseStatus) val;
+        }
+
+        public object FromDB(ColumnMap map, object dbValue)
+        {
+            return FromDB(new ConverterContext {ColumnMap = map, DbValue = dbValue});
+        }
+
+        public object ToDB(object clrValue)
+        {
+            if (clrValue == DBNull.Value)
+            {
+                return 0;
+            }
+
+            if (clrValue as ReleaseStatus == null)
+            {
+                throw new InvalidOperationException("Attempted to save a albumtype that isn't really a albumtype");
+            }
+
+            var language = (ReleaseStatus) clrValue;
+            return (int) language;
+        }
+
+        public Type DbType => typeof(int);
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(ReleaseStatus);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
+            JsonSerializer serializer)
+        {
+            var item = reader.Value;
+            return (ReleaseStatus) Convert.ToInt32(item);
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            writer.WriteValue(ToDB(value));
+        }
+    }
+}

--- a/src/NzbDrone.Core/Datastore/Migration/012_add_release_status.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/012_add_release_status.cs
@@ -1,0 +1,138 @@
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using FluentMigrator;
+using Newtonsoft.Json;
+using NzbDrone.Common.Serializer;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(12)]
+    public class add_release_status : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("MetadataProfiles").AddColumn("ReleaseStatuses").AsString().WithDefaultValue("");
+            Execute.WithConnection(ConvertProfile);
+        }
+
+        private void ConvertProfile(IDbConnection conn, IDbTransaction tran)
+        {
+            var updater = new ProfileUpdater11(conn, tran);
+            updater.AddDefaultReleaseStatus();
+            updater.Commit();
+        }
+    }
+
+    public class Profile12
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public List<ProfileItem12> ReleaseStatuses { get; set; }
+    }
+
+    public class ProfileItem12
+    {
+        public int ReleaseStatus { get; set; }
+        public bool Allowed { get; set; }
+    }
+
+    public enum ReleaseStatus12
+    {
+        Official = 0,
+        Promotional = 1,
+        Bootleg = 2,
+        Pseudo = 3
+    }
+    
+    public class ProfileUpdater11
+    {
+        private readonly IDbConnection _connection;
+        private readonly IDbTransaction _transaction;
+
+        private List<Profile12> _profiles;
+
+        public ProfileUpdater11(IDbConnection conn, IDbTransaction tran)
+        {
+            _connection = conn;
+            _transaction = tran;
+
+            _profiles = GetProfiles();
+        }
+
+        public void Commit()
+        {
+            foreach (var profile in _profiles)
+            {
+                using (var updateProfileCmd = _connection.CreateCommand())
+                {
+                    updateProfileCmd.Transaction = _transaction;
+                    updateProfileCmd.CommandText =
+                        "UPDATE MetadataProfiles SET ReleaseStatuses = ? WHERE Id = ?";
+                    updateProfileCmd.AddParameter(profile.ReleaseStatuses.ToJson());
+                    updateProfileCmd.AddParameter(profile.Id);
+
+                    updateProfileCmd.ExecuteNonQuery();
+                }
+            }
+
+            _profiles.Clear();
+        }
+
+        public void AddDefaultReleaseStatus()
+        {
+            foreach (var profile in _profiles)
+            {
+                profile.ReleaseStatuses = new List<ProfileItem12>
+                {
+                    new ProfileItem12
+                    {
+                        ReleaseStatus = (int)ReleaseStatus12.Official,
+                        Allowed = true
+                    },
+                    new ProfileItem12
+                    {
+                        ReleaseStatus = (int)ReleaseStatus12.Promotional,
+                        Allowed = false
+                    },
+                    new ProfileItem12
+                    {
+                        ReleaseStatus = (int)ReleaseStatus12.Bootleg,
+                        Allowed = false
+                    },
+                    new ProfileItem12
+                    {
+                        ReleaseStatus = (int)ReleaseStatus12.Pseudo,
+                        Allowed = false
+                    }
+                };
+            }
+        }
+
+        private List<Profile12> GetProfiles()
+        {
+            var profiles = new List<Profile12>();
+
+            using (var getProfilesCmd = _connection.CreateCommand())
+            {
+                getProfilesCmd.Transaction = _transaction;
+                getProfilesCmd.CommandText = @"SELECT Id, Name FROM MetadataProfiles";
+
+                using (var profileReader = getProfilesCmd.ExecuteReader())
+                {
+                    while (profileReader.Read())
+                    {
+                        profiles.Add(new Profile12
+                        {
+                            Id = profileReader.GetInt32(0),
+                            Name = profileReader.GetString(1)
+                        });
+                    }
+                }
+            }
+
+            return profiles;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Datastore/TableMapping.cs
+++ b/src/NzbDrone.Core/Datastore/TableMapping.cs
@@ -162,6 +162,7 @@ namespace NzbDrone.Core.Datastore
             MapRepository.Instance.RegisterTypeConverter(typeof(List<ProfileLanguageItem>), new EmbeddedDocumentConverter(new LanguageIntConverter()));
             MapRepository.Instance.RegisterTypeConverter(typeof(List<ProfilePrimaryAlbumTypeItem>), new EmbeddedDocumentConverter(new PrimaryAlbumTypeIntConverter()));
             MapRepository.Instance.RegisterTypeConverter(typeof(List<ProfileSecondaryAlbumTypeItem>), new EmbeddedDocumentConverter(new SecondaryAlbumTypeIntConverter()));
+            MapRepository.Instance.RegisterTypeConverter(typeof(List<ProfileReleaseStatusItem>), new EmbeddedDocumentConverter(new ReleaseStatusIntConverter()));
             MapRepository.Instance.RegisterTypeConverter(typeof(ParsedAlbumInfo), new EmbeddedDocumentConverter());
             MapRepository.Instance.RegisterTypeConverter(typeof(ParsedTrackInfo), new EmbeddedDocumentConverter());
             MapRepository.Instance.RegisterTypeConverter(typeof(ReleaseInfo), new EmbeddedDocumentConverter());

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -52,16 +52,17 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
 
             SetCustomProvider();
 
-            var metadataProfile = _metadataProfileService.Exists(metadataProfileId) ? _metadataProfileService.Get(metadataProfileId) : _metadataProfileService.All().FirstOrDefault();
-            
+            var metadataProfile = _metadataProfileService.Exists(metadataProfileId) ? _metadataProfileService.Get(metadataProfileId) : _metadataProfileService.All().First();
 
             var primaryTypes = metadataProfile.PrimaryAlbumTypes.Where(s => s.Allowed).Select(s => s.PrimaryAlbumType.Name);
             var secondaryTypes = metadataProfile.SecondaryAlbumTypes.Where(s => s.Allowed).Select(s => s.SecondaryAlbumType.Name);
+            var releaseStatuses = metadataProfile.ReleaseStatuses.Where(s => s.Allowed).Select(s => s.ReleaseStatus.Name);
 
             var httpRequest = _customerRequestBuilder.Create()
                                             .SetSegment("route", "artist/" + foreignArtistId)
                                             .AddQueryParam("primTypes", string.Join("|", primaryTypes))
                                             .AddQueryParam("secTypes", string.Join("|", secondaryTypes))
+                                            .AddQueryParam("releaseStatuses", string.Join("|", releaseStatuses))
                                             .Build();
 
             httpRequest.AllowAutoRedirect = true;

--- a/src/NzbDrone.Core/Music/ReleaseStatus.cs
+++ b/src/NzbDrone.Core/Music/ReleaseStatus.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NzbDrone.Core.Datastore;
+
+namespace NzbDrone.Core.Music
+{
+    public class ReleaseStatus : IEmbeddedDocument, IEquatable<ReleaseStatus>
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+
+        public ReleaseStatus()
+        {
+        }
+
+        private ReleaseStatus(int id, string name)
+        {
+            Id = id;
+            Name = name;
+        }
+
+        public override string ToString()
+        {
+            return Name;
+        }
+
+        public override int GetHashCode()
+        {
+            return Id.GetHashCode();
+        }
+
+        public bool Equals(ReleaseStatus other)
+        {
+            if (ReferenceEquals(null, other))
+            {
+                return false;
+            }
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+            return Id.Equals(other.Id);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+            return ReferenceEquals(this, obj) || Equals(obj as PrimaryAlbumType);
+        }
+
+        public static bool operator ==(ReleaseStatus left, ReleaseStatus right)
+        {
+            return Equals(left, right);
+        }
+
+        public static bool operator !=(ReleaseStatus left, ReleaseStatus right)
+        {
+            return !Equals(left, right);
+        }
+
+        public static ReleaseStatus Official => new ReleaseStatus(0, "Official");
+        public static ReleaseStatus Promotional => new ReleaseStatus(1, "Promotional");
+        public static ReleaseStatus Bootleg => new ReleaseStatus(2, "Bootleg");
+        public static ReleaseStatus Pseudo => new ReleaseStatus(3, "Pseudo");
+
+
+        public static readonly List<ReleaseStatus> All = new List<ReleaseStatus>
+        {
+            Official,
+            Promotional,
+            Bootleg,
+            Pseudo
+        };
+
+
+        public static ReleaseStatus FindById(int id)
+        {
+            if (id == 0)
+            {
+                return Official;
+            }
+
+            ReleaseStatus albumType = All.FirstOrDefault(v => v.Id == id);
+
+            if (albumType == null)
+            {
+                throw new ArgumentException(@"ID does not match a known album type", nameof(id));
+            }
+
+            return albumType;
+        }
+
+        public static explicit operator ReleaseStatus(int id)
+        {
+            return FindById(id);
+        }
+
+        public static explicit operator int(ReleaseStatus albumType)
+        {
+            return albumType.Id;
+        }
+
+        public static explicit operator ReleaseStatus(string type)
+        {
+            var releaseStatus = All.FirstOrDefault(v => v.Name.Equals(type, StringComparison.InvariantCultureIgnoreCase));
+
+            if (releaseStatus == null)
+            {
+                throw new ArgumentException(@"Status does not match a known release status", nameof(type));
+            }
+
+            return releaseStatus;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Music/ReleaseStatus.cs
+++ b/src/NzbDrone.Core/Music/ReleaseStatus.cs
@@ -49,7 +49,7 @@ namespace NzbDrone.Core.Music
             {
                 return false;
             }
-            return ReferenceEquals(this, obj) || Equals(obj as PrimaryAlbumType);
+            return ReferenceEquals(this, obj) || Equals(obj as ReleaseStatus);
         }
 
         public static bool operator ==(ReleaseStatus left, ReleaseStatus right)

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -148,6 +148,7 @@
     <Compile Include="Datastore\Converters\DoubleConverter.cs" />
     <Compile Include="Datastore\Converters\EmbeddedDocumentConverter.cs" />
     <Compile Include="Datastore\Converters\EnumIntConverter.cs" />
+    <Compile Include="Datastore\Converters\ReleaseStatusIntConverter.cs" />
     <Compile Include="Datastore\Converters\SecondaryAlbumTypeIntConverter.cs" />
     <Compile Include="Datastore\Converters\PrimaryAlbumTypeIntConverter.cs" />
     <Compile Include="Datastore\Converters\LanguageIntConverter.cs" />
@@ -181,6 +182,7 @@
     <Compile Include="Datastore\Migration\009_album_releases.cs" />
     <Compile Include="Datastore\Migration\010_album_releases_fix.cs" />
     <Compile Include="Datastore\Migration\011_import_lists.cs" />
+    <Compile Include="Datastore\Migration\012_add_release_status.cs" />
     <Compile Include="Datastore\Migration\Framework\MigrationContext.cs" />
     <Compile Include="Datastore\Migration\Framework\MigrationController.cs" />
     <Compile Include="Datastore\Migration\Framework\MigrationDbFactory.cs" />
@@ -811,8 +813,9 @@
     <Compile Include="Music\Commands\BulkMoveArtistCommand.cs" />
     <Compile Include="Music\Commands\RefreshAlbumCommand.cs" />
     <Compile Include="Music\Events\ArtistsImportedEvent.cs" />
-    <Compile Include="Music\SecondaryAlbumType.cs" />
     <Compile Include="Music\PrimaryAlbumType.cs" />
+    <Compile Include="Music\SecondaryAlbumType.cs" />
+    <Compile Include="Music\ReleaseStatus.cs" />
     <Compile Include="Music\Links.cs" />
     <Compile Include="Music\Commands\MoveArtistCommand.cs" />
     <Compile Include="Music\Events\ArtistMovedEvent.cs" />
@@ -935,6 +938,7 @@
     <Compile Include="Profiles\Metadata\MetadataProfileInUseException.cs" />
     <Compile Include="Profiles\Metadata\MetadataProfile.cs" />
     <Compile Include="Profiles\Metadata\MetadataProfileRepository.cs" />
+    <Compile Include="Profiles\Metadata\ProfileReleaseStatusTypeItem.cs" />
     <Compile Include="Profiles\Metadata\ProfileSecondaryAlbumTypeItem.cs" />
     <Compile Include="Profiles\Metadata\ProfilePrimaryAlbumTypeItem.cs" />
     <Compile Include="Profiles\Qualities\ProfileRepository.cs" />

--- a/src/NzbDrone.Core/Profiles/Metadata/MetadataProfile.cs
+++ b/src/NzbDrone.Core/Profiles/Metadata/MetadataProfile.cs
@@ -9,6 +9,7 @@ namespace NzbDrone.Core.Profiles.Metadata
         public string Name { get; set; }
         public List<ProfilePrimaryAlbumTypeItem> PrimaryAlbumTypes { get; set; }
         public List<ProfileSecondaryAlbumTypeItem> SecondaryAlbumTypes { get; set; }
+        public List<ProfileReleaseStatusItem> ReleaseStatuses { get; set; }
 
     }
 }

--- a/src/NzbDrone.Core/Profiles/Metadata/MetadataProfileService.cs
+++ b/src/NzbDrone.Core/Profiles/Metadata/MetadataProfileService.cs
@@ -66,23 +66,29 @@ namespace NzbDrone.Core.Profiles.Metadata
             return _profileRepository.Exists(id);
         }
 
-        private void AddDefaultProfile(string name, List<PrimaryAlbumType> primAllowed, List<SecondaryAlbumType> secAllowed)
+        private void AddDefaultProfile(string name, List<PrimaryAlbumType> primAllowed, List<SecondaryAlbumType> secAllowed, List<ReleaseStatus> relAllowed)
         {
             var primaryTypes = PrimaryAlbumType.All
-                                    .OrderByDescending(l => l.Name)
-                                    .Select(v => new ProfilePrimaryAlbumTypeItem { PrimaryAlbumType = v, Allowed = primAllowed.Contains(v) })
-                                    .ToList();
+                .OrderByDescending(l => l.Name)
+                .Select(v => new ProfilePrimaryAlbumTypeItem {PrimaryAlbumType = v, Allowed = primAllowed.Contains(v)})
+                .ToList();
 
             var secondaryTypes = SecondaryAlbumType.All
-                                    .OrderByDescending(l => l.Name)
-                                    .Select(v => new ProfileSecondaryAlbumTypeItem { SecondaryAlbumType = v, Allowed = secAllowed.Contains(v) })
-                                    .ToList();
+                .OrderByDescending(l => l.Name)
+                .Select(v => new ProfileSecondaryAlbumTypeItem {SecondaryAlbumType = v, Allowed = secAllowed.Contains(v)})
+                .ToList();
+
+            var releaseStatues = ReleaseStatus.All
+                .OrderByDescending(l => l.Name)
+                .Select(v => new ProfileReleaseStatusItem {ReleaseStatus = v, Allowed = relAllowed.Contains(v)})
+                .ToList();
 
             var profile = new MetadataProfile
             {
                 Name = name,
                 PrimaryAlbumTypes = primaryTypes,
-                SecondaryAlbumTypes = secondaryTypes
+                SecondaryAlbumTypes = secondaryTypes,
+                ReleaseStatuses = releaseStatues
             };
 
             Add(profile);
@@ -97,7 +103,7 @@ namespace NzbDrone.Core.Profiles.Metadata
 
             _logger.Info("Setting up default metadata profile");
 
-            AddDefaultProfile("Standard", new List<PrimaryAlbumType>{PrimaryAlbumType.Album}, new List<SecondaryAlbumType>{ SecondaryAlbumType.Studio });
+            AddDefaultProfile("Standard", new List<PrimaryAlbumType>{PrimaryAlbumType.Album}, new List<SecondaryAlbumType>{ SecondaryAlbumType.Studio }, new List<ReleaseStatus>{ReleaseStatus.Official});
         }
     }
 }

--- a/src/NzbDrone.Core/Profiles/Metadata/ProfileReleaseStatusTypeItem.cs
+++ b/src/NzbDrone.Core/Profiles/Metadata/ProfileReleaseStatusTypeItem.cs
@@ -1,0 +1,11 @@
+using NzbDrone.Core.Datastore;
+using NzbDrone.Core.Music;
+
+namespace NzbDrone.Core.Profiles.Metadata
+{
+    public class ProfileReleaseStatusItem : IEmbeddedDocument
+    {
+        public ReleaseStatus ReleaseStatus { get; set; }
+        public bool Allowed { get; set; }
+    }
+}


### PR DESCRIPTION
#### Database Migration
YES

#### Description
Adds ability to filter library by Release Status using metadata profiles
Default is to official only

#### Issues Fixed or Closed by this PR
#202 
