### PR TITLE
New: Grouped Album Import Notification

### DIFF
--- a/frontend/src/Settings/Notifications/Notifications/EditNotificationModalContent.js
+++ b/frontend/src/Settings/Notifications/Notifications/EditNotificationModalContent.js
@@ -39,10 +39,12 @@ function EditNotificationModalContent(props) {
     name,
     onGrab,
     onDownload,
+    onAlbumDownload,
     onUpgrade,
     onRename,
     supportsOnGrab,
     supportsOnDownload,
+    supportsOnAlbumDownload,
     supportsOnUpgrade,
     supportsOnRename,
     tags,
@@ -107,12 +109,25 @@ function EditNotificationModalContent(props) {
               </FormGroup>
 
               <FormGroup>
-                <FormLabel>On Import</FormLabel>
+                <FormLabel>On Album Import</FormLabel>
+
+                <FormInputGroup
+                  type={inputTypes.CHECK}
+                  name="onAlbumDownload"
+                  helpText="Be notified when complete albums are successfully imported"
+                  isDisabled={!supportsOnAlbumDownload.value}
+                  {...onAlbumDownload}
+                  onChange={onInputChange}
+                />
+              </FormGroup>
+
+              <FormGroup>
+                <FormLabel>On Track Import</FormLabel>
 
                 <FormInputGroup
                   type={inputTypes.CHECK}
                   name="onDownload"
-                  helpText="Be notified when tracks are successfully imported"
+                  helpText="Be notified when track files are successfully imported"
                   isDisabled={!supportsOnDownload.value}
                   {...onDownload}
                   onChange={onInputChange}
@@ -122,7 +137,7 @@ function EditNotificationModalContent(props) {
               {
                 onDownload.value &&
                   <FormGroup>
-                    <FormLabel>On Upgrade</FormLabel>
+                    <FormLabel>On Track Upgrade</FormLabel>
 
                     <FormInputGroup
                       type={inputTypes.CHECK}

--- a/frontend/src/Settings/Notifications/Notifications/Notification.js
+++ b/frontend/src/Settings/Notifications/Notifications/Notification.js
@@ -68,10 +68,12 @@ class Notification extends Component {
       name,
       onGrab,
       onDownload,
+      onAlbumDownload,
       onUpgrade,
       onRename,
       supportsOnGrab,
       supportsOnDownload,
+      supportsOnAlbumDownload,
       supportsOnUpgrade,
       supportsOnRename
     } = this.props;
@@ -94,10 +96,17 @@ class Notification extends Component {
         </Label>
 
         <Label
+          kind={getLabelKind(supportsOnAlbumDownload, onAlbumDownload)}
+          outline={supportsOnAlbumDownload && !onAlbumDownload}
+        >
+          On Album Download
+        </Label>
+
+        <Label
           kind={getLabelKind(supportsOnDownload, onDownload)}
           outline={supportsOnDownload && !onDownload}
         >
-          On Download
+          On Track Download
         </Label>
 
         <Label
@@ -140,10 +149,12 @@ Notification.propTypes = {
   name: PropTypes.string.isRequired,
   onGrab: PropTypes.bool.isRequired,
   onDownload: PropTypes.bool.isRequired,
+  onAlbumDownload: PropTypes.bool.isRequired,
   onUpgrade: PropTypes.bool.isRequired,
   onRename: PropTypes.bool.isRequired,
   supportsOnGrab: PropTypes.bool.isRequired,
   supportsOnDownload: PropTypes.bool.isRequired,
+  supportsOnAlbumDownload: PropTypes.bool.isRequired,
   supportsOnUpgrade: PropTypes.bool.isRequired,
   supportsOnRename: PropTypes.bool.isRequired,
   onConfirmDeleteNotification: PropTypes.func.isRequired

--- a/src/Lidarr.Api.V1/Notifications/NotificationResource.cs
+++ b/src/Lidarr.Api.V1/Notifications/NotificationResource.cs
@@ -1,4 +1,4 @@
-﻿using NzbDrone.Core.Notifications;
+using NzbDrone.Core.Notifications;
 
 namespace Lidarr.Api.V1.Notifications
 {
@@ -7,10 +7,12 @@ namespace Lidarr.Api.V1.Notifications
         public string Link { get; set; }
         public bool OnGrab { get; set; }
         public bool OnDownload { get; set; }
+        public bool OnAlbumDownload { get; set; }
         public bool OnUpgrade { get; set; }
         public bool OnRename { get; set; }
         public bool SupportsOnGrab { get; set; }
         public bool SupportsOnDownload { get; set; }
+        public bool SupportsOnAlbumDownload { get; set; }
         public bool SupportsOnUpgrade { get; set; }
         public bool SupportsOnRename { get; set; }
         public string TestCommand { get; set; }
@@ -26,10 +28,12 @@ namespace Lidarr.Api.V1.Notifications
 
             resource.OnGrab = definition.OnGrab;
             resource.OnDownload = definition.OnDownload;
+            resource.OnAlbumDownload = definition.OnAlbumDownload;
             resource.OnUpgrade = definition.OnUpgrade;
             resource.OnRename = definition.OnRename;
             resource.SupportsOnGrab = definition.SupportsOnGrab;
             resource.SupportsOnDownload = definition.SupportsOnDownload;
+            resource.SupportsOnAlbumDownload = definition.SupportsOnAlbumDownload;
             resource.SupportsOnUpgrade = definition.SupportsOnUpgrade;
             resource.SupportsOnRename = definition.SupportsOnRename;
 
@@ -44,10 +48,12 @@ namespace Lidarr.Api.V1.Notifications
 
             definition.OnGrab = resource.OnGrab;
             definition.OnDownload = resource.OnDownload;
+            definition.OnAlbumDownload = resource.OnAlbumDownload;
             definition.OnUpgrade = resource.OnUpgrade;
             definition.OnRename = resource.OnRename;
             definition.SupportsOnGrab = resource.SupportsOnGrab;
             definition.SupportsOnDownload = resource.SupportsOnDownload;
+            definition.SupportsOnAlbumDownload = resource.SupportsOnAlbumDownload;
             definition.SupportsOnUpgrade = resource.SupportsOnUpgrade;
             definition.SupportsOnRename = resource.SupportsOnRename;
 

--- a/src/NzbDrone.Core.Test/NotificationTests/NotificationBaseFixture.cs
+++ b/src/NzbDrone.Core.Test/NotificationTests/NotificationBaseFixture.cs
@@ -32,7 +32,7 @@ namespace NzbDrone.Core.Test.NotificationTests
                 throw new NotImplementedException();
             }
 
-            public override void OnDownload(DownloadMessage downloadMessage)
+            public override void OnDownload(TrackDownloadMessage trackDownloadMessage)
             {
                 TestLogger.Info("OnDownload was called");
             }
@@ -55,9 +55,14 @@ namespace NzbDrone.Core.Test.NotificationTests
                 TestLogger.Info("OnGrab was called");
             }
 
-            public override void OnDownload(DownloadMessage message)
+            public override void OnDownload(TrackDownloadMessage message)
             {
                 TestLogger.Info("OnDownload was called");
+            }
+
+            public override void OnAlbumDownload(AlbumDownloadMessage message)
+            {
+                TestLogger.Info("OnAlbumDownload was called");
             }
 
             public override void OnRename(Artist artist)
@@ -100,6 +105,7 @@ namespace NzbDrone.Core.Test.NotificationTests
 
             notification.SupportsOnGrab.Should().BeTrue();
             notification.SupportsOnDownload.Should().BeTrue();
+            notification.SupportsOnAlbumDownload.Should().BeTrue();
             notification.SupportsOnUpgrade.Should().BeTrue();
             notification.SupportsOnRename.Should().BeTrue();
         }
@@ -112,6 +118,7 @@ namespace NzbDrone.Core.Test.NotificationTests
 
             notification.SupportsOnGrab.Should().BeFalse();
             notification.SupportsOnDownload.Should().BeFalse();
+            notification.SupportsOnAlbumDownload.Should().BeFalse();
             notification.SupportsOnUpgrade.Should().BeFalse();
             notification.SupportsOnRename.Should().BeFalse();
         }

--- a/src/NzbDrone.Core.Test/NotificationTests/SynologyIndexerFixture.cs
+++ b/src/NzbDrone.Core.Test/NotificationTests/SynologyIndexerFixture.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Test.NotificationTests
     public class SynologyIndexerFixture : CoreTest<SynologyIndexer>
     {
         private Artist _artist;
-        private DownloadMessage _upgrade;
+        private TrackDownloadMessage _upgrade;
 
         [SetUp]
         public void SetUp()
@@ -24,7 +24,7 @@ namespace NzbDrone.Core.Test.NotificationTests
                 Path = @"C:\Test\".AsOsAgnostic()
             };
 
-            _upgrade = new DownloadMessage()
+            _upgrade = new TrackDownloadMessage()
             {
                 Artist = _artist,
 

--- a/src/NzbDrone.Core.Test/NotificationTests/Xbmc/OnDownloadFixture.cs
+++ b/src/NzbDrone.Core.Test/NotificationTests/Xbmc/OnDownloadFixture.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Test.NotificationTests.Xbmc
     [TestFixture]
     public class OnDownloadFixture : CoreTest<Notifications.Xbmc.Xbmc>
     {
-        private DownloadMessage _downloadMessage;
+        private TrackDownloadMessage _trackDownloadMessage;
         
         [SetUp]
         public void Setup()
@@ -25,7 +25,7 @@ namespace NzbDrone.Core.Test.NotificationTests.Xbmc
             var trackFile = Builder<TrackFile>.CreateNew()
                                                    .Build();
 
-            _downloadMessage = Builder<DownloadMessage>.CreateNew()
+            _trackDownloadMessage = Builder<TrackDownloadMessage>.CreateNew()
                                                        .With(d => d.Artist = artist)
                                                        .With(d => d.TrackFile = trackFile)
                                                        .With(d => d.OldFiles = new List<TrackFile>())
@@ -40,7 +40,7 @@ namespace NzbDrone.Core.Test.NotificationTests.Xbmc
 
         private void GivenOldFiles()
         {
-            _downloadMessage.OldFiles = Builder<TrackFile>.CreateListOfSize(1)
+            _trackDownloadMessage.OldFiles = Builder<TrackFile>.CreateListOfSize(1)
                                                             .Build()
                                                             .ToList();
 
@@ -54,7 +54,7 @@ namespace NzbDrone.Core.Test.NotificationTests.Xbmc
         [Test]
         public void should_not_clean_if_no_episode_was_replaced()
         {
-            Subject.OnDownload(_downloadMessage);
+            Subject.OnDownload(_trackDownloadMessage);
 
             Mocker.GetMock<IXbmcService>().Verify(v => v.Clean(It.IsAny<XbmcSettings>()), Times.Never());
         }
@@ -63,7 +63,7 @@ namespace NzbDrone.Core.Test.NotificationTests.Xbmc
         public void should_clean_if_episode_was_replaced()
         {
             GivenOldFiles();
-            Subject.OnDownload(_downloadMessage);
+            Subject.OnDownload(_trackDownloadMessage);
 
             Mocker.GetMock<IXbmcService>().Verify(v => v.Clean(It.IsAny<XbmcSettings>()), Times.Once());
         }

--- a/src/NzbDrone.Core/Datastore/Migration/013_album_download_notification.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/013_album_download_notification.cs
@@ -1,0 +1,14 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(13)]
+    public class album_download_notification : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("Notifications").AddColumn("OnAlbumDownload").AsBoolean().WithDefaultValue(0);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Datastore/TableMapping.cs
+++ b/src/NzbDrone.Core/Datastore/TableMapping.cs
@@ -71,6 +71,7 @@ namespace NzbDrone.Core.Datastore
             Mapper.Entity<NotificationDefinition>().RegisterDefinition("Notifications")
                   .Ignore(i => i.SupportsOnGrab)
                   .Ignore(i => i.SupportsOnDownload)
+                  .Ignore(i => i.SupportsOnAlbumDownload)
                   .Ignore(i => i.SupportsOnUpgrade)
                   .Ignore(i => i.SupportsOnRename);
             

--- a/src/NzbDrone.Core/MediaFiles/Events/AlbumImportedEvent.cs
+++ b/src/NzbDrone.Core/MediaFiles/Events/AlbumImportedEvent.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using NzbDrone.Common.Messaging;
+using NzbDrone.Core.Download;
+using NzbDrone.Core.Music;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.MediaFiles.Events
+{
+    public class AlbumImportedEvent : IEvent
+    {
+        public Artist Artist { get; private set; }
+        public Album Album { get; private set; }
+        public List<LocalTrack> ImportedTracks { get; private set; }
+        public bool NewDownload { get; private set; }
+        public string DownloadClient { get; private set; }
+        public string DownloadId { get; private set; }
+
+        public AlbumImportedEvent(Artist artist, Album album, List<LocalTrack> importedTracks, bool newDownload, DownloadClientItem downloadClientItem)
+        {
+            Artist = artist;
+            Album = album;
+            ImportedTracks = importedTracks;
+            NewDownload = newDownload;
+
+            if (downloadClientItem != null)
+            {
+                DownloadClient = downloadClientItem.DownloadClient;
+                DownloadId = downloadClientItem.DownloadId;
+            }
+
+        }
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/TrackImport/ImportApprovedTracks.cs
+++ b/src/NzbDrone.Core/MediaFiles/TrackImport/ImportApprovedTracks.cs
@@ -157,6 +157,19 @@ namespace NzbDrone.Core.MediaFiles.TrackImport
                 }
             }
 
+            var albumImports = importResults.GroupBy(e => e.ImportDecision.LocalTrack.Album.Id).ToList();
+
+            foreach (var albumImport in albumImports)
+            {
+                var album = albumImport.First().ImportDecision.LocalTrack.Album;
+                var artist = albumImport.First().ImportDecision.LocalTrack.Artist;
+
+                if (albumImport.Where(e => e.Errors.Count == 0).ToList().Count > 0 && artist != null && album != null)
+                {
+                    _eventAggregator.PublishEvent(new AlbumImportedEvent(artist, album, albumImport.Select(e => e.ImportDecision.LocalTrack).ToList(), newDownload, downloadClientItem));
+                }
+            }
+
             //Adding all the rejected decisions
             importResults.AddRange(decisions.Where(c => !c.Approved)
                                             .Select(d => new ImportResult(d, d.Rejections.Select(r => r.Reason).ToArray())));

--- a/src/NzbDrone.Core/Notifications/AlbumDownloadMessage.cs
+++ b/src/NzbDrone.Core/Notifications/AlbumDownloadMessage.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Music;
+
+namespace NzbDrone.Core.Notifications
+{
+    public class AlbumDownloadMessage
+    {
+        public string Message { get; set; }
+        public Artist Artist { get; set; }
+        public Album Album { get; set; }
+        public List<TrackFile> TrackFiles { get; set; }
+        public string DownloadClient { get; set; }
+        public string DownloadId { get; set; }
+
+        public override string ToString()
+        {
+            return Message;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Boxcar/Boxcar.cs
+++ b/src/NzbDrone.Core/Notifications/Boxcar/Boxcar.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using FluentValidation.Results;
 using NzbDrone.Common.Extensions;
 
@@ -21,9 +21,14 @@ namespace NzbDrone.Core.Notifications.Boxcar
             _proxy.SendNotification(ALBUM_GRABBED_TITLE, grabMessage.Message, Settings);
         }
 
-        public override void OnDownload(DownloadMessage message)
+        public override void OnDownload(TrackDownloadMessage message)
         {
             _proxy.SendNotification(TRACK_DOWNLOADED_TITLE , message.Message, Settings);
+        }
+
+        public override void OnAlbumDownload(AlbumDownloadMessage message)
+        {
+            _proxy.SendNotification(TRACK_DOWNLOADED_TITLE, message.Message, Settings);
         }
 
         public override ValidationResult Test()

--- a/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
+++ b/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
@@ -55,7 +55,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             ExecuteScript(environmentVariables);
         }
 
-        public override void OnDownload(DownloadMessage message)
+        public override void OnDownload(TrackDownloadMessage message)
         {
             var artist = message.Artist;
             var trackFile = message.TrackFile;
@@ -90,6 +90,27 @@ namespace NzbDrone.Core.Notifications.CustomScript
                 environmentVariables.Add("Lidarr_DeletedRelativePaths", string.Join("|", message.OldFiles.Select(e => e.RelativePath)));
                 environmentVariables.Add("Lidarr_DeletedPaths", string.Join("|", message.OldFiles.Select(e => Path.Combine(artist.Path, e.RelativePath))));
             }
+
+            ExecuteScript(environmentVariables);
+        }
+
+        public override void OnAlbumDownload(AlbumDownloadMessage message)
+        {
+            var artist = message.Artist;
+            var album = message.Album;
+            var environmentVariables = new StringDictionary();
+
+            environmentVariables.Add("Lidarr_EventType", "AlbumDownload");
+            environmentVariables.Add("Lidarr_Artist_Id", artist.Id.ToString());
+            environmentVariables.Add("Lidarr_Artist_Name", artist.Name);
+            environmentVariables.Add("Lidarr_Artist_Path", artist.Path);
+            environmentVariables.Add("Lidarr_Artist_MBId", artist.ForeignArtistId);
+            environmentVariables.Add("Lidarr_Artist_Type", artist.ArtistType);
+            environmentVariables.Add("Lidarr_Album_Id", album.Id.ToString());
+            environmentVariables.Add("Lidarr_Album_Title", album.Title);
+            environmentVariables.Add("Lidarr_Album_MBId", album.ForeignAlbumId);
+            environmentVariables.Add("Lidarr_Download_Client", message.DownloadClient ?? string.Empty);
+            environmentVariables.Add("Lidarr_Download_Id", message.DownloadId ?? string.Empty);
 
             ExecuteScript(environmentVariables);
         }

--- a/src/NzbDrone.Core/Notifications/Email/Email.cs
+++ b/src/NzbDrone.Core/Notifications/Email/Email.cs
@@ -25,13 +25,19 @@ namespace NzbDrone.Core.Notifications.Email
             _emailService.SendEmail(Settings, ALBUM_GRABBED_TITLE_BRANDED, body);
         }
 
-        public override void OnDownload(DownloadMessage message)
+        public override void OnDownload(TrackDownloadMessage message)
         {
             var body = $"{message.Message} Downloaded and sorted.";
 
             _emailService.SendEmail(Settings, TRACK_DOWNLOADED_TITLE_BRANDED, body);
         }
 
+        public override void OnAlbumDownload(AlbumDownloadMessage message)
+        {
+            var body = $"{message.Message} Downloaded and sorted.";
+
+            _emailService.SendEmail(Settings, ALBUM_DOWNLOADED_TITLE_BRANDED, body);
+        }
 
         public override ValidationResult Test()
         {

--- a/src/NzbDrone.Core/Notifications/Growl/Growl.cs
+++ b/src/NzbDrone.Core/Notifications/Growl/Growl.cs
@@ -23,11 +23,15 @@ namespace NzbDrone.Core.Notifications.Growl
             _growlService.SendNotification(ALBUM_GRABBED_TITLE, grabMessage.Message, "GRAB", Settings.Host, Settings.Port, Settings.Password);
         }
 
-        public override void OnDownload(DownloadMessage message)
+        public override void OnDownload(TrackDownloadMessage message)
         {
             _growlService.SendNotification(TRACK_DOWNLOADED_TITLE, message.Message, "DOWNLOAD", Settings.Host, Settings.Port, Settings.Password);
         }
 
+        public override void OnAlbumDownload(AlbumDownloadMessage message)
+        {
+            _growlService.SendNotification(ALBUM_DOWNLOADED_TITLE, message.Message, "DOWNLOAD", Settings.Host, Settings.Port, Settings.Password);
+        }
 
         public override ValidationResult Test()
         {

--- a/src/NzbDrone.Core/Notifications/INotification.cs
+++ b/src/NzbDrone.Core/Notifications/INotification.cs
@@ -8,10 +8,12 @@ namespace NzbDrone.Core.Notifications
         string Link { get; }
 
         void OnGrab(GrabMessage grabMessage);
-        void OnDownload(DownloadMessage message);
+        void OnDownload(TrackDownloadMessage message);
+        void OnAlbumDownload(AlbumDownloadMessage message);
         void OnRename(Artist artist);
         bool SupportsOnGrab { get; }
         bool SupportsOnDownload { get; }
+        bool SupportsOnAlbumDownload { get; }
         bool SupportsOnUpgrade { get; }
         bool SupportsOnRename { get; }
     }

--- a/src/NzbDrone.Core/Notifications/Join/Join.cs
+++ b/src/NzbDrone.Core/Notifications/Join/Join.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using FluentValidation.Results;
 using NzbDrone.Common.Extensions;
 
@@ -22,9 +22,14 @@ namespace NzbDrone.Core.Notifications.Join
             _proxy.SendNotification(ALBUM_GRABBED_TITLE_BRANDED, message.Message, Settings);
         }
 
-        public override void OnDownload(DownloadMessage message)
+        public override void OnDownload(TrackDownloadMessage message)
         {
             _proxy.SendNotification(TRACK_DOWNLOADED_TITLE_BRANDED, message.Message, Settings);
+        }
+
+        public override void OnAlbumDownload(AlbumDownloadMessage message)
+        {
+            _proxy.SendNotification(ALBUM_DOWNLOADED_TITLE_BRANDED, message.Message, Settings);
         }
 
         public override ValidationResult Test()

--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowser.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowser.cs
@@ -26,7 +26,7 @@ namespace NzbDrone.Core.Notifications.Emby
             }
         }
 
-        public override void OnDownload(DownloadMessage message)
+        public override void OnDownload(TrackDownloadMessage message)
         {
             if (Settings.Notify)
             {

--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowser.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowser.cs
@@ -26,6 +26,14 @@ namespace NzbDrone.Core.Notifications.Emby
             }
         }
 
+        public override void OnAlbumDownload(AlbumDownloadMessage message)
+        {
+            if (Settings.Notify)
+            {
+                _mediaBrowserService.Notify(Settings, ALBUM_DOWNLOADED_TITLE_BRANDED, message.Message);
+            }
+        }
+
         public override void OnDownload(TrackDownloadMessage message)
         {
             if (Settings.Notify)

--- a/src/NzbDrone.Core/Notifications/NotificationBase.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationBase.cs
@@ -10,9 +10,11 @@ namespace NzbDrone.Core.Notifications
     {
         protected const string ALBUM_GRABBED_TITLE = "Album Grabbed";
         protected const string TRACK_DOWNLOADED_TITLE = "Track Downloaded";
+        protected const string ALBUM_DOWNLOADED_TITLE = "Album Downloaded";
 
         protected const string ALBUM_GRABBED_TITLE_BRANDED = "Lidarr - " + ALBUM_GRABBED_TITLE;
         protected const string TRACK_DOWNLOADED_TITLE_BRANDED = "Lidarr - " + TRACK_DOWNLOADED_TITLE;
+        protected const string ALBUM_DOWNLOADED_TITLE_BRANDED = "Lidarr - " + ALBUM_DOWNLOADED_TITLE;
 
         public abstract string Name { get; }
 
@@ -32,12 +34,17 @@ namespace NzbDrone.Core.Notifications
 
         }
 
-        public virtual void OnDownload(DownloadMessage message)
+        public virtual void OnDownload(TrackDownloadMessage message)
         {
 
         }
 
-        public virtual void OnRename(Artist series)
+        public virtual void OnAlbumDownload(AlbumDownloadMessage message)
+        {
+
+        }
+
+        public virtual void OnRename(Artist artist)
         {
 
         }
@@ -45,6 +52,7 @@ namespace NzbDrone.Core.Notifications
         public bool SupportsOnGrab => HasConcreteImplementation("OnGrab");
         public bool SupportsOnRename => HasConcreteImplementation("OnRename");
         public bool SupportsOnDownload => HasConcreteImplementation("OnDownload");
+        public bool SupportsOnAlbumDownload => HasConcreteImplementation("OnAlbumDownload");
         public bool SupportsOnUpgrade => SupportsOnDownload;
 
         protected TSettings Settings => (TSettings)Definition.Settings;

--- a/src/NzbDrone.Core/Notifications/NotificationDefinition.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationDefinition.cs
@@ -7,13 +7,15 @@ namespace NzbDrone.Core.Notifications
 
         public bool OnGrab { get; set; }
         public bool OnDownload { get; set; }
+        public bool OnAlbumDownload { get; set; }
         public bool OnUpgrade { get; set; }
         public bool OnRename { get; set; }
         public bool SupportsOnGrab { get; set; }
         public bool SupportsOnDownload { get; set; }
+        public bool SupportsOnAlbumDownload { get; set; }
         public bool SupportsOnUpgrade { get; set; }
         public bool SupportsOnRename { get; set; }
 
-        public override bool Enable => OnGrab || OnDownload || (OnDownload && OnUpgrade);
+        public override bool Enable => OnGrab || OnDownload || OnAlbumDownload || (OnDownload && OnUpgrade);
     }
 }

