### PR TITLE
Fixed: Search fails for many artist and albums with specials

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerSearchTests/SearchDefinitionFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerSearchTests/SearchDefinitionFixture.cs
@@ -11,6 +11,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
     public class AlbumSearchDefinitionFixture : CoreTest<AlbumSearchCriteria>
     {
         [TestCase("Mötley Crüe", "Motley+Crue")]
+        [TestCase("방탄소년단", "방탄소년단")]
         public void should_replace_some_special_characters_artist(string artist, string expected)
         {
             Subject.Artist = new Artist { Name = artist };
@@ -19,6 +20,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
 
         [TestCase("…and Justice for All", "and+Justice+for+All")]
         [TestCase("American III: Solitary Man", "American+III+Solitary+Man")]
+        [TestCase("Sad Clowns & Hillbillies", "Sad+Clowns+Hillbillies")]
         public void should_replace_some_special_characters(string album, string expected)
         {
             Subject.AlbumTitle = album;

--- a/src/NzbDrone.Core.Test/IndexerSearchTests/SearchDefinitionFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerSearchTests/SearchDefinitionFixture.cs
@@ -21,6 +21,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         [TestCase("…and Justice for All", "and+Justice+for+All")]
         [TestCase("American III: Solitary Man", "American+III+Solitary+Man")]
         [TestCase("Sad Clowns & Hillbillies", "Sad+Clowns+Hillbillies")]
+        [TestCase("¿Quién sabe?", "Quien+sabe")]
         public void should_replace_some_special_characters(string album, string expected)
         {
             Subject.AlbumTitle = album;

--- a/src/NzbDrone.Core.Test/IndexerSearchTests/SearchDefinitionFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerSearchTests/SearchDefinitionFixture.cs
@@ -3,22 +3,33 @@ using System.Linq;
 using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Core.IndexerSearch.Definitions;
+using NzbDrone.Core.Music;
 using NzbDrone.Core.Test.Framework;
 
 namespace NzbDrone.Core.Test.IndexerSearchTests
-{
-    public class SearchDefinitionFixture : CoreTest<AlbumSearchCriteria>
+{ 
+    public class AlbumSearchDefinitionFixture : CoreTest<AlbumSearchCriteria>
     {
-        [TestCase("Betty White's Off Their Rockers", "Betty+Whites+Off+Their+Rockers")]
-        [TestCase("Star Wars: The Clone Wars", "Star+Wars+The+Clone+Wars")]
-        [TestCase("Hawaii Five-0", "Hawaii+Five+0")]
-        [TestCase("Franklin & Bash", "Franklin+and+Bash")]
-        [TestCase("Chicago P.D.", "Chicago+PD")]
-        [TestCase("Kourtney And Khlo\u00E9 Take The Hamptons", "Kourtney+And+Khloe+Take+The+Hamptons")]
-        public void should_replace_some_special_characters(string input, string expected)
+        [TestCase("Mötley Crüe", "Motley+Crue")]
+        public void should_replace_some_special_characters_artist(string artist, string expected)
         {
-            Subject.SceneTitles = new List<string> { input };
-            Subject.QueryTitles.First().Should().Be(expected);
+            Subject.Artist = new Artist { Name = artist };
+            Subject.ArtistQuery.Should().Be(expected);
+        }
+
+        [TestCase("…and Justice for All", "and+Justice+for+All")]
+        [TestCase("American III: Solitary Man", "American+III+Solitary+Man")]
+        public void should_replace_some_special_characters(string album, string expected)
+        {
+            Subject.AlbumTitle = album;
+            Subject.AlbumQuery.Should().Be(expected);
+        }
+        
+        [TestCase("+", "+")]
+        public void should_not_replace_some_special_characters_if_result_empty_string(string album, string expected)
+        {
+            Subject.AlbumTitle = album;
+            Subject.AlbumQuery.Should().Be(expected);
         }
     }
 }

--- a/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using Moq;
@@ -60,7 +60,7 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
 
             var page = results.GetAllTiers().First().First();
 
-            page.Url.Query.Should().Contain("artist=Alien Ant Farm");
+            page.Url.Query.Should().Contain("artist=Alien%20Ant%20Farm");
             page.Url.Query.Should().Contain("album=TruANT");
         }
     }

--- a/src/NzbDrone.Core/IndexerSearch/Definitions/AlbumSearchCriteria.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/AlbumSearchCriteria.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace NzbDrone.Core.IndexerSearch.Definitions
 {
@@ -7,6 +7,8 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
 
         public string AlbumTitle { get; set; }
         public int AlbumYear { get; set; }
+
+        public string AlbumQuery => GetQueryTitle(AlbumTitle);
 
         public override string ToString()
         {

--- a/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
@@ -29,7 +29,7 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
 
             var cleanTitle = BeginningThe.Replace(title, string.Empty);
 
-            cleanTitle = cleanTitle.Replace("&", "and");
+            cleanTitle = cleanTitle.Replace(" & ", " ");
             cleanTitle = SpecialCharacter.Replace(cleanTitle, "");
             cleanTitle = NonWord.Replace(cleanTitle, "+");
 

--- a/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
@@ -13,9 +13,6 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
         private static readonly Regex NonWord = new Regex(@"[\W]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex BeginningThe = new Regex(@"^the\s", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        [System.Obsolete("Sonarr TV Stuff -- Shouldn't be needed for Lidarr")]
-        public List<string> SceneTitles { get; set; }
-
         public virtual bool MonitoredEpisodesOnly { get; set; }
         public virtual bool UserInvokedSearch { get; set; }
         public virtual bool InteractiveSearch { get; set; }
@@ -24,7 +21,7 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
         public List<Album> Albums { get; set; }
         public List<Track> Tracks { get; set; }
 
-        public List<string> QueryTitles => SceneTitles.Select(GetQueryTitle).ToList();
+        public string ArtistQuery => GetQueryTitle(Artist.Name);
 
         public static string GetQueryTitle(string title)
         {
@@ -39,7 +36,9 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
             //remove any repeating +s
             cleanTitle = Regex.Replace(cleanTitle, @"\+{2,}", "+");
             cleanTitle = cleanTitle.RemoveAccent();
-            return cleanTitle.Trim('+', ' ');
+            cleanTitle = cleanTitle.Trim('+', ' ');
+
+            return cleanTitle.Length == 0 ? title : cleanTitle;
         }
     }
 }

--- a/src/NzbDrone.Core/Indexers/Gazelle/GazelleRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Gazelle/GazelleRequestGenerator.cs
@@ -30,14 +30,14 @@ namespace NzbDrone.Core.Indexers.Gazelle
         public IndexerPageableRequestChain GetSearchRequests(AlbumSearchCriteria searchCriteria)
         {
             var pageableRequests = new IndexerPageableRequestChain();
-            pageableRequests.Add(GetRequest(string.Format("&artistname={0}&groupname={1}", searchCriteria.Artist.Name, searchCriteria.AlbumTitle)));
+            pageableRequests.Add(GetRequest(string.Format("&artistname={0}&groupname={1}", searchCriteria.ArtistQuery, searchCriteria.AlbumQuery)));
             return pageableRequests;
         }
 
         public IndexerPageableRequestChain GetSearchRequests(ArtistSearchCriteria searchCriteria)
         {
             var pageableRequests = new IndexerPageableRequestChain();
-            pageableRequests.Add(GetRequest(string.Format("&artistname={0}",searchCriteria.Artist.Name)));
+            pageableRequests.Add(GetRequest(string.Format("&artistname={0}",searchCriteria.ArtistQuery)));
             return pageableRequests;
         }
 

--- a/src/NzbDrone.Core/Indexers/Headphones/HeadphonesRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Headphones/HeadphonesRequestGenerator.cs
@@ -40,8 +40,8 @@ namespace NzbDrone.Core.Indexers.Headphones
                 pageableRequests.Add(GetPagedRequests(MaxPages, Settings.Categories, "search",
                         string.Format("&q={0}",
                         NewsnabifyTitle(string.Format("{0} {1}",
-                                         searchCriteria.Artist.Name,
-                                         searchCriteria.AlbumTitle)))));
+                                         searchCriteria.ArtistQuery,
+                                         searchCriteria.AlbumQuery)))));
 
             return pageableRequests;
         }
