### PR TITLE
Parser Enhancements

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/GetLocalTrackFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/GetLocalTrackFixture.cs
@@ -65,7 +65,7 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
                 .Returns(_fakeAlbum);
 
             Mocker.GetMock<ITrackService>()
-                .Setup(s => s.FindTrackByTitle(_fakeArtist.Id, _fakeAlbum.Id, It.IsAny<int>(), _fakeTrack.Title))
+                .Setup(s => s.FindTrackByTitle(_fakeArtist.Id, _fakeAlbum.Id, It.IsAny<int>(), It.IsAny<int>(), _fakeTrack.Title))
                 .Returns(_fakeTrack);
         }
 

--- a/src/NzbDrone.Core/Music/TrackService.cs
+++ b/src/NzbDrone.Core/Music/TrackService.cs
@@ -88,11 +88,19 @@ namespace NzbDrone.Core.Music
                     Position = normalizedReleaseTitle.IndexOf(Parser.Parser.NormalizeEpisodeTitle(track.Title), StringComparison.CurrentCultureIgnoreCase),
                     Length = Parser.Parser.NormalizeEpisodeTitle(track.Title).Length,
                     Track = track
-                })
-                                .Where(e => e.Track.Title.Length > 0 && e.Position >= 0 && e.Track.AbsoluteTrackNumber == trackNumber)
-                                .OrderBy(e => e.Position)
-                                .ThenByDescending(e => e.Length)
-                                .ToList();
+                });
+
+            if (trackNumber == 0)
+            {
+                matches =  matches.Where(e => e.Track.Title.Length > 0 && e.Position >= 0);
+            } else
+            {
+                matches = matches.Where(e => e.Track.Title.Length > 0 && e.Position >= 0 && e.Track.AbsoluteTrackNumber == trackNumber);
+            }
+ 
+            matches.OrderBy(e => e.Position)
+                    .ThenByDescending(e => e.Length)
+                    .ToList();
 
             if (matches.Any())
             {

--- a/src/NzbDrone.Core/Music/TrackService.cs
+++ b/src/NzbDrone.Core/Music/TrackService.cs
@@ -17,7 +17,7 @@ namespace NzbDrone.Core.Music
         Track GetTrack(int id);
         List<Track> GetTracks(IEnumerable<int> ids);
         Track FindTrack(int artistId, int albumId, int mediumNumber, int trackNumber);
-        Track FindTrackByTitle(int artistId, int albumId, int mediumNumber, string releaseTitle);
+        Track FindTrackByTitle(int artistId, int albumId, int mediumNumber, int trackNumber, string releaseTitle);
         List<Track> GetTracksByArtist(int artistId);
         List<Track> GetTracksByAlbum(int albumId);
         //List<Track> GetTracksByAlbumTitle(string artistId, string albumTitle);
@@ -76,7 +76,7 @@ namespace NzbDrone.Core.Music
             return _trackRepository.GetTracksByAlbum(albumId);
         }
 
-        public Track FindTrackByTitle(int artistId, int albumId, int mediumNumber, string releaseTitle)
+        public Track FindTrackByTitle(int artistId, int albumId, int mediumNumber, int trackNumber, string releaseTitle)
         {
             // TODO: can replace this search mechanism with something smarter/faster/better
             var normalizedReleaseTitle = Parser.Parser.NormalizeEpisodeTitle(releaseTitle).Replace(".", " ");
@@ -89,7 +89,7 @@ namespace NzbDrone.Core.Music
                     Length = Parser.Parser.NormalizeEpisodeTitle(track.Title).Length,
                     Track = track
                 })
-                                .Where(e => e.Track.Title.Length > 0 && e.Position >= 0)
+                                .Where(e => e.Track.Title.Length > 0 && e.Position >= 0 && e.Track.AbsoluteTrackNumber == trackNumber)
                                 .OrderBy(e => e.Position)
                                 .ThenByDescending(e => e.Length)
                                 .ToList();

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -312,11 +312,11 @@ namespace NzbDrone.Core.Parser
                 var cleanTrackTitle = Parser.CleanTrackTitle(parsedTrackInfo.Title);
                 _logger.Debug("Cleaning Track title of common matching issues. Cleaned track title is '{0}'", cleanTrackTitle);
 
-                trackInfo = _trackService.FindTrackByTitle(artist.Id, album.Id, parsedTrackInfo.DiscNumber, cleanTrackTitle);
+                trackInfo = _trackService.FindTrackByTitle(artist.Id, album.Id, parsedTrackInfo.DiscNumber, parsedTrackInfo.TrackNumbers.FirstOrDefault(), cleanTrackTitle);
 
                 if (trackInfo == null)
                 {
-                    trackInfo = _trackService.FindTrackByTitle(artist.Id, album.Id, parsedTrackInfo.DiscNumber, parsedTrackInfo.Title);
+                    trackInfo = _trackService.FindTrackByTitle(artist.Id, album.Id, parsedTrackInfo.DiscNumber, parsedTrackInfo.TrackNumbers.FirstOrDefault(), parsedTrackInfo.Title);
                 }
 
                 if (trackInfo != null)

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -308,10 +308,16 @@ namespace NzbDrone.Core.Parser
 
             if (parsedTrackInfo.Title.IsNotNullOrWhiteSpace())
             {
+                Track trackInfo;
                 var cleanTrackTitle = Parser.CleanTrackTitle(parsedTrackInfo.Title);
                 _logger.Debug("Cleaning Track title of common matching issues. Cleaned track title is '{0}'", cleanTrackTitle);
 
-                var trackInfo = _trackService.FindTrackByTitle(artist.Id, album.Id, parsedTrackInfo.DiscNumber, cleanTrackTitle);
+                trackInfo = _trackService.FindTrackByTitle(artist.Id, album.Id, parsedTrackInfo.DiscNumber, cleanTrackTitle);
+
+                if (trackInfo == null)
+                {
+                    trackInfo = _trackService.FindTrackByTitle(artist.Id, album.Id, parsedTrackInfo.DiscNumber, parsedTrackInfo.Title);
+                }
 
                 if (trackInfo != null)
                 {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
* Fallback to non-cleaned track titles when a cleaned track is not matched in the database.
* When matching tracks on an album, include the track number as some albums have tracks with same name. Fixes #287 

#### Todos
- [ ] Tests
- [ ] Documentation


#### Issues Fixed or Closed by this PR
Fixes #287