--- a/src/NzbDrone.Core/Notifications/NotificationFactory.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationFactory.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using NLog;
 using NzbDrone.Common.Composition;
@@ -11,6 +11,7 @@ namespace NzbDrone.Core.Notifications
     {
         List<INotification> OnGrabEnabled();
         List<INotification> OnDownloadEnabled();
+        List<INotification> OnAlbumDownloadEnabled();
         List<INotification> OnUpgradeEnabled();
         List<INotification> OnRenameEnabled();
     }
@@ -32,6 +33,11 @@ namespace NzbDrone.Core.Notifications
             return GetAvailableProviders().Where(n => ((NotificationDefinition)n.Definition).OnDownload).ToList();
         }
 
+        public List<INotification> OnAlbumDownloadEnabled()
+        {
+            return GetAvailableProviders().Where(n => ((NotificationDefinition)n.Definition).OnAlbumDownload).ToList();
+        }
+
         public List<INotification> OnUpgradeEnabled()
         {
             return GetAvailableProviders().Where(n => ((NotificationDefinition)n.Definition).OnUpgrade).ToList();
@@ -48,6 +54,7 @@ namespace NzbDrone.Core.Notifications
 
             definition.SupportsOnGrab = provider.SupportsOnGrab;
             definition.SupportsOnDownload = provider.SupportsOnDownload;
+            definition.SupportsOnAlbumDownload = provider.SupportsOnAlbumDownload;
             definition.SupportsOnUpgrade = provider.SupportsOnUpgrade;
             definition.SupportsOnRename = provider.SupportsOnRename;
         }

