### PR TITLE
Changed: Modify Artist Update Intervals

### DIFF
--- a/src/NzbDrone.Core/Jobs/TaskManager.cs
+++ b/src/NzbDrone.Core/Jobs/TaskManager.cs
@@ -64,7 +64,7 @@ namespace NzbDrone.Core.Jobs
                     new ScheduledTask{ Interval = 5, TypeName = typeof(MessagingCleanupCommand).FullName},
                     new ScheduledTask{ Interval = 6*60, TypeName = typeof(ApplicationUpdateCommand).FullName},
                     new ScheduledTask{ Interval = 6*60, TypeName = typeof(CheckHealthCommand).FullName},
-                    new ScheduledTask{ Interval = 12*60, TypeName = typeof(RefreshArtistCommand).FullName},
+                    new ScheduledTask{ Interval = 24*60, TypeName = typeof(RefreshArtistCommand).FullName},
                     new ScheduledTask{ Interval = 24*60, TypeName = typeof(HousekeepingCommand).FullName},
 
                     new ScheduledTask

--- a/src/NzbDrone.Core/Music/ShouldRefreshAlbum.cs
+++ b/src/NzbDrone.Core/Music/ShouldRefreshAlbum.cs
@@ -19,15 +19,15 @@ namespace NzbDrone.Core.Music
 
         public bool ShouldRefresh(Album album)
         {
-            if (album.LastInfoSync < DateTime.UtcNow.AddDays(-30))
+            if (album.LastInfoSync < DateTime.UtcNow.AddDays(-60))
             {
-                _logger.Trace("Album {0} last updated more than 30 days ago, should refresh.", album.Title);
+                _logger.Trace("Album {0} last updated more than 60 days ago, should refresh.", album.Title);
                 return true;
             }
 
-            if (album.LastInfoSync >= DateTime.UtcNow.AddHours(-6))
+            if (album.LastInfoSync >= DateTime.UtcNow.AddHours(-12))
             {
-                _logger.Trace("Album {0} last updated less than 6 hours ago, should not be refreshed.", album.Title);
+                _logger.Trace("Album {0} last updated less than 12 hours ago, should not be refreshed.", album.Title);
                 return false;
             }
 

--- a/src/NzbDrone.Core/Music/ShouldRefreshArtist.cs
+++ b/src/NzbDrone.Core/Music/ShouldRefreshArtist.cs
@@ -30,15 +30,15 @@ namespace NzbDrone.Core.Music
                 return true;
             }
 
-            if (artist.LastInfoSync >= DateTime.UtcNow.AddHours(-6))
+            if (artist.LastInfoSync >= DateTime.UtcNow.AddHours(-12))
             {
-                _logger.Trace("Artist {0} last updated less than 6 hours ago, should not be refreshed.", artist.Name);
+                _logger.Trace("Artist {0} last updated less than 12 hours ago, should not be refreshed.", artist.Name);
                 return false;
             }
 
-            if (artist.Status == ArtistStatusType.Continuing)
+            if (artist.Status == ArtistStatusType.Continuing && artist.LastInfoSync < DateTime.UtcNow.AddDays(-2))
             {
-                _logger.Trace("Artist {0} is continuing, should refresh.", artist.Name);
+                _logger.Trace("Artist {0} is continuing and has not been refreshed in 2 days, should refresh.", artist.Name);
                 return true;
             }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Sets Artist Refresh Scan to 24 hours instead of 12
Sets old album refresh interval to 60 days instead of 30
Sets continuing artist refresh interval to 2 days instead of 12 hours.

