### PR TITLE
Add Reflink support (on Linux)

### DIFF
--- a/frontend/src/Settings/MediaManagement/MediaManagement.js
+++ b/frontend/src/Settings/MediaManagement/MediaManagement.js
@@ -151,6 +151,7 @@ class MediaManagement extends Component {
                           type={inputTypes.CHECK}
                           name="copyUsingReflinks"
                           helpText="Use Reflinks when trying to copy files from torrents that are still being seeded"
+                          helpTextWarning="Reflinks are currently only implemented for Linux."
                           onChange={onInputChange}
                           {...settings.copyUsingReflinks}
                         />

--- a/frontend/src/Settings/MediaManagement/MediaManagement.js
+++ b/frontend/src/Settings/MediaManagement/MediaManagement.js
@@ -140,22 +140,31 @@ class MediaManagement extends Component {
                           </FormGroup>
                       }
 
+                      {
+                        isMono &&
+                          <FormGroup
+                            advancedSettings={advancedSettings}
+                            isAdvanced={true}
+                            size={sizes.MEDIUM}
+                          >
+                            <FormLabel>Use Reflinks instead of Copy</FormLabel>
+
+                            <FormInputGroup
+                              type={inputTypes.CHECK}
+                              name="copyUsingReflinks"
+                              helpText="Use Reflinks when trying to copy files from torrents that are still being seeded"
+                              helpTextWarning="Reflinks are currently only implemented for Linux."
+                              onChange={onInputChange}
+                              {...settings.copyUsingReflinks}
+                            />
+                          </FormGroup>
+                      }
+
                       <FormGroup
                         advancedSettings={advancedSettings}
                         isAdvanced={true}
                         size={sizes.MEDIUM}
                       >
-                        <FormLabel>Use Reflinks instead of Copy</FormLabel>
-
-                        <FormInputGroup
-                          type={inputTypes.CHECK}
-                          name="copyUsingReflinks"
-                          helpText="Use Reflinks when trying to copy files from torrents that are still being seeded"
-                          helpTextWarning="Reflinks are currently only implemented for Linux."
-                          onChange={onInputChange}
-                          {...settings.copyUsingReflinks}
-                        />
-
                         <FormLabel>Use Hardlinks instead of Copy</FormLabel>
 
                         <FormInputGroup

--- a/frontend/src/Settings/MediaManagement/MediaManagement.js
+++ b/frontend/src/Settings/MediaManagement/MediaManagement.js
@@ -145,6 +145,16 @@ class MediaManagement extends Component {
                         isAdvanced={true}
                         size={sizes.MEDIUM}
                       >
+                        <FormLabel>Use Reflinks instead of Copy</FormLabel>
+
+                        <FormInputGroup
+                          type={inputTypes.CHECK}
+                          name="copyUsingReflinks"
+                          helpText="Use Reflinks when trying to copy files from torrents that are still being seeded"
+                          onChange={onInputChange}
+                          {...settings.copyUsingReflinks}
+                        />
+
                         <FormLabel>Use Hardlinks instead of Copy</FormLabel>
 
                         <FormInputGroup

--- a/frontend/src/Settings/MediaManagement/MediaManagement.js
+++ b/frontend/src/Settings/MediaManagement/MediaManagement.js
@@ -153,7 +153,7 @@ class MediaManagement extends Component {
                               type={inputTypes.CHECK}
                               name="copyUsingReflinks"
                               helpText="Use Reflinks when trying to copy files from torrents that are still being seeded"
-                              helpTextWarning="Reflinks are currently only implemented for Linux."
+                              helpTextWarning="Reflinks are currently only implemented for Linux, and only work on very specific filesystems: btrfs, OCFS2 and newer XFS systems."
                               onChange={onInputChange}
                               {...settings.copyUsingReflinks}
                             />

--- a/src/Lidarr.Api.V1/Config/MediaManagementConfigResource.cs
+++ b/src/Lidarr.Api.V1/Config/MediaManagementConfigResource.cs
@@ -23,6 +23,7 @@ namespace Lidarr.Api.V1.Config
 
         public bool SkipFreeSpaceCheckWhenImporting { get; set; }
         public bool CopyUsingHardlinks { get; set; }
+        public bool CopyUsingReflinks { get; set; }
         public bool ImportExtraFiles { get; set; }
         public string ExtraFileExtensions { get; set; }
     }
@@ -50,6 +51,7 @@ namespace Lidarr.Api.V1.Config
 
                 SkipFreeSpaceCheckWhenImporting = model.SkipFreeSpaceCheckWhenImporting,
                 CopyUsingHardlinks = model.CopyUsingHardlinks,
+                CopyUsingReflinks = model.CopyUsingReflinks,
                 ImportExtraFiles = model.ImportExtraFiles,
                 ExtraFileExtensions = model.ExtraFileExtensions,
             };

--- a/src/NzbDrone.Common/Disk/DiskProviderBase.cs
+++ b/src/NzbDrone.Common/Disk/DiskProviderBase.cs
@@ -241,6 +241,7 @@ namespace NzbDrone.Common.Disk
         }
 
         public abstract bool TryCreateHardLink(string source, string destination);