--- a/src/NzbDrone.Core/Notifications/NotifyMyAndroid/NotifyMyAndroid.cs
+++ b/src/NzbDrone.Core/Notifications/NotifyMyAndroid/NotifyMyAndroid.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using FluentValidation.Results;
 using NzbDrone.Common.Extensions;
 
@@ -21,9 +21,14 @@ namespace NzbDrone.Core.Notifications.NotifyMyAndroid
             _proxy.SendNotification(ALBUM_GRABBED_TITLE, grabMessage.Message, Settings.ApiKey, (NotifyMyAndroidPriority)Settings.Priority);
         }
 
-        public override void OnDownload(DownloadMessage message)
+        public override void OnDownload(TrackDownloadMessage message)
         {
             _proxy.SendNotification(TRACK_DOWNLOADED_TITLE, message.Message, Settings.ApiKey, (NotifyMyAndroidPriority)Settings.Priority);
+        }
+
+        public override void OnAlbumDownload(AlbumDownloadMessage message)
+        {
+            _proxy.SendNotification(ALBUM_DOWNLOADED_TITLE, message.Message, Settings.ApiKey, (NotifyMyAndroidPriority)Settings.Priority);
         }
 
         public override ValidationResult Test()

--- a/src/NzbDrone.Core/Notifications/Plex/PlexClient.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/PlexClient.cs
@@ -21,7 +21,7 @@ namespace NzbDrone.Core.Notifications.Plex
             _plexClientService.Notify(Settings, ALBUM_GRABBED_TITLE_BRANDED, grabMessage.Message);
         }
 
