### PR TITLE
Check for MusicBrainz Release Id during Scan (#227)

### DIFF
--- a/src/NzbDrone.Core.Test/MusicTests/AlbumRepositoryTests/AlbumRepositoryFixture.cs
+++ b/src/NzbDrone.Core.Test/MusicTests/AlbumRepositoryTests/AlbumRepositoryFixture.cs
@@ -1,0 +1,45 @@
+﻿using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Music;
+using NzbDrone.Core.Test.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NzbDrone.Core.Test.MusicTests.AlbumRepositoryTests
+{
+    [TestFixture]
+    public class AlbumRepositoryFixture : DbTest<AlbumService, Album>
+    {
+        [Test]
+        public void should_find_album_in_db_by_releaseid()
+        {
+            var id = "e00e40a3-5ed5-4ed3-9c22-0a8ff4119bdf";
+            var artist = new Artist();
+            artist.Name = "Alien Ant Farm";
+            artist.Monitored = true;
+            artist.MBId = "this is a fake id";
+            artist.Id = 1;
+            var album = new Album();
+            album.Title = "ANThology";
+            AlbumRelease release = new AlbumRelease();
+            release.Id = id;
+            album.ForeignAlbumId = "1";
+            album.CleanTitle = "anthology";
+            album.Artist = artist;
+            album.AlbumType = "";
+
+            album.Releases.Add(release);
+
+            var albumRepo = Mocker.Resolve<AlbumRepository>();
+
+            albumRepo.Insert(album);
+
+            var builtAlbum = Builder<Album>.CreateNew().BuildNew();
+            album.Title.Should().Be(albumRepo.FindAlbumByRelease(id).Title);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/MusicTests/AlbumRepositoryTests/AlbumRepositoryFixture.cs
+++ b/src/NzbDrone.Core.Test/MusicTests/AlbumRepositoryTests/AlbumRepositoryFixture.cs
@@ -1,4 +1,4 @@
-﻿using FizzWare.NBuilder;
+using FizzWare.NBuilder;
 using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Core.Music;
@@ -14,32 +14,62 @@ namespace NzbDrone.Core.Test.MusicTests.AlbumRepositoryTests
     [TestFixture]
     public class AlbumRepositoryFixture : DbTest<AlbumService, Album>
     {
+        private Artist _artist;
+        private Album _album;
+        private AlbumRepository _albumRepo;
+
+        [SetUp]
+        public void Setup()
+        {
+            _artist = new Artist
+            {
+                Name = "Alien Ant Farm",
+                Monitored = true,
+                MBId = "this is a fake id",
+                Id = 1
+            };
+
+            _album = new Album
+            {
+                Title = "ANThology",
+                ForeignAlbumId = "1",
+                CleanTitle = "anthology",
+                Artist = _artist,
+                AlbumType = "",
+                Releases = new List<AlbumRelease>
+                {
+                    new AlbumRelease
+                    {
+                        Id = "e00e40a3-5ed5-4ed3-9c22-0a8ff4119bdf"
+                    }
+                }
+                
+            };
+
+            _albumRepo = Mocker.Resolve<AlbumRepository>();
+
+            _albumRepo.Insert(_album);
+        }
+
+
         [Test]
         public void should_find_album_in_db_by_releaseid()
         {
             var id = "e00e40a3-5ed5-4ed3-9c22-0a8ff4119bdf";
-            var artist = new Artist();
-            artist.Name = "Alien Ant Farm";
-            artist.Monitored = true;
-            artist.MBId = "this is a fake id";
-            artist.Id = 1;
-            var album = new Album();
-            album.Title = "ANThology";
-            AlbumRelease release = new AlbumRelease();
-            release.Id = id;
-            album.ForeignAlbumId = "1";
-            album.CleanTitle = "anthology";
-            album.Artist = artist;
-            album.AlbumType = "";
 
-            album.Releases.Add(release);
+            var album = _albumRepo.FindAlbumByRelease(id);
 
-            var albumRepo = Mocker.Resolve<AlbumRepository>();
+            album.Title.Should().Be(_album.Title);
+        }
 
-            albumRepo.Insert(album);
+        [Test]
+        public void should_not_find_album_in_db_by_partial_releaseid()
+        {
+            var id = "e00e40a3-5ed5-4ed3-9c22";
 
-            var builtAlbum = Builder<Album>.CreateNew().BuildNew();
-            album.Title.Should().Be(albumRepo.FindAlbumByRelease(id).Title);
+            var album = _albumRepo.FindAlbumByRelease(id);
+
+            album.Should().BeNull();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -299,6 +299,7 @@
     <Compile Include="MusicTests\AddAlbumFixture.cs" />
     <Compile Include="MusicTests\AddArtistFixture.cs" />
     <Compile Include="MusicTests\AlbumMonitoredServiceTests\AlbumMonitoredServiceFixture.cs" />
+    <Compile Include="MusicTests\AlbumRepositoryTests\AlbumRepositoryFixture.cs" />
     <Compile Include="MusicTests\ArtistRepositoryTests\ArtistRepositoryFixture.cs" />
     <Compile Include="MusicTests\ArtistServiceTests\AddArtistFixture.cs" />
     <Compile Include="MusicTests\ArtistServiceTests\UpdateMultipleArtistFixture.cs" />

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -310,6 +310,7 @@
     <Compile Include="OrganizerTests\FileNameBuilderTests\CleanTitleFixture.cs" />
     <Compile Include="OrganizerTests\FileNameBuilderTests\TitleTheFixture.cs" />
     <Compile Include="ParserTests\MusicParserFixture.cs" />
+    <Compile Include="ParserTests\ParsingServiceTests\GetLocalTrackFixture.cs" />
     <Compile Include="Profiles\Delay\DelayProfileServiceFixture.cs" />
     <Compile Include="Profiles\Metadata\MetadataProfileServiceFixture.cs" />
     <Compile Include="Profiles\Metadata\MetadataProfileRepositoryFixture.cs" />

--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/GetLocalTrackFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/GetLocalTrackFixture.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Core.Music;
+using NzbDrone.Core.Parser;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Test.Common;
+
+namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
+{
+    [TestFixture]
+    public class GetLocalTrackFixture : CoreTest<ParsingService>
+    {
+        private Artist _fakeArtist;
+        private Album _fakeAlbum;
+        private Track _fakeTrack;
+        private ParsedTrackInfo _parsedTrackInfo;
+
+        [SetUp]
+        public void Setup()
+        {
+            _fakeArtist = Builder<Artist>
+                .CreateNew()
+                .Build();
+
+            _fakeAlbum = Builder<Album>
+                .CreateNew()
+                .With(e => e.ArtistId = _fakeArtist.Id)
+                .With(e => e.Releases = new List<AlbumRelease>
+                {
+                    new AlbumRelease
+                    {
+                        Id = "5ecd552b-e54b-4c37-b62c-9d6234834bad"
+                    }
+                })
+                .Build();
+
+            _fakeTrack = Builder<Track>
+                .CreateNew()
+                .With(e => e.ArtistId = _fakeArtist.Id)
+                .With(e => e.AlbumId = _fakeAlbum.Id)
+                .With(e => e.Album = null)
+                .Build();
+
+            _parsedTrackInfo = Builder<ParsedTrackInfo>
+                .CreateNew()
+                .With(e => e.AlbumTitle = _fakeAlbum.Title)
+                .With(e => e.Title = _fakeTrack.Title)
+                .With(e => e.ArtistTitle = _fakeArtist.Name)
+                .Build();
+
+            Mocker.GetMock<IAlbumService>()
+                .Setup(s => s.FindByTitle(_fakeArtist.Id,_fakeAlbum.Title))
+                .Returns(_fakeAlbum);
+
+            Mocker.GetMock<IAlbumService>()
+                .Setup(s => s.FindAlbumByRelease(_fakeAlbum.Releases.First().Id))
+                .Returns(_fakeAlbum);
+
+            Mocker.GetMock<ITrackService>()
+                .Setup(s => s.FindTrackByTitle(_fakeArtist.Id, _fakeAlbum.Id, It.IsAny<int>(), _fakeTrack.Title))
+                .Returns(_fakeTrack);
+        }
+
+        private void HasAlbumTitleNoReleaseId()
+        {
+            _parsedTrackInfo.AlbumTitle = _fakeAlbum.Title;
+            _parsedTrackInfo.ReleaseMBId = "";
+        }
+
+        private void HasReleaseMbIdNoTitle()
+        {
+            _parsedTrackInfo.AlbumTitle = "";
+            _parsedTrackInfo.ReleaseMBId = _fakeAlbum.Releases.First().Id;
+        }
+
+        private void HasNoReleaseIdOrTitle()
+        {
+            _parsedTrackInfo.AlbumTitle = "";
+            _parsedTrackInfo.ReleaseMBId = "";
+        }
+
+        [Test]
+        public void should_find_album_with_title_no_MBID()
+        {
+            HasAlbumTitleNoReleaseId();
+
+            var localTrack = Subject.GetLocalTrack("somfile.mp3", _fakeArtist, _parsedTrackInfo);
+
+            localTrack.Artist.Id.Should().Be(_fakeArtist.Id);
+            localTrack.Album.Id.Should().Be(_fakeAlbum.Id);
+            localTrack.Tracks.First().Id.Should().Be(_fakeTrack.Id);
+        }
+
+        [Test]
+        public void should_find_album_with_release_MBID_no_title()
+        {
+            HasReleaseMbIdNoTitle();
+
+            var localTrack = Subject.GetLocalTrack("somfile.mp3", _fakeArtist, _parsedTrackInfo);
+
+            localTrack.Artist.Id.Should().Be(_fakeArtist.Id);
+            localTrack.Album.Id.Should().Be(_fakeAlbum.Id);
+            localTrack.Tracks.First().Id.Should().Be(_fakeTrack.Id);
+        }
+
+        [Test]
+        public void should_not_find_album_with_no_release_MBID_no_title()
+        {
+            HasNoReleaseIdOrTitle();
+            
+            var localTrack = Subject.GetLocalTrack("somfile.mp3", _fakeArtist, _parsedTrackInfo);
+            ExceptionVerification.ExpectedWarns(1);
+
+            localTrack.Should().BeNull();
+
+        }
+    }
+}

--- a/src/NzbDrone.Core/Music/AlbumRepository.cs
+++ b/src/NzbDrone.Core/Music/AlbumRepository.cs
@@ -305,10 +305,7 @@ namespace NzbDrone.Core.Music
 
         public Album FindAlbumByRelease(string releaseId)
         {
-            string query = "SELECT * FROM Albums " +
-                         "WHERE Releases LIKE '%" + releaseId + "%'";
-
-            return Query.QueryText(query).FirstOrDefault();
+            return Query.FirstOrDefault(e => e.Releases.Any(r => r.Id == releaseId));
         }
     }
 }

--- a/src/NzbDrone.Core/Music/AlbumRepository.cs
+++ b/src/NzbDrone.Core/Music/AlbumRepository.cs
@@ -308,11 +308,7 @@ namespace NzbDrone.Core.Music
             string query = "SELECT * FROM Albums " +
                          "WHERE Releases LIKE '%" + releaseId + "%'";
 
-            
-
             return Query.QueryText(query).FirstOrDefault();
-            //return Query.Where<Album>(album => album.Releases.Contains(release => release.Id == releaseId) != null)
-            //        .SingleOrDefault();
         }
     }
 }

--- a/src/NzbDrone.Core/Music/AlbumRepository.cs
+++ b/src/NzbDrone.Core/Music/AlbumRepository.cs
@@ -24,6 +24,7 @@ namespace NzbDrone.Core.Music
         List<Album> ArtistAlbumsBetweenDates(Artist artist, DateTime startDate, DateTime endDate, bool includeUnmonitored);
         void SetMonitoredFlat(Album album, bool monitored);
         void SetMonitored(IEnumerable<int> ids, bool monitored);
+        Album FindAlbumByRelease(string releaseId);
     }
 
     public class AlbumRepository : BasicRepository<Album>, IAlbumRepository