@@ -54,7 +54,7 @@ namespace NzbDrone.Core.Indexers.Headphones
 
             pageableRequests.Add(GetPagedRequests(MaxPages, Settings.Categories, "search",
                     string.Format("&q={0}",
-                    NewsnabifyTitle(searchCriteria.Artist.Name))));
+                    NewsnabifyTitle(searchCriteria.ArtistQuery))));
 
             return pageableRequests;
         }

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
@@ -71,8 +71,8 @@ namespace NzbDrone.Core.Indexers.Newznab
             {
                 AddAudioPageableRequests(pageableRequests, searchCriteria,
                                          string.Format("&artist={0}&album={1}",
-                                         NewsnabifyTitle(searchCriteria.Artist.Name),
-                                         NewsnabifyTitle(searchCriteria.AlbumTitle)));
+                                         NewsnabifyTitle(searchCriteria.ArtistQuery),
+                                         NewsnabifyTitle(searchCriteria.AlbumQuery)));
             }
 
             if (SupportsSearch)
@@ -82,8 +82,8 @@ namespace NzbDrone.Core.Indexers.Newznab
                 pageableRequests.Add(GetPagedRequests(MaxPages, Settings.Categories, "search",
                         string.Format("&q={0}",
                         NewsnabifyTitle(string.Format("{0} {1}",
-                                         searchCriteria.Artist.Name,
-                                         searchCriteria.AlbumTitle)))));
+                                         searchCriteria.ArtistQuery,
+                                         searchCriteria.AlbumQuery)))));
 
             }
 