-        public override void OnDownload(DownloadMessage message)
+        public override void OnDownload(TrackDownloadMessage message)
         {
             _plexClientService.Notify(Settings, TRACK_DOWNLOADED_TITLE_BRANDED, message.Message);
         }

--- a/src/NzbDrone.Core/Notifications/Plex/PlexHomeTheater.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/PlexHomeTheater.cs
@@ -26,7 +26,7 @@ namespace NzbDrone.Core.Notifications.Plex
             Notify(Settings, ALBUM_GRABBED_TITLE_BRANDED, grabMessage.Message);
         }
 
-        public override void OnDownload(DownloadMessage message)
+        public override void OnDownload(TrackDownloadMessage message)
         {
             Notify(Settings, TRACK_DOWNLOADED_TITLE_BRANDED, message.Message);
         }

--- a/src/NzbDrone.Core/Notifications/Plex/PlexServer.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/PlexServer.cs
@@ -17,7 +17,7 @@ namespace NzbDrone.Core.Notifications.Plex
         public override string Link => "https://www.plex.tv/";
         public override string Name => "Plex Media Server";
 
-        public override void OnDownload(DownloadMessage message)
+        public override void OnDownload(TrackDownloadMessage message)
         {
             UpdateIfEnabled(message.Artist);
         }