@@ -300,6 +301,18 @@ namespace NzbDrone.Core.Music
             return Query.Join<Album, Artist>(JoinType.Inner, album => album.Artist, (album, artist) => album.ArtistId == artist.Id)
                         .Where<Artist>(artist => artist.CleanName == cleanArtistName)
                         .SingleOrDefault(album => album.CleanTitle == cleanTitle);
+        }
+
+        public Album FindAlbumByRelease(string releaseId)
+        {
+            string query = "SELECT * FROM Albums " +
+                         "WHERE Releases LIKE '%" + releaseId + "%'";
+
+            
+
+            return Query.QueryText(query).FirstOrDefault();
+            //return Query.Where<Album>(album => album.Releases.Contains(release => release.Id == releaseId) != null)
+            //        .SingleOrDefault();
         }
     }
 }

--- a/src/NzbDrone.Core/Music/AlbumService.cs
+++ b/src/NzbDrone.Core/Music/AlbumService.cs
@@ -31,6 +31,7 @@ namespace NzbDrone.Core.Music
         void UpdateMany(List<Album> albums);
         void DeleteMany(List<Album> albums);
         void RemoveAddOptions(Album album);
+        Album FindAlbumByRelease(string releaseId);
     }
 
     public class AlbumService : IAlbumService,
