### PR TITLE
Fixed: Allow text in front of cleaned Album/Track tag

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -59,6 +59,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Sweet Dreams (Album)", "Sweet Dreams")]
         [TestCase("Now What?! (Limited Edition)", "Now What?!")]
         [TestCase("Random Album Title (Promo CD)", "Random Album Title")]
+        [TestCase("Limited Edition", "Limited Edition")]
         public void should_remove_common_tags_from_album_title(string title, string correct)
         {
             var result = Parser.Parser.CleanAlbumTitle(title);

--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -53,6 +53,8 @@ namespace NzbDrone.Core.Test.ParserTests
         }
 
         [TestCase("Songs of Experience (Deluxe Edition)", "Songs of Experience")]
+        [TestCase("Songs of Experience (iTunes Deluxe Edition)", "Songs of Experience")]
+        [TestCase("Songs of Experience [Super Special Edition]", "Songs of Experience")]
         [TestCase("Mr. Bad Guy [Special Edition]", "Mr. Bad Guy")]
         [TestCase("Sweet Dreams (Album)", "Sweet Dreams")]
         [TestCase("Now What?! (Limited Edition)", "Now What?!")]

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -207,7 +207,7 @@ namespace NzbDrone.Core.Parser
 
         private static readonly Regex[] CommonTagRegex = new Regex[] {
             new Regex(@"(\[|\()*\b((featuring|feat.|feat|ft|ft.)\s{1}){1}\s*.*(\]|\))*", RegexOptions.IgnoreCase | RegexOptions.Compiled),
-            new Regex(@"(\[|\(){1}(version|limited|deluxe|single|clean|album|special|bonus|promo)+\s*.*(\]|\)){1}", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            new Regex(@"(?:\(|\[)(?:[^\(\[]*)(?:version|limited|deluxe|single|clean|album|special|bonus|promo)(?:[^\)\]]*)(?:\)|\])", RegexOptions.IgnoreCase | RegexOptions.Compiled)
         };
         
         public static ParsedTrackInfo ParseMusicPath(string path)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This adjusts the regex to allow text in front and back and only clean what is in parenthesis in case of back to back info.

Cases:
Meteora (iTunes Deluxe Edition)

#### Todos
- [x] Tests