--- a/src/NzbDrone.Core/Notifications/Prowl/Prowl.cs
+++ b/src/NzbDrone.Core/Notifications/Prowl/Prowl.cs
@@ -22,9 +22,14 @@ namespace NzbDrone.Core.Notifications.Prowl
             _prowlService.SendNotification(ALBUM_GRABBED_TITLE, grabMessage.Message, Settings.ApiKey, (NotificationPriority)Settings.Priority);
         }
 
-        public override void OnDownload(DownloadMessage message)
+        public override void OnDownload(TrackDownloadMessage message)
         {
             _prowlService.SendNotification(TRACK_DOWNLOADED_TITLE, message.Message, Settings.ApiKey, (NotificationPriority)Settings.Priority);
+        }
+
+        public override void OnAlbumDownload(AlbumDownloadMessage message)
+        {
+            _prowlService.SendNotification(ALBUM_DOWNLOADED_TITLE, message.Message, Settings.ApiKey, (NotificationPriority)Settings.Priority);
         }
 
         public override ValidationResult Test()

--- a/src/NzbDrone.Core/Notifications/PushBullet/PushBullet.cs
+++ b/src/NzbDrone.Core/Notifications/PushBullet/PushBullet.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using FluentValidation.Results;
 using NzbDrone.Common.Extensions;
 
