### PR TITLE
Added cases to strip feat. from track titles.

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -60,6 +60,10 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Songs of Experience (Deluxe Edition)", "Songs of Experience")]
         [TestCase("Mr. Bad Guy [Special Edition]", "Mr. Bad Guy")]
         [TestCase("Smooth Criminal (single)", "Smooth Criminal")]
+        [TestCase("Wie Maak Die Jol Vol (Ft. Isaac Mutant, Knoffel, Jaak Paarl & Scallywag)", "Wie Maak Die Jol Vol")]
+        [TestCase("Alles Schon Gesehen (Feat. Deichkind)", "Alles Schon Gesehen")]
+        [TestCase("Science Fiction/Double Feature", "Science Fiction/Double Feature")]
+        [TestCase("Dancing Feathers", "Dancing Feathers")]
         public void should_remove_common_tags_from_track_title(string title, string correct)
         {
             var result = Parser.Parser.CleanTrackTitle(title);

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -591,7 +591,7 @@ namespace NzbDrone.Core.Parser
 
         public static string CleanAlbumTitle(string album)
         {
-            return CommonTagRegex[1].Replace(album, string.Empty).Trim(); ;
+            return CommonTagRegex[1].Replace(album, string.Empty).Trim();
         }
 
         public static string CleanTrackTitle(string title)

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -200,7 +200,10 @@ namespace NzbDrone.Core.Parser
 
         private static readonly string[] Numbers = new[] { "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine" };
 
-        private static readonly Regex CommonTagRegex = new Regex(@"(\[|\(){1}(version|limited|deluxe|single|clean|album|special|bonus)+\s*.*(\]|\)){1}", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex[] CommonTagRegex = new Regex[] {
+            new Regex(@"(\[|\()*\b((featuring|feat.|feat|ft|ft.)\s{1}){1}\s*.*(\]|\))*", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            new Regex(@"(\[|\(){1}(version|limited|deluxe|single|clean|album|special|bonus)+\s*.*(\]|\)){1}", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        };
         
         public static ParsedTrackInfo ParseMusicPath(string path)
         {
@@ -588,12 +591,18 @@ namespace NzbDrone.Core.Parser
 
         public static string CleanAlbumTitle(string album)
         {
-            return CommonTagRegex.Replace(album, string.Empty).Trim();
+            return CommonTagRegex[1].Replace(album, string.Empty).Trim(); ;
         }
 
         public static string CleanTrackTitle(string title)
         {
-            return CommonTagRegex.Replace(title, string.Empty).Trim();
+            var intermediateTitle = title;
+            foreach (var regex in CommonTagRegex)
+            {
+                intermediateTitle = regex.Replace(intermediateTitle, string.Empty).Trim();
+            }
+
+            return intermediateTitle;
         }
 
         private static ParsedTrackInfo ParseAudioTags(string path)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Enhances our cleaning code to ensure feat. ARTIST, ft. ARTIST, or featuring ARTIST is stripped before matching. 

#### Todos
- [x] Tests
- [ ] Documentation


#### Issues Fixed or Closed by this PR

* #283 
