### PR TITLE
Changed: Force album refresh when artist refresh manually triggered

### DIFF
--- a/src/NzbDrone.Core.Test/MusicTests/RefreshAlbumServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MusicTests/RefreshAlbumServiceFixture.cs
@@ -59,7 +59,7 @@ namespace NzbDrone.Core.Test.MusicTests
         [Test]
         public void should_log_error_if_musicbrainz_id_not_found()
         {
-            Subject.RefreshAlbumInfo(_albums);
+            Subject.RefreshAlbumInfo(_albums, false);
 
             Mocker.GetMock<IAlbumService>()
                 .Verify(v => v.UpdateMany(It.IsAny<List<Album>>()), Times.Never());
@@ -75,7 +75,7 @@ namespace NzbDrone.Core.Test.MusicTests
 
             GivenNewAlbumInfo(newAlbumInfo);
 
-            Subject.RefreshAlbumInfo(_albums);
+            Subject.RefreshAlbumInfo(_albums, false);
 
             Mocker.GetMock<IAlbumService>()
                 .Verify(v => v.UpdateMany(It.Is<List<Album>>(s => s.First().ForeignAlbumId == newAlbumInfo.ForeignAlbumId)));

--- a/src/NzbDrone.Core/Music/RefreshAlbumService.cs
+++ b/src/NzbDrone.Core/Music/RefreshAlbumService.cs
@@ -20,7 +20,7 @@ namespace NzbDrone.Core.Music
     public interface IRefreshAlbumService
     {
         void RefreshAlbumInfo(Album album);
-        void RefreshAlbumInfo(List<Album> albums);
+        void RefreshAlbumInfo(List<Album> albums, bool forceAlbumRefresh);
     }
 
     public class RefreshAlbumService : IRefreshAlbumService, IExecute<RefreshAlbumCommand>
@@ -50,11 +50,11 @@ namespace NzbDrone.Core.Music
             _logger = logger;
         }
 
-        public void RefreshAlbumInfo(List<Album> albums)
+        public void RefreshAlbumInfo(List<Album> albums, bool forceAlbumRefresh)
         {
             foreach (var album in albums)
             {
-                if (_checkIfAlbumShouldBeRefreshed.ShouldRefresh(album))
+                if (forceAlbumRefresh || _checkIfAlbumShouldBeRefreshed.ShouldRefresh(album))
                 {
                     RefreshAlbumInfo(album);
                 }

--- a/src/NzbDrone.Core/Music/RefreshArtistService.cs
+++ b/src/NzbDrone.Core/Music/RefreshArtistService.cs
@@ -52,7 +52,7 @@ namespace NzbDrone.Core.Music
             _logger = logger;
         }
 
-        private void RefreshArtistInfo(Artist artist)
+        private void RefreshArtistInfo(Artist artist, bool forceAlbumRefresh)
         {
             _logger.ProgressInfo("Updating Info for {0}", artist.Name);
 
@@ -131,7 +131,7 @@ namespace NzbDrone.Core.Music
 
             _addAlbumService.AddAlbums(newAlbumsList);
 
-            _refreshAlbumService.RefreshAlbumInfo(updateAlbumsList);
+            _refreshAlbumService.RefreshAlbumInfo(updateAlbumsList, forceAlbumRefresh);
 
             _albumService.DeleteMany(existingAlbums);
 
@@ -160,7 +160,7 @@ namespace NzbDrone.Core.Music
             if (message.ArtistId.HasValue)
             {
                 var artist = _artistService.GetArtist(message.ArtistId.Value);
-                RefreshArtistInfo(artist);
+                RefreshArtistInfo(artist, false);
             }
             else
             {
@@ -168,11 +168,12 @@ namespace NzbDrone.Core.Music
 
                 foreach (var artist in allArtists)
                 {
-                    if (message.Trigger == CommandTrigger.Manual || _checkIfArtistShouldBeRefreshed.ShouldRefresh(artist))
+                    var manualTrigger = message.Trigger == CommandTrigger.Manual;
+                    if (manualTrigger || _checkIfArtistShouldBeRefreshed.ShouldRefresh(artist))
                     {
                         try
                         {
-                            RefreshArtistInfo(artist);
+                            RefreshArtistInfo(artist, manualTrigger);
                         }
                         catch (Exception e)
                         {

--- a/src/NzbDrone.Core/Music/RefreshArtistService.cs
+++ b/src/NzbDrone.Core/Music/RefreshArtistService.cs
@@ -160,7 +160,7 @@ namespace NzbDrone.Core.Music
             if (message.ArtistId.HasValue)
             {
                 var artist = _artistService.GetArtist(message.ArtistId.Value);
-                RefreshArtistInfo(artist, false);
+                RefreshArtistInfo(artist, true);
             }
             else
             {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Override album refresh logic when triggered by a manual artist refresh.