@@ -22,9 +22,14 @@ namespace NzbDrone.Core.Notifications.PushBullet
             _proxy.SendNotification(ALBUM_GRABBED_TITLE_BRANDED, grabMessage.Message, Settings);
         }
 
-        public override void OnDownload(DownloadMessage message)
+        public override void OnDownload(TrackDownloadMessage message)
         {
             _proxy.SendNotification(TRACK_DOWNLOADED_TITLE_BRANDED, message.Message, Settings);
+        }
+
+        public override void OnAlbumDownload(AlbumDownloadMessage message)
+        {
+            _proxy.SendNotification(ALBUM_DOWNLOADED_TITLE_BRANDED, message.Message, Settings);
         }
 
         public override ValidationResult Test()

--- a/src/NzbDrone.Core/Notifications/Pushalot/Pushalot.cs
+++ b/src/NzbDrone.Core/Notifications/Pushalot/Pushalot.cs
@@ -21,11 +21,15 @@ namespace NzbDrone.Core.Notifications.Pushalot
             _proxy.SendNotification(ALBUM_GRABBED_TITLE, grabMessage.Message, Settings);
         }
 
-        public override void OnDownload(DownloadMessage message)
+        public override void OnDownload(TrackDownloadMessage message)
         {
             _proxy.SendNotification(TRACK_DOWNLOADED_TITLE, message.Message, Settings);
         }
 
