### PR TITLE
Fixed: MacOS Appveyor builds don't inlcude startup script

### DIFF
--- a/appveyor-package.sh
+++ b/appveyor-package.sh
@@ -11,10 +11,18 @@ PublishArtifacts()
     7z a $artifactsFolder/Lidarr.${APPVEYOR_REPO_BRANCH}.${APPVEYOR_BUILD_VERSION}.windows.zip $artifactsFolderWindows/*
     
     7z a $artifactsFolder/Lidarr.${APPVEYOR_REPO_BRANCH}.${APPVEYOR_BUILD_VERSION}.osx-app.zip $artifactsFolderMacOSApp/*
+    mkdir -p $artifactsFolderMacOSApp/StartScript/Lidarr.app/Contents/MacOS
+    cp ./osx/Lidarr $artifactsFolderMacOSApp/StartScript/Lidarr.app/Contents/MacOS
+    7z a $artifactsFolder/Lidarr.${APPVEYOR_REPO_BRANCH}.${APPVEYOR_BUILD_VERSION}.osx-app.zip $artifactsFolderMacOSApp/StartScript/*
+    rm -rf $artifactsFolderMacOSApp/StartScript/
     
     7z a -ttar $artifactsFolder/Lidarr.${APPVEYOR_REPO_BRANCH}.${APPVEYOR_BUILD_VERSION}.osx.tar $artifactsFolderMacOS/*
+    mkdir -p $artifactsFolderMacOS/StartScript/Lidarr
+    cp ./osx/Lidarr $artifactsFolderMacOS/StartScript/Lidarr/Lidarr
+    7z a -ttar $artifactsFolder/Lidarr.${APPVEYOR_REPO_BRANCH}.${APPVEYOR_BUILD_VERSION}.osx.tar $artifactsFolderMacOS/StartScript/*
     7z a -tgzip $artifactsFolder/Lidarr.${APPVEYOR_REPO_BRANCH}.${APPVEYOR_BUILD_VERSION}.osx.tar.gz $artifactsFolder/Lidarr.${APPVEYOR_REPO_BRANCH}.${APPVEYOR_BUILD_VERSION}.osx.tar
     rm -f $artifactsFolder/Lidarr.${APPVEYOR_REPO_BRANCH}.${APPVEYOR_BUILD_VERSION}.osx.tar
+    rm -rf $artifactsFolderMacOS/StartScript/
     
     7z a -ttar $artifactsFolder/Lidarr.${APPVEYOR_REPO_BRANCH}.${APPVEYOR_BUILD_VERSION}.linux.tar $artifactsFolderLinux/*
     7z a -tgzip $artifactsFolder/Lidarr.${APPVEYOR_REPO_BRANCH}.${APPVEYOR_BUILD_VERSION}.linux.tar.gz $artifactsFolder/Lidarr.${APPVEYOR_REPO_BRANCH}.${APPVEYOR_BUILD_VERSION}.linux.tar


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fix MacOS builds. A bit hacky but it seems to work to get around windows build environment thinking Lidarr is same as Lidarr.exe

#### Todos
- [x] @danielunderwood test build artifact

#### Issues Fixed or Closed by this PR
#209 
* 