@@ -108,6 +109,11 @@ namespace NzbDrone.Core.Music
         public List<Album> GetAlbumsByArtist(int artistId)
         {
             return _albumRepository.GetAlbums(artistId).ToList();
+        }
+
+        public Album FindAlbumByRelease(string releaseId)
+        {
+            return _albumRepository.FindAlbumByRelease(releaseId);
         }
 
         public void RemoveAddOptions(Album album)

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -212,7 +212,16 @@ namespace NzbDrone.Core.Parser
             {
                 result = ParseAudioTags(path);
 
-                if (CommonTagRegex.IsMatch(result.AlbumTitle))
+                // Joe: We need to check if we have an AlbumTitle or not here, if tag is empty, it crashes. 
+
+                if (result.AlbumTitle.IsNullOrWhiteSpace())
+                {
+                    Logger.Debug("Album title is empty.");
+                    return result;
+                }
+
+
+                if (CommonTagRegex.IsMatch(result?.AlbumTitle))
                 {
                     result.AlbumTitle = CleanAlbumTitle(result.AlbumTitle);
                     Logger.Debug("Cleaning Album title of common matching issues. Cleaned album title is '{0}'", result.AlbumTitle);

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -219,6 +219,7 @@ namespace NzbDrone.Core.Parser
             // TODO: Check if it is common that we might need to fallback to parser to gather details
             //var result = ParseMusicTitle(fileInfo.Name);
 
+
             if (result == null)
             {
                 Logger.Debug("Attempting to parse track info using directory and file names. {0}", fileInfo.Directory.Name);
@@ -620,6 +621,8 @@ namespace NzbDrone.Core.Parser
                 ArtistTitleInfo = artistTitleInfo,
                 Title = trackTitle
             };
+
+
             
             Logger.Trace("File Tags Parsed: Artist: {0}, Album: {1}, Disc: {2}, Track Numbers(s): {3}, TrackTitle: {4}", result.ArtistTitle, result.AlbumTitle, result.DiscNumber, trackNumber, result.Title);
 

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -206,26 +206,11 @@ namespace NzbDrone.Core.Parser
         {
             var fileInfo = new FileInfo(path);
 
-            var result = new ParsedTrackInfo { };
+            ParsedTrackInfo result;
 
             if (MediaFiles.MediaFileExtensions.Extensions.Contains(fileInfo.Extension))
             {
                 result = ParseAudioTags(path);
-
-                // Joe: We need to check if we have an AlbumTitle or not here, if tag is empty, it crashes. 
-
-                if (result.AlbumTitle.IsNullOrWhiteSpace())
-                {
-                    Logger.Debug("Album title is empty.");
-                    return result;
-                }
-
-
-                if (CommonTagRegex.IsMatch(result?.AlbumTitle))
-                {
-                    result.AlbumTitle = CleanAlbumTitle(result.AlbumTitle);
-                    Logger.Debug("Cleaning Album title of common matching issues. Cleaned album title is '{0}'", result.AlbumTitle);
-                }
             }
             else
             {

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -249,7 +249,7 @@ namespace NzbDrone.Core.Parser
             }
 
             var tracks = GetTracks(artist, parsedTrackInfo);
-            var album = tracks.FirstOrDefault()?.Album;
+            album = tracks.FirstOrDefault()?.Album;
 
             return new LocalTrack
             {

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -221,6 +221,7 @@ namespace NzbDrone.Core.Parser
         public LocalTrack GetLocalTrack(string filename, Artist artist, ParsedTrackInfo folderInfo)
         {
             ParsedTrackInfo parsedTrackInfo;
+            Album album = null;
 
 
             if (folderInfo != null)
@@ -234,7 +235,10 @@ namespace NzbDrone.Core.Parser
                 parsedTrackInfo = Parser.ParseMusicPath(filename);
             }
 
-            if (parsedTrackInfo == null || parsedTrackInfo.AlbumTitle.IsNullOrWhiteSpace())
+            if (parsedTrackInfo != null && parsedTrackInfo.ReleaseMBId.IsNotNullOrWhiteSpace())
+            {
+                album = _albumService.FindAlbumByRelease(parsedTrackInfo.ReleaseMBId);
+            } else if (parsedTrackInfo == null || parsedTrackInfo.AlbumTitle.IsNullOrWhiteSpace())
             {
                 if (MediaFileExtensions.Extensions.Contains(Path.GetExtension(filename)))
                 {
@@ -245,7 +249,11 @@ namespace NzbDrone.Core.Parser
             }
 
             var tracks = GetTracks(artist, parsedTrackInfo);
-            var album = _albumService.FindByTitle(artist.Id, parsedTrackInfo.AlbumTitle);
+            if (album == null)
+            {
+                album = _albumService.FindByTitle(artist.Id, parsedTrackInfo.AlbumTitle);
+            }
+            
 
             return new LocalTrack
             {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Check if an album has a MusicBrainz Release Id during Import/Scan and check if a match in DB. If so, bypass metadata lookup against LidarrAPI.

#### Todos
- [X] Tests
- [ ] Documentation


#### Issues Fixed or Closed by this PR

Feature #227 