+        public abstract bool TryCreateRefLink(string source, string destination);
 
         public void DeleteFolder(string path, bool recursive)
         {

--- a/src/NzbDrone.Common/Disk/DiskTransferService.cs
+++ b/src/NzbDrone.Common/Disk/DiskTransferService.cs
@@ -272,6 +272,14 @@ namespace NzbDrone.Common.Disk
 
             ClearTargetPath(sourcePath, targetPath, overwrite);
 
+            if (mode.HasFlag(TransferMode.RefLink))
+            {
+                var createdRefLink = _diskProvider.TryCreateRefLink(sourcePath, targetPath);
+                if (createdRefLink) {
+                    return TransferMode.RefLink;
+                }
+            }
+
             if (mode.HasFlag(TransferMode.HardLink))
             {
                 var createdHardlink = _diskProvider.TryCreateHardLink(sourcePath, targetPath);

--- a/src/NzbDrone.Common/Disk/IDiskProvider.cs
+++ b/src/NzbDrone.Common/Disk/IDiskProvider.cs
@@ -30,6 +30,7 @@ namespace NzbDrone.Common.Disk
         void MoveFile(string source, string destination, bool overwrite = false);
         void MoveFolder(string source, string destination);
         bool TryCreateHardLink(string source, string destination);
+        bool TryCreateRefLink(string source, string destination);
         void DeleteFolder(string path, bool recursive);
         string ReadAllText(string filePath);
         void WriteAllText(string filename, string contents);

--- a/src/NzbDrone.Common/Disk/TransferMode.cs
+++ b/src/NzbDrone.Common/Disk/TransferMode.cs
@@ -10,7 +10,8 @@ namespace NzbDrone.Common.Disk
         Move = 1,
         Copy = 2,
         HardLink = 4,
+        RefLink = 8,
 
-        HardLinkOrCopy = Copy | HardLink
+        HardLinkOrCopy = Copy | HardLink,
     }
 }

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -195,6 +195,20 @@ namespace NzbDrone.Core.Configuration
             set { SetValue("CopyUsingHardlinks", value); }
         }
 
+        public bool CopyUsingReflinks
+        {
+            get { return GetValueBoolean("CopyUsingReflinks", true); }
+
+            set { SetValue("CopyUsingReflinks", value); }
+        }
+
+        public bool EnableMediaInfo
+        {
+            get { return GetValueBoolean("EnableMediaInfo", true); }
+
+            set { SetValue("EnableMediaInfo", value); }
+        }
+
         public bool ImportExtraFiles
         {
             get { return GetValueBoolean("ImportExtraFiles", false); }

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -30,6 +30,8 @@ namespace NzbDrone.Core.Configuration
         FileDateType FileDate { get; set; }
         bool SkipFreeSpaceCheckWhenImporting { get; set; }
         bool CopyUsingHardlinks { get; set; }
+        bool CopyUsingReflinks { get; set; }
+        bool EnableMediaInfo { get; set; }
         bool ImportExtraFiles { get; set; }
         string ExtraFileExtensions { get; set; }
         RescanAfterRefreshType RescanAfterRefresh { get; set; }

--- a/src/NzbDrone.Core/MediaFiles/TrackFileMovingService.cs
+++ b/src/NzbDrone.Core/MediaFiles/TrackFileMovingService.cs
@@ -95,7 +95,12 @@ namespace NzbDrone.Core.MediaFiles
 
             EnsureTrackFolder(trackFile, localTrack, filePath);
 
-            if (_configService.CopyUsingHardlinks)
+            if (_configService.CopyUsingReflinks)
+            {
+                _logger.Debug("Reflinking track file: {0} to {1}", trackFile.Path, filePath);
+                return TransferFile(trackFile, localTrack.Artist, localTrack.Tracks, filePath, TransferMode.RefLinkOrCopy);
+            }
+            else if (_configService.CopyUsingHardlinks)
             {
                 _logger.Debug("Hardlinking track file: {0} to {1}", trackFile.Path, filePath);
                 return TransferFile(trackFile, localTrack.Artist, localTrack.Tracks, filePath, TransferMode.HardLinkOrCopy);

--- a/src/NzbDrone.Core/MediaFiles/TrackFileMovingService.cs
+++ b/src/NzbDrone.Core/MediaFiles/TrackFileMovingService.cs
@@ -95,19 +95,24 @@ namespace NzbDrone.Core.MediaFiles
 
             EnsureTrackFolder(trackFile, localTrack, filePath);
 
+            var transferMode = TransferMode.Copy;
+
             if (_configService.CopyUsingReflinks)
             {
+                transferMode |= TransferMode.RefLink;
                 _logger.Debug("Reflinking track file: {0} to {1}", trackFile.Path, filePath);
-                return TransferFile(trackFile, localTrack.Artist, localTrack.Tracks, filePath, TransferMode.RefLinkOrCopy);
             }
             else if (_configService.CopyUsingHardlinks)
             {
+                transferMode |= TransferMode.HardLink;
                 _logger.Debug("Hardlinking track file: {0} to {1}", trackFile.Path, filePath);
-                return TransferFile(trackFile, localTrack.Artist, localTrack.Tracks, filePath, TransferMode.HardLinkOrCopy);
+            }
+            else
+            {
+                _logger.Debug("Copying track file: {0} to {1}", trackFile.Path, filePath);
             }
 
-            _logger.Debug("Copying track file: {0} to {1}", trackFile.Path, filePath);
-            return TransferFile(trackFile, localTrack.Artist, localTrack.Tracks, filePath, TransferMode.Copy);
+            return TransferFile(trackFile, localTrack.Artist, localTrack.Tracks, filePath, transferMode);
         }
 
         private TrackFile TransferFile(TrackFile trackFile, Artist artist, List<Track> tracks, string destinationFilePath, TransferMode mode)

--- a/src/NzbDrone.Mono/Disk/DiskProvider.cs
+++ b/src/NzbDrone.Mono/Disk/DiskProvider.cs
@@ -208,6 +208,11 @@ namespace NzbDrone.Mono.Disk
             }
         }
 