+        public override void OnAlbumDownload(AlbumDownloadMessage message)
+        {
+            _proxy.SendNotification(ALBUM_DOWNLOADED_TITLE, message.Message, Settings);
+        }
 
         public override ValidationResult Test()
         {

--- a/src/NzbDrone.Core/Notifications/Pushover/Pushover.cs
+++ b/src/NzbDrone.Core/Notifications/Pushover/Pushover.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using FluentValidation.Results;
 using NzbDrone.Common.Extensions;
 
@@ -21,9 +21,14 @@ namespace NzbDrone.Core.Notifications.Pushover
             _proxy.SendNotification(ALBUM_GRABBED_TITLE, grabMessage.Message, Settings);
         }
 
-        public override void OnDownload(DownloadMessage message)
+        public override void OnDownload(TrackDownloadMessage message)
         {
             _proxy.SendNotification(TRACK_DOWNLOADED_TITLE, message.Message, Settings);
+        }
+
+        public override void OnAlbumDownload(AlbumDownloadMessage message)
+        {
+            _proxy.SendNotification(ALBUM_DOWNLOADED_TITLE, message.Message, Settings);
         }
 
         public override ValidationResult Test()

--- a/src/NzbDrone.Core/Notifications/Slack/Slack.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/Slack.cs
@@ -45,7 +45,7 @@ namespace NzbDrone.Core.Notifications.Slack
             _proxy.SendPayload(payload, Settings);
         }
 
-        public override void OnDownload(DownloadMessage message)
+        public override void OnDownload(TrackDownloadMessage message)
         {
             var attachments = new List<Attachment>
                               {
@@ -57,6 +57,23 @@ namespace NzbDrone.Core.Notifications.Slack
                                       Color = "good"
                                   }
                               };