--- a/src/NzbDrone.Core/Indexers/Omgwtfnzbs/OmgwtfnzbsRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Omgwtfnzbs/OmgwtfnzbsRequestGenerator.cs
@@ -31,8 +31,8 @@ namespace NzbDrone.Core.Indexers.Omgwtfnzbs
 
 
             pageableRequests.Add(GetPagedRequests(string.Format("{0}+{1}",
-                searchCriteria.Artist.Name,
-                searchCriteria.AlbumTitle)));
+                searchCriteria.ArtistQuery,
+                searchCriteria.AlbumQuery)));
 
 
             return pageableRequests;
@@ -44,7 +44,7 @@ namespace NzbDrone.Core.Indexers.Omgwtfnzbs
 
 
             pageableRequests.Add(GetPagedRequests(string.Format("{0}",
-                searchCriteria.Artist.Name)));
+                searchCriteria.ArtistQuery)));
 
 
             return pageableRequests;

--- a/src/NzbDrone.Core/Indexers/Rarbg/RarbgRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Rarbg/RarbgRequestGenerator.cs
@@ -29,7 +29,7 @@ namespace NzbDrone.Core.Indexers.Rarbg
         {
             var pageableRequests = new IndexerPageableRequestChain();
 
-            pageableRequests.Add(GetPagedRequests("search", null, "{0}+{1}", searchCriteria.Artist.Name, searchCriteria.AlbumTitle));
+            pageableRequests.Add(GetPagedRequests("search", null, "{0}+{1}", searchCriteria.ArtistQuery, searchCriteria.AlbumQuery));
 
             return pageableRequests;
         }
@@ -38,7 +38,7 @@ namespace NzbDrone.Core.Indexers.Rarbg
         {
             var pageableRequests = new IndexerPageableRequestChain();
 
-            pageableRequests.Add(GetPagedRequests("search", null, "{0}", searchCriteria.Artist.Name));
+            pageableRequests.Add(GetPagedRequests("search", null, "{0}", searchCriteria.ArtistQuery));
 
             return pageableRequests;
         }

--- a/src/NzbDrone.Core/Indexers/Waffles/WafflesRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Waffles/WafflesRequestGenerator.cs
@@ -30,7 +30,7 @@ namespace NzbDrone.Core.Indexers.Waffles
         {
             var pageableRequests = new IndexerPageableRequestChain();
 
-            pageableRequests.Add(GetPagedRequests(MaxPages, string.Format("&q=artist:{0} album:{1}",searchCriteria.Artist.Name,searchCriteria.AlbumTitle)));
+            pageableRequests.Add(GetPagedRequests(MaxPages, string.Format("&q=artist:{0} album:{1}",searchCriteria.ArtistQuery,searchCriteria.AlbumQuery)));
 
             return pageableRequests;
         }
@@ -39,7 +39,7 @@ namespace NzbDrone.Core.Indexers.Waffles
         {
             var pageableRequests = new IndexerPageableRequestChain();
 
-            pageableRequests.Add(GetPagedRequests(MaxPages, string.Format("&q=artist:{0}", searchCriteria.Artist.Name)));
+            pageableRequests.Add(GetPagedRequests(MaxPages, string.Format("&q=artist:{0}", searchCriteria.ArtistQuery)));
 
             return pageableRequests;
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Searches fail on Newznab (and maybe some torrent indexers) when artists or albums have special characters. This builds a clean query to use for searching.

Fixes:
Mötley Crüe
AC/DC
Titles with ellipsis (ex. …and Justice for All)
Titles with colons (ex. American III: Solitary Man)

#### Todos
- [x] Tests (more maybe necessary to cover all basis?)

#### Issues Fixed or Closed by this PR

#410 - not fixed but improved 

* 