+        public override bool TryCreateRefLink(string source, string destination)
+        {
+            return false;
+        }
+
         private void SetPermissions(string path, string mask)
         {
             Logger.Debug("Setting permissions: {0} on {1}", mask, path);

--- a/src/NzbDrone.Mono/Disk/DiskProvider.cs
+++ b/src/NzbDrone.Mono/Disk/DiskProvider.cs
@@ -232,8 +232,7 @@ namespace NzbDrone.Mono.Disk
             {
                 var result = FiCloneIoCtl(dest_fd, FICLONE, source_fd);
                 if (result == 0) {
-                    Syscall.close(source_fd);
-                    Syscall.close(dest_fd);
+                    // Files get closed in the finally block
                     return true;
                 }
                 var error = Stdlib.GetLastError();
@@ -247,9 +246,12 @@ namespace NzbDrone.Mono.Disk
             {
                 Logger.Debug(e, "No libc.so on this platform; macOS currently unsupported for reflink");
             }
+            finally
+            {
+                Syscall.close(source_fd);
+                Syscall.close(dest_fd);
+            }
 
-            Syscall.close(source_fd);
-            Syscall.close(dest_fd);
             return false;
         }
 

--- a/src/NzbDrone.Windows/Disk/DiskProvider.cs
+++ b/src/NzbDrone.Windows/Disk/DiskProvider.cs
@@ -103,7 +103,6 @@ namespace NzbDrone.Windows.Disk
             return 0;
         }
 
-        
         public override bool TryCreateHardLink(string source, string destination)
         {
             try
@@ -115,6 +114,11 @@ namespace NzbDrone.Windows.Disk
                 Logger.Debug(ex, string.Format("Hardlink '{0}' to '{1}' failed.", source, destination));
                 return false;
             }
+        }
+
+        public override bool TryCreateRefLink(string source, string destination)
+        {
+            return false;
         }
     }
 }


### PR DESCRIPTION
<small>(**note**: C#/.NET n00b here)</small>

#### Database Migration
YES | NO

not sure, do I have to make one for config entries?

#### Description
When adding [ID3 retagging](https://github.com/lidarr/Lidarr/issues/289) support, files will get changed. Hardlinked files will corrupt seeding torrents.
Reflinks refer to the same data blocks, but on file change, will copy the blocks before changing. That way torrents don't get corrupted, and we can alter files a volonté.

Reflinks are thus a CoW (copy-on-write) version of links.

They are only supported on a few platforms and filesystems though. Linux has support on btrfs, ocfs2, and new XFS formats. MacOS supports it on their new filesystem. Windows supports it on ReFS.

Personally, I am only interested in the Linux code (FICLONE syscall). If someone really wants Windows/macOS support, feel free to add to this PR. I have macOS and Linux code in [my Python library](https://gitlab.com/rubdos/pyreflink).

#### Todos
- [ ] Tests
- [ ] Documentation
- [x] Implementation of the reflink