### PR TITLE
New: Expand OnAlbumDownload, Add Synology handling

### DIFF
--- a/src/NzbDrone.Core.Test/NotificationTests/SynologyIndexerFixture.cs
+++ b/src/NzbDrone.Core.Test/NotificationTests/SynologyIndexerFixture.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Test.NotificationTests
     public class SynologyIndexerFixture : CoreTest<SynologyIndexer>
     {
         private Artist _artist;
-        private TrackDownloadMessage _upgrade;
+        private AlbumDownloadMessage _upgrade;
 
         [SetUp]
         public void SetUp()
@@ -24,13 +24,17 @@ namespace NzbDrone.Core.Test.NotificationTests
                 Path = @"C:\Test\".AsOsAgnostic()
             };
 
-            _upgrade = new TrackDownloadMessage()
+            _upgrade = new AlbumDownloadMessage()
             {
                 Artist = _artist,
 
-                TrackFile = new TrackFile
+                TrackFiles = new List<TrackFile>
                 {
-                    RelativePath = "file1.S01E01E02.mkv"
+                    new TrackFile
+                    {
+                        RelativePath = "file1.S01E01E02.mkv"
+                    }
+                    
                 },
 
                 OldFiles = new List<TrackFile>
@@ -69,7 +73,7 @@ namespace NzbDrone.Core.Test.NotificationTests
         [Test]
         public void should_remove_old_episodes_on_upgrade()
         {
-            Subject.OnDownload(_upgrade);
+            Subject.OnAlbumDownload(_upgrade);
 
             Mocker.GetMock<ISynologyIndexerProxy>()
                 .Verify(v => v.DeleteFile(@"C:\Test\file1.S01E01.mkv".AsOsAgnostic()), Times.Once());
@@ -81,7 +85,7 @@ namespace NzbDrone.Core.Test.NotificationTests
         [Test]
         public void should_add_new_episode_on_upgrade()
         {
-            Subject.OnDownload(_upgrade);
+            Subject.OnAlbumDownload(_upgrade);
 
             Mocker.GetMock<ISynologyIndexerProxy>()
                 .Verify(v => v.AddFile(@"C:\Test\file1.S01E01E02.mkv".AsOsAgnostic()), Times.Once());

--- a/src/NzbDrone.Core/MediaFiles/Events/AlbumImportedEvent.cs
+++ b/src/NzbDrone.Core/MediaFiles/Events/AlbumImportedEvent.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using NzbDrone.Common.Messaging;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.Music;
-using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.MediaFiles.Events
 {
@@ -10,16 +9,18 @@ namespace NzbDrone.Core.MediaFiles.Events
     {
         public Artist Artist { get; private set; }
         public Album Album { get; private set; }
-        public List<LocalTrack> ImportedTracks { get; private set; }
+        public List<TrackFile> ImportedTracks { get; private set; }
+        public List<TrackFile> OldFiles { get; private set; }
         public bool NewDownload { get; private set; }
         public string DownloadClient { get; private set; }
         public string DownloadId { get; private set; }
 
-        public AlbumImportedEvent(Artist artist, Album album, List<LocalTrack> importedTracks, bool newDownload, DownloadClientItem downloadClientItem)
+        public AlbumImportedEvent(Artist artist, Album album, List<TrackFile> importedTracks, List<TrackFile> oldFiles, bool newDownload, DownloadClientItem downloadClientItem)
         {
             Artist = artist;
             Album = album;
             ImportedTracks = importedTracks;
+            OldFiles = oldFiles;
             NewDownload = newDownload;
 
             if (downloadClientItem != null)

--- a/src/NzbDrone.Core/MediaFiles/TrackImport/ImportApprovedTracks.cs
+++ b/src/NzbDrone.Core/MediaFiles/TrackImport/ImportApprovedTracks.cs
@@ -27,14 +27,14 @@ namespace NzbDrone.Core.MediaFiles.TrackImport
         private readonly IEventAggregator _eventAggregator;
         private readonly Logger _logger;
 
-        public ImportApprovedTracks(IUpgradeMediaFiles episodeFileUpgrader,
+        public ImportApprovedTracks(IUpgradeMediaFiles trackFileUpgrader,
                                       IMediaFileService mediaFileService,
                                       IExtraService extraService,
                                       IDiskProvider diskProvider,
                                       IEventAggregator eventAggregator,
                                       Logger logger)
         {
-            _trackFileUpgrader = episodeFileUpgrader;
+            _trackFileUpgrader = trackFileUpgrader;
             _mediaFileService = mediaFileService;
             _extraService = extraService;
             _diskProvider = diskProvider;

--- a/src/NzbDrone.Core/Notifications/AlbumDownloadMessage.cs
+++ b/src/NzbDrone.Core/Notifications/AlbumDownloadMessage.cs
@@ -10,6 +10,7 @@ namespace NzbDrone.Core.Notifications
         public Artist Artist { get; set; }
         public Album Album { get; set; }
         public List<TrackFile> TrackFiles { get; set; }
+        public List<TrackFile> OldFiles { get; set; }
         public string DownloadClient { get; set; }
         public string DownloadId { get; set; }
 

--- a/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
+++ b/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
@@ -117,6 +117,18 @@ namespace NzbDrone.Core.Notifications.CustomScript
             environmentVariables.Add("Lidarr_Download_Client", message.DownloadClient ?? string.Empty);
             environmentVariables.Add("Lidarr_Download_Id", message.DownloadId ?? string.Empty);
 
+            if (message.TrackFiles.Any())
+            {
+                environmentVariables.Add("Lidarr_AddedTrackRelativePaths", string.Join("|", message.TrackFiles.Select(e => e.RelativePath)));
+                environmentVariables.Add("Lidarr_AddedTrackPaths", string.Join("|", message.TrackFiles.Select(e => Path.Combine(artist.Path, e.RelativePath))));
+            }
+
+            if (message.OldFiles.Any())
+            {
+                environmentVariables.Add("Lidarr_DeletedRelativePaths", string.Join("|", message.OldFiles.Select(e => e.RelativePath)));
+                environmentVariables.Add("Lidarr_DeletedPaths", string.Join("|", message.OldFiles.Select(e => Path.Combine(artist.Path, e.RelativePath))));
+            }
+
             ExecuteScript(environmentVariables);
         }
 

--- a/src/NzbDrone.Core/Notifications/NotificationService.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Download;
+using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.Events;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Qualities;
@@ -64,7 +65,7 @@ namespace NzbDrone.Core.Notifications
                                     qualityString);
         }
 
-        private string GetAlbumDownloadMessage(Artist artist, Album album, List<LocalTrack> tracks)
+        private string GetAlbumDownloadMessage(Artist artist, Album album, List<TrackFile> tracks)
         {
             return string.Format("{0} - {1} ({2} Tracks Imported)",
                 artist.Name,
@@ -172,7 +173,9 @@ namespace NzbDrone.Core.Notifications
                 Artist = message.Artist,
                 Album = message.Album,
                 DownloadClient = message.DownloadClient,
-                DownloadId = message.DownloadId
+                DownloadId = message.DownloadId,
+                TrackFiles = message.ImportedTracks,
+                OldFiles = message.OldFiles,
             };
 
             foreach (var notification in _notificationFactory.OnAlbumDownloadEnabled())

--- a/src/NzbDrone.Core/Notifications/Synology/SynologyIndexer.cs
+++ b/src/NzbDrone.Core/Notifications/Synology/SynologyIndexer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using FluentValidation.Results;
@@ -20,7 +21,7 @@ namespace NzbDrone.Core.Notifications.Synology
         public override string Name => "Synology Indexer";
 
 
-        public override void OnDownload(TrackDownloadMessage message)
+        public override void OnAlbumDownload(AlbumDownloadMessage message)
         {
             if (Settings.UpdateLibrary)
             {
@@ -31,8 +32,9 @@ namespace NzbDrone.Core.Notifications.Synology
                     _indexerProxy.DeleteFile(fullPath);
                 }
 
+                foreach (var newFile in message.TrackFiles)
                 {
-                    var fullPath = Path.Combine(message.Artist.Path, message.TrackFile.RelativePath);
+                    var fullPath = Path.Combine(message.Artist.Path, newFile.RelativePath);
 
                     _indexerProxy.AddFile(fullPath);
                 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Send OldFiles and NewFiles with OnAlbumDownloaded Event.
Handle Synology add and delete with a OnAlbumDownloaded Event.
Add OldFiles and AddedFiles to Custom Script variables for OnAlbumDownloaded Event.

#### Todos
- [x] Documentation

#### Issues Fixed or Closed by this PR
Fixes #324
