### PR TITLE
Feature/common tag parsing

### DIFF
--- a/frontend/src/AddArtist/ImportArtist/Import/SelectArtist/ImportArtistSelectArtist.js
+++ b/frontend/src/AddArtist/ImportArtist/Import/SelectArtist/ImportArtistSelectArtist.js
@@ -227,6 +227,7 @@ class ImportArtistSelectArtist extends Component {
                     canSpin={true}
                     isSpinning={isFetching}
                     onPress={this.onRefreshPress}
+                    title="Refresh"
                   >
                     <Icon name={icons.REFRESH} />
                   </FormInputButton>

--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -46,6 +46,24 @@ namespace NzbDrone.Core.Test.ParserTests
             title.CleanArtistName().Should().Be("carnivale");
         }
 
+        [TestCase("Songs of Experience (Deluxe Edition)", "Songs of Experience")]
+        [TestCase("Mr. Bad Guy [Special Edition]", "Mr. Bad Guy")]
+        [TestCase("Sweet Dreams (Album)", "Sweet Dreams")]
+        public void should_remove_common_tags_from_album_title(string title, string correct)
+        {
+            var result = Parser.Parser.CleanAlbumTitle(title);
+            result.Should().Be(correct);
+        }
+
+        [TestCase("Songs of Experience (Deluxe Edition)", "Songs of Experience")]
+        [TestCase("Mr. Bad Guy [Special Edition]", "Mr. Bad Guy")]
+        [TestCase("Smooth Criminal (single)", "Smooth Criminal")]
+        public void should_remove_common_tags_from_track_title(string title, string correct)
+        {
+            var result = Parser.Parser.CleanTrackTitle(title);
+            result.Should().Be(correct);
+        }
+
         [TestCase("Discovery TV - Gold Rush : 02 Road From Hell [S04].mp4")]
         public void should_clean_up_invalid_path_characters(string postTitle)
         {

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -193,9 +193,10 @@ namespace NzbDrone.Core.Parser
 
         private static readonly string[] Numbers = new[] { "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine" };
 
+        private static readonly Regex CommonTagRegex = new Regex(@"(\[|\(){1}(version|deluxe|single|clean|album|special|bonus)+\s*.*(\]|\)){1}", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        
         public static ParsedTrackInfo ParseMusicPath(string path)
         {
-
             var fileInfo = new FileInfo(path);
 
             var result = new ParsedTrackInfo { };
@@ -203,6 +204,12 @@ namespace NzbDrone.Core.Parser
             if (MediaFiles.MediaFileExtensions.Extensions.Contains(fileInfo.Extension))
             {
                 result = ParseAudioTags(path);
+
+                if (CommonTagRegex.IsMatch(result.AlbumTitle))
+                {
+                    result.AlbumTitle = CleanAlbumTitle(result.AlbumTitle);
+                    Logger.Debug("Cleaning Album title of common matching issues. Cleaned album title is '{0}'", result.AlbumTitle);
+                }
             }
             else
             {
@@ -211,6 +218,8 @@ namespace NzbDrone.Core.Parser
 
             // TODO: Check if it is common that we might need to fallback to parser to gather details
             //var result = ParseMusicTitle(fileInfo.Name);
+
+            
 
             if (result == null)
             {
@@ -320,6 +329,7 @@ namespace NzbDrone.Core.Parser
 
                 Logger.Debug("Parsing string '{0}'", title);
 
+
                 if (ReversedTitleRegex.IsMatch(title))
                 {
                     var titleWithoutExtension = RemoveFileExtension(title).ToCharArray();
@@ -399,6 +409,7 @@ namespace NzbDrone.Core.Parser
                 if (!ValidateBeforeParsing(title)) return null;
 
                 Logger.Debug("Parsing string '{0}'", title);
+
 
                 if (ReversedTitleRegex.IsMatch(title))
                 {
@@ -573,6 +584,16 @@ namespace NzbDrone.Core.Parser
                 });
 
             return title;
+        }
+
+        public static string CleanAlbumTitle(string album)
+        {
+            return CommonTagRegex.Replace(album, string.Empty).Trim();
+        }
+
+        public static string CleanTrackTitle(string title)
+        {
+            return CommonTagRegex.Replace(title, string.Empty).Trim();
         }
 
         private static ParsedTrackInfo ParseAudioTags(string path)

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -205,10 +205,6 @@ namespace NzbDrone.Core.Parser
 
             filename = artist.Path.GetRelativePath(filename);
 
-            // Joe: We can clean here
-            filename = Parser.CleanAlbumTitle(filename);
-            _logger.Debug("GetLocalAlbum, cleaned album title: {0}", filename);
-
             var tracksInAlbum = _mediaFileService.GetFilesByArtist(artist.Id)
                 .FindAll(s => Path.GetDirectoryName(s.RelativePath) == filename)
                 .DistinctBy(s => s.AlbumId)
@@ -249,7 +245,8 @@ namespace NzbDrone.Core.Parser
             }
 
             var tracks = GetTracks(artist, parsedTrackInfo);
-            var album = _albumService.FindByTitle(artist.Id, parsedTrackInfo.AlbumTitle);
+            //var album = _albumService.FindByTitle(artist.Id, parsedTrackInfo.AlbumTitle);
+            var album = tracks.FirstOrDefault()?.Album;
 
             return new LocalTrack
             {

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -205,6 +205,10 @@ namespace NzbDrone.Core.Parser
 
             filename = artist.Path.GetRelativePath(filename);
 
+            // Joe: We can clean here
+            filename = Parser.CleanAlbumTitle(filename);
+            _logger.Debug("GetLocalAlbum, cleaned album title: {0}", filename);
+
             var tracksInAlbum = _mediaFileService.GetFilesByArtist(artist.Id)
                 .FindAll(s => Path.GetDirectoryName(s.RelativePath) == filename)
                 .DistinctBy(s => s.AlbumId)
@@ -270,6 +274,9 @@ namespace NzbDrone.Core.Parser
                 return new List<Track>();
             }
 
+            parsedTrackInfo.AlbumTitle = Parser.CleanAlbumTitle(parsedTrackInfo.AlbumTitle);
+            _logger.Debug("Cleaning Album title of common matching issues. Cleaned album title is '{0}'", parsedTrackInfo.AlbumTitle);
+
             var album = _albumService.FindByTitle(artist.Id, parsedTrackInfo.AlbumTitle);
             _logger.Debug("Album {0} selected for {1}", album, parsedTrackInfo);
 
@@ -283,6 +290,9 @@ namespace NzbDrone.Core.Parser
 
             if (parsedTrackInfo.Title.IsNotNullOrWhiteSpace())
             {
+                parsedTrackInfo.Title = Parser.CleanTrackTitle(parsedTrackInfo.Title);
+                _logger.Debug("Cleaning Track title of common matching issues. Cleaned track title is '{0}'", parsedTrackInfo.Title);
+
                 trackInfo = _trackService.FindTrackByTitle(artist.Id, album.Id, parsedTrackInfo.DiscNumber, parsedTrackInfo.Title);
                 
                 if (trackInfo != null)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Per discussion with QStick, this PR will remove common problematic strings from tracks/albums along the following conditions:
(version | special | deluxe | single | bonus | clean | album)

This also adds a title attribute to the Refresh button on ArtistImport to help new users understand what the button does. 

#### Todos
- [X] Tests
- [X] Documentation


#### Issues Fixed or Closed by this PR

N/A