+            var payload = CreatePayload($"Imported: {message.Message}", attachments);
+
+            _proxy.SendPayload(payload, Settings);
+        }
+
+        public override void OnAlbumDownload(AlbumDownloadMessage message)
+        {
+            var attachments = new List<Attachment>
+            {
+                new Attachment
+                {
+                    Fallback = message.Message,
+                    Title = message.Artist.Name,
+                    Text = message.Message,
+                    Color = "good"
+                }
+            };
             var payload = CreatePayload($"Imported: {message.Message}", attachments);
 
             _proxy.SendPayload(payload, Settings);

--- a/src/NzbDrone.Core/Notifications/Synology/SynologyIndexer.cs
+++ b/src/NzbDrone.Core/Notifications/Synology/SynologyIndexer.cs
@@ -20,7 +20,7 @@ namespace NzbDrone.Core.Notifications.Synology
         public override string Name => "Synology Indexer";
 
 
-        public override void OnDownload(DownloadMessage message)
+        public override void OnDownload(TrackDownloadMessage message)
         {
             if (Settings.UpdateLibrary)
             {

--- a/src/NzbDrone.Core/Notifications/Telegram/Telegram.cs
+++ b/src/NzbDrone.Core/Notifications/Telegram/Telegram.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using FluentValidation.Results;
 using NzbDrone.Common.Extensions;
 
@@ -21,7 +21,12 @@ namespace NzbDrone.Core.Notifications.Telegram
             _proxy.SendNotification(ALBUM_GRABBED_TITLE, grabMessage.Message, Settings);
         }
 
-        public override void OnDownload(DownloadMessage message)
+        public override void OnDownload(TrackDownloadMessage message)
+        {
+            _proxy.SendNotification(TRACK_DOWNLOADED_TITLE, message.Message, Settings);
+        }
+
+        public override void OnAlbumDownload(AlbumDownloadMessage message)
         {
             _proxy.SendNotification(TRACK_DOWNLOADED_TITLE, message.Message, Settings);
         }

--- a/src/NzbDrone.Core/Notifications/TrackDownloadMessage.cs
+++ b/src/NzbDrone.Core/Notifications/TrackDownloadMessage.cs
@@ -4,7 +4,7 @@ using NzbDrone.Core.Music;
 
 namespace NzbDrone.Core.Notifications
 {
-    public class DownloadMessage
+    public class TrackDownloadMessage
     {
         public string Message { get; set; }
         public Artist Artist { get; set; }

--- a/src/NzbDrone.Core/Notifications/Twitter/Twitter.cs
+++ b/src/NzbDrone.Core/Notifications/Twitter/Twitter.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using FluentValidation.Results;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Exceptions;
@@ -24,7 +24,12 @@ namespace NzbDrone.Core.Notifications.Twitter
             _twitterService.SendNotification($"Grabbed: {message.Message}", Settings);
         }
 
-        public override void OnDownload(DownloadMessage message)
+        public override void OnDownload(TrackDownloadMessage message)
+        {
+            _twitterService.SendNotification($"Imported: {message.Message}", Settings);
+        }
+
+        public override void OnAlbumDownload(AlbumDownloadMessage message)
         {
             _twitterService.SendNotification($"Imported: {message.Message}", Settings);
         }

--- a/src/NzbDrone.Core/Notifications/Webhook/Webhook.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/Webhook.cs
@@ -41,7 +41,7 @@ namespace NzbDrone.Core.Notifications.Webhook
             _proxy.SendWebhook(payload, Settings);
         }
 
-        public override void OnDownload(DownloadMessage message)
+        public override void OnDownload(TrackDownloadMessage message)
         {
             var trackFile = message.TrackFile;
 

--- a/src/NzbDrone.Core/Notifications/Xbmc/Xbmc.cs
+++ b/src/NzbDrone.Core/Notifications/Xbmc/Xbmc.cs
@@ -28,6 +28,13 @@ namespace NzbDrone.Core.Notifications.Xbmc
             Notify(Settings, header, grabMessage.Message);
         }
 
+        public override void OnAlbumDownload(AlbumDownloadMessage message)
+        {
+            const string header = "Lidarr - Downloaded";
+
+            Notify(Settings, header, message.Message);
+        }
+
         public override void OnDownload(TrackDownloadMessage message)
         {
             const string header = "Lidarr - Downloaded";

--- a/src/NzbDrone.Core/Notifications/Xbmc/Xbmc.cs
+++ b/src/NzbDrone.Core/Notifications/Xbmc/Xbmc.cs
@@ -28,7 +28,7 @@ namespace NzbDrone.Core.Notifications.Xbmc
             Notify(Settings, header, grabMessage.Message);
         }
 
-        public override void OnDownload(DownloadMessage message)
+        public override void OnDownload(TrackDownloadMessage message)
         {
             const string header = "Lidarr - Downloaded";
 

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -179,6 +179,7 @@
     <Compile Include="Datastore\Migration\003_add_medium_support.cs" />
     <Compile Include="Datastore\Migration\006_separate_automatic_and_interactive_search.cs" />
     <Compile Include="Datastore\Migration\007_change_album_path_to_relative.cs" />
+    <Compile Include="Datastore\Migration\013_album_download_notification.cs" />
     <Compile Include="Datastore\Migration\009_album_releases.cs" />
     <Compile Include="Datastore\Migration\010_album_releases_fix.cs" />
     <Compile Include="Datastore\Migration\011_import_lists.cs" />
@@ -684,6 +685,7 @@
     <Compile Include="MediaFiles\Commands\CleanUpRecycleBinCommand.cs" />
     <Compile Include="MediaFiles\Commands\DownloadedAlbumsScanCommand.cs" />
     <Compile Include="MediaFiles\Commands\RenameArtistCommand.cs" />
+    <Compile Include="MediaFiles\Events\AlbumImportedEvent.cs" />
     <Compile Include="MediaFiles\Events\TrackFileRenamedEvent.cs" />
     <Compile Include="MediaFiles\Events\TrackFolderCreatedEvent.cs" />
     <Compile Include="MediaFiles\Events\TrackImportFailedEvent.cs" />
@@ -858,6 +860,7 @@
     <Compile Include="Music\Track.cs" />
     <Compile Include="Music\TrackRepository.cs" />
     <Compile Include="Music\TrackService.cs" />
+    <Compile Include="Notifications\AlbumDownloadMessage.cs" />
     <Compile Include="Notifications\Join\JoinAuthException.cs" />
     <Compile Include="Notifications\Join\JoinInvalidDeviceException.cs" />
     <Compile Include="Notifications\Join\JoinResponseModel.cs" />
@@ -953,7 +956,7 @@
     <Compile Include="RemotePathMappings\RemotePathMappingRepository.cs" />
     <Compile Include="RemotePathMappings\RemotePathMappingService.cs" />
     <Compile Include="MediaFiles\TorrentInfo\TorrentFileInfoReader.cs" />
-    <Compile Include="Notifications\DownloadMessage.cs" />
+    <Compile Include="Notifications\TrackDownloadMessage.cs" />
     <Compile Include="Notifications\Email\Email.cs">
       <SubType>Code</SubType>
     </Compile>


### PR DESCRIPTION
#### Database Migration
YES

#### Description
Adds a notification option for Album Downloaded/Imported. Sends one notification for the entire album instead of one per track. 

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR
Fixes #172 
* 
