### PR TITLE
New: Added album disambiguation to UI [ex. Weezer (Blue Album)]

### DIFF
--- a/frontend/src/Activity/History/HistoryRow.js
+++ b/frontend/src/Activity/History/HistoryRow.js
@@ -114,6 +114,7 @@ class HistoryRow extends Component {
                   <AlbumTitleLink
                     foreignAlbumId={album.foreignAlbumId}
                     title={album.title}
+                    disambiguation={album.disambiguation}
                   />
                 </TableRowCell>
               );

--- a/frontend/src/Activity/Queue/QueueRow.js
+++ b/frontend/src/Activity/Queue/QueueRow.js
@@ -158,6 +158,7 @@ class QueueRow extends Component {
                   <AlbumTitleLink
                     foreignAlbumId={album.foreignAlbumId}
                     title={album.title}
+                    disambiguation={album.disambiguation}
                   />
                 </TableRowCell>
               );

--- a/frontend/src/Album/AlbumTitleLink.js
+++ b/frontend/src/Album/AlbumTitleLink.js
@@ -2,19 +2,20 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Link from 'Components/Link/Link';
 
-function AlbumTitleLink({ foreignAlbumId, title }) {
+function AlbumTitleLink({ foreignAlbumId, title, disambiguation }) {
   const link = `/album/${foreignAlbumId}`;
 
   return (
     <Link to={link}>
-      {title}
+      {title}{disambiguation ? ` (${disambiguation})` : ''}
     </Link>
   );
 }
 
 AlbumTitleLink.propTypes = {
   foreignAlbumId: PropTypes.string.isRequired,
-  title: PropTypes.string.isRequired
+  title: PropTypes.string.isRequired,
+  disambiguation: PropTypes.string
 };
 
 export default AlbumTitleLink;

--- a/frontend/src/Album/Details/AlbumDetails.js
+++ b/frontend/src/Album/Details/AlbumDetails.js
@@ -136,6 +136,7 @@ class AlbumDetails extends Component {
     const {
       id,
       title,
+      disambiguation,
       albumType,
       statistics,
       monitored,
@@ -251,7 +252,7 @@ class AlbumDetails extends Component {
               <div className={styles.info}>
                 <div className={styles.titleContainer}>
                   <div className={styles.title}>
-                    {title}
+                    {title}{disambiguation ? ` (${disambiguation})` : ''}
                   </div>
 
                   <div className={styles.artistNavigationButtons}>
@@ -444,6 +445,7 @@ AlbumDetails.propTypes = {
   id: PropTypes.number.isRequired,
   foreignAlbumId: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
+  disambiguation: PropTypes.string,
   albumType: PropTypes.string.isRequired,
   statistics: PropTypes.object.isRequired,
   releaseDate: PropTypes.string.isRequired,

--- a/frontend/src/Artist/Details/AlbumRow.js
+++ b/frontend/src/Artist/Details/AlbumRow.js
@@ -76,6 +76,7 @@ class AlbumRow extends Component {
       secondaryTypes,
       title,
       ratings,
+      disambiguation,
       isSaving,
       artistMonitored,
       foreignAlbumId,
@@ -124,8 +125,9 @@ class AlbumRow extends Component {
                   className={styles.title}
                 >
                   <AlbumTitleLink
-                    title={title}
                     foreignAlbumId={foreignAlbumId}
+                    title={title}
+                    disambiguation={disambiguation}
                   />
                 </TableRowCell>
               );
@@ -239,6 +241,7 @@ AlbumRow.propTypes = {
   duration: PropTypes.number.isRequired,
   title: PropTypes.string.isRequired,
   ratings: PropTypes.object.isRequired,
+  disambiguation: PropTypes.string,
   secondaryTypes: PropTypes.arrayOf(PropTypes.string).isRequired,
   foreignAlbumId: PropTypes.string.isRequired,
   isSaving: PropTypes.bool,

--- a/frontend/src/Artist/Index/Table/ArtistIndexRow.js
+++ b/frontend/src/Artist/Index/Table/ArtistIndexRow.js
@@ -187,6 +187,7 @@ class ArtistIndexRow extends Component {
                   >
                     <AlbumTitleLink
                       title={nextAlbum.title}
+                      disambiguation={nextAlbum.disambiguation}
                       foreignAlbumId={nextAlbum.foreignAlbumId}
                     />
                   </VirtualTableRowCell>
@@ -211,6 +212,7 @@ class ArtistIndexRow extends Component {
                   >
                     <AlbumTitleLink
                       title={lastAlbum.title}
+                      disambiguation={lastAlbum.disambiguation}
                       foreignAlbumId={lastAlbum.foreignAlbumId}
                     />
                   </VirtualTableRowCell>

--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
@@ -134,7 +134,9 @@ class NamingModal extends Component {
 
       { token: '{Album CleanTitle}', example: 'Album Title' },
 
-      { token: '{Album Type}', example: 'Album Type' }
+      { token: '{Album Type}', example: 'Album Type' },
+
+      { token: '{Album Disambiguation}', example: 'Disambiguation' }
     ];
 
     const mediumTokens = [

--- a/frontend/src/Wanted/CutoffUnmet/CutoffUnmetRow.js
+++ b/frontend/src/Wanted/CutoffUnmet/CutoffUnmetRow.js
@@ -21,6 +21,7 @@ function CutoffUnmetRow(props) {
     foreignAlbumId,
     albumType,
     title,
+    disambiguation,
     isSelected,
     columns,
     onSelectedChange
@@ -62,6 +63,7 @@ function CutoffUnmetRow(props) {
                 <AlbumTitleLink
                   foreignAlbumId={foreignAlbumId}
                   title={title}
+                  disambiguation={disambiguation}
                 />
               </TableRowCell>
             );
@@ -140,6 +142,7 @@ CutoffUnmetRow.propTypes = {
   foreignAlbumId: PropTypes.string.isRequired,
   albumType: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
+  disambiguation: PropTypes.string,
   isSelected: PropTypes.bool,
   columns: PropTypes.arrayOf(PropTypes.object).isRequired,
   onSelectedChange: PropTypes.func.isRequired

--- a/frontend/src/Wanted/Missing/MissingRow.js
+++ b/frontend/src/Wanted/Missing/MissingRow.js
@@ -20,6 +20,7 @@ function MissingRow(props) {
     albumType,
     foreignAlbumId,
     title,
+    disambiguation,
     isSelected,
     columns,
     onSelectedChange
@@ -55,30 +56,13 @@ function MissingRow(props) {
             );
           }
 
-          // if (name === 'episode') {
-          //   return (
-          //     <TableRowCell
-          //       key={name}
-          //       className={styles.episode}
-          //     >
-          //       <SeasonEpisodeNumber
-          //         seasonNumber={seasonNumber}
-          //         episodeNumber={episodeNumber}
-          //         absoluteEpisodeNumber={absoluteEpisodeNumber}
-          //         sceneSeasonNumber={sceneSeasonNumber}
-          //         sceneEpisodeNumber={sceneEpisodeNumber}
-          //         sceneAbsoluteEpisodeNumber={sceneAbsoluteEpisodeNumber}
-          //       />
-          //     </TableRowCell>
-          //   );
-          // }
-
           if (name === 'albumTitle') {
             return (
               <TableRowCell key={name}>
                 <AlbumTitleLink
                   foreignAlbumId={foreignAlbumId}
                   title={title}
+                  disambiguation={disambiguation}
                 />
               </TableRowCell>
             );
@@ -100,21 +84,6 @@ function MissingRow(props) {
               />
             );
           }
-
-          // if (name === 'status') {
-          //   return (
-          //     <TableRowCell
-          //       key={name}
-          //       className={styles.status}
-          //     >
-          //       <EpisodeStatusConnector
-          //         albumId={id}
-          //         trackFileId={trackFileId}
-          //         albumEntity={albumEntities.WANTED_MISSING}
-          //       />
-          //     </TableRowCell>
-          //   );
-          // }
 
           if (name === 'actions') {
             return (
@@ -144,6 +113,7 @@ MissingRow.propTypes = {
   foreignAlbumId: PropTypes.string.isRequired,
   albumType: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
+  disambiguation: PropTypes.string,
   isSelected: PropTypes.bool,
   columns: PropTypes.arrayOf(PropTypes.object).isRequired,
   onSelectedChange: PropTypes.func.isRequired

--- a/src/Lidarr.Api.V1/Albums/AlbumResource.cs
+++ b/src/Lidarr.Api.V1/Albums/AlbumResource.cs
@@ -12,6 +12,7 @@ namespace Lidarr.Api.V1.Albums
     public class AlbumResource : RestResource
     {
         public string Title { get; set; }
+        public string Disambiguation { get; set; }
         public int ArtistId { get; set; }
         public List<string> AlbumLabel { get; set; }
         public string ForeignAlbumId { get; set; }
@@ -66,6 +67,7 @@ namespace Lidarr.Api.V1.Albums
                 ReleaseDate = model.ReleaseDate,
                 Genres = model.Genres,
                 Title = model.Title,
+                Disambiguation = model.Disambiguation,
                 Images = model.Images,
                 Ratings = model.Ratings,
                 Duration = model.Duration,
@@ -87,6 +89,7 @@ namespace Lidarr.Api.V1.Albums
                 Id = resource.Id,
                 ForeignAlbumId = resource.ForeignAlbumId,
                 Title = resource.Title,
+                Disambiguation = resource.Disambiguation,
                 Images = resource.Images,
                 Monitored = resource.Monitored,
                 CurrentRelease = resource.CurrentRelease

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
@@ -33,6 +33,8 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
             _album = Builder<Album>
                     .CreateNew()
                     .With(s => s.Title = "Hybrid Theory")
+                    .With(s => s.AlbumType = "Album")
+                    .With(s => s.Disambiguation = "The Best Album")
                     .Build();
 
 
@@ -145,6 +147,24 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
 
             Subject.BuildTrackFileName(new List<Track> { _track1 }, _artist, _album, _trackFile)
                    .Should().Be("Hybrid Theory");
+        }
+
+        [Test]
+        public void should_replace_Album_Type()
+        {
+            _namingConfig.StandardTrackFormat = "{Album Type}";
+
+            Subject.BuildTrackFileName(new List<Track> { _track1 }, _artist, _album, _trackFile)
+                .Should().Be("Album");
+        }
+
+        [Test]
+        public void should_replace_Album_Disambiguation()
+        {
+            _namingConfig.StandardTrackFormat = "{Album Disambiguation}";
+
+            Subject.BuildTrackFileName(new List<Track> { _track1 }, _artist, _album, _trackFile)
+                .Should().Be("The Best Album");
         }
 
         [Test]

--- a/src/NzbDrone.Core/Datastore/Migration/018_album_disambiguation.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/018_album_disambiguation.cs
@@ -1,0 +1,14 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(18)]
+    public class album_disambiguation : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("Albums").AddColumn("Disambiguation").AsString().Nullable();
+        }
+    }
+}

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/AlbumResource.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/AlbumResource.cs
@@ -19,6 +19,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook.Resource
         public DateTime ReleaseDate { get; set; }
         public List<ImageResource> Images { get; set; }
         public string Title { get; set; }
+        public string Disambiguation { get; set; }
         public string Overview { get; set; }
         public List<string> Genres { get; set; }
         public List<string> Labels { get; set; }

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -262,6 +262,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
         {
             Album album = new Album();
             album.Title = resource.Title;
+            album.Disambiguation = resource.Disambiguation;
             album.ForeignAlbumId = resource.Id;
             album.ReleaseDate = resource.ReleaseDate;
             album.CleanTitle = Parser.Parser.CleanArtistName(album.Title);

--- a/src/NzbDrone.Core/Music/Album.cs
+++ b/src/NzbDrone.Core/Music/Album.cs
@@ -22,6 +22,7 @@ namespace NzbDrone.Core.Music
         public string ForeignAlbumId { get; set; }
         public int ArtistId { get; set; }
         public string Title { get; set; }
+        public string Disambiguation { get; set; }
         public string CleanTitle { get; set; }
         public DateTime? ReleaseDate { get; set; }
         public List<string> Label { get; set; }

--- a/src/NzbDrone.Core/Music/RefreshAlbumService.cs
+++ b/src/NzbDrone.Core/Music/RefreshAlbumService.cs
@@ -92,6 +92,7 @@ namespace NzbDrone.Core.Music
             album.LastInfoSync = DateTime.UtcNow;
             album.CleanTitle = albumInfo.CleanTitle;
             album.Title = albumInfo.Title ?? "Unknown";
+            album.Disambiguation = albumInfo.Disambiguation;
             album.AlbumType = albumInfo.AlbumType;
             album.SecondaryTypes = albumInfo.SecondaryTypes;
             album.Genres = albumInfo.Genres;

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -189,6 +189,7 @@
     <Compile Include="Datastore\Migration\015_remove_fanzub.cs" />
     <Compile Include="Datastore\Migration\016_update_artist_history_indexes.cs" />
     <Compile Include="Datastore\Migration\017_remove_nma.cs" />
+    <Compile Include="Datastore\Migration\018_album_disambiguation.cs" />
     <Compile Include="Datastore\Migration\Framework\MigrationContext.cs" />
     <Compile Include="Datastore\Migration\Framework\MigrationController.cs" />
     <Compile Include="Datastore\Migration\Framework\MigrationDbFactory.cs" />

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -269,6 +269,12 @@ namespace NzbDrone.Core.Organizer
             tokenHandlers["{Album CleanTitle}"] = m => CleanTitle(album.Title);
             tokenHandlers["{Album TitleThe}"] = m => TitleThe(album.Title);
             tokenHandlers["{Album Type}"] = m => album.AlbumType;
+
+            if (album.Disambiguation != null)
+            {
+                tokenHandlers["{Album Disambiguation}"] = m => album.Disambiguation;
+            }
+            
             if (album.ReleaseDate.HasValue)
             {
                 tokenHandlers["{Release Year}"] = m => album.ReleaseDate.Value.Year.ToString();

--- a/src/NzbDrone.Core/Organizer/FileNameSampleService.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameSampleService.cs
@@ -38,6 +38,7 @@ namespace NzbDrone.Core.Organizer
                 Title = "The Album Title",
                 ReleaseDate = System.DateTime.Today,
                 AlbumType = "Album",
+                Disambiguation = "The Best Album",
                 Media = new List<Medium>
                 {
                     new Medium


### PR DESCRIPTION
#### Database Migration
YES

#### Description
This adds ability for Lidarr to store and use album disambiguation from Musicbrainz. Adds disambiguation to certain places in UI (Artist Album List, History, Queue, Wanted) and allows user to use the disambiguation in album folder and track naming models.

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR
#430 
* 
