### PR TITLE
Fuzzy matching

### DIFF
--- a/src/NzbDrone.Common/Extensions/StringExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/StringExtensions.cs
@@ -71,7 +71,7 @@ namespace NzbDrone.Common.Extensions
             return string.Join(separator, values);
         }
 
-    public static string CleanSpaces(this string text)
+        public static string CleanSpaces(this string text)
         {
             return CollapseSpace.Replace(text, " ").Trim();
         }
@@ -139,6 +139,43 @@ namespace NzbDrone.Common.Extensions
         public static string SplitCamelCase(this string input)
         {
             return CamelCaseRegex.Replace(input, match => " " + match.Value);
+        }
+
+        public static double FuzzyMatch(this string a, string b)
+        {
+            if (a.Contains(" ") && b.Contains(" "))
+            {
+                var partsA = a.Split(' ');
+                var partsB = b.Split(' ');
+                var weightedHighCoefficients = new double[partsA.Length];
+                var distanceRatios = new double[partsA.Length];
+                for (int i = 0; i < partsA.Length; i++)
+                {
+                    double high = 0.0;
+                    int indexDistance = 0;
+                    for (int x = 0; x < partsB.Length; x++)
+                    {
+                        var coef = LevenshteinCoefficient(partsA[i], partsB[x]);
+                        if (coef > high)
+                        {
+                            high = coef;
+                            indexDistance = Math.Abs(i - x);
+                        }
+                    }
+                    double distanceWeight = 1.0 - (double)indexDistance / (double)partsA.Length;
+                    weightedHighCoefficients[i] = high * distanceWeight;
+                }
+                return weightedHighCoefficients.Sum() / (double)partsA.Length;
+            }
+            else
+            {
+                return LevenshteinCoefficient(a, b);
+            }
+        }
+
+        public static double LevenshteinCoefficient(this string a, string b)
+        {
+            return 1.0 - (double)a.LevenshteinDistance(b) / Math.Max(a.Length, b.Length);
         }
 
     }

--- a/src/NzbDrone.Core.Test/MusicTests/TitleMatchingTests/TitleMatchingFixture.cs
+++ b/src/NzbDrone.Core.Test/MusicTests/TitleMatchingTests/TitleMatchingFixture.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Music;
 using NzbDrone.Core.Test.Framework;
+using System.Collections.Generic;
 
 namespace NzbDrone.Core.Test.MusicTests.TitleMatchingTests
 {
@@ -21,49 +22,82 @@ namespace NzbDrone.Core.Test.MusicTests.TitleMatchingTests
             _trackService =
                 new TrackService(_trackRepository, Mocker.Resolve<ConfigService>(), Mocker.Resolve<Logger>());
 
-            _trackRepository.Insert(new Track
-            {
-                Title = "This is the short test title",
-                ForeignTrackId = "this is a fake id2",
-                AlbumId = 4321,
-                AbsoluteTrackNumber = 1,
-                MediumNumber = 1,
-                TrackFileId = 1
-            });
+            var trackNames = new List<string> {
+                "Courage",
+                "Movies",
+                "Flesh and Bone",
+                "Whisper",
+                "Summer",
+                "Sticks and Stones",
+                "Attitude",
+                "Stranded",
+                "Wish",
+                "Calico",
+                "(Happy) Death Day",
+                "Smooth Criminal",
+                "Universe / Orange Appeal"
+            };
 
-            _trackRepository.Insert(new Track
-            {
-                Title = "This is the long test title",
-                ForeignTrackId = "this is a fake id",
-                AlbumId = 4321,
-                AbsoluteTrackNumber = 2,
-                MediumNumber = 1,
-                TrackFileId = 2
-            });
+            for (int i = 0; i < trackNames.Count; i++) {
+                _trackRepository.Insert(new Track
+                        {
+                            Title = trackNames[i],
+                            ForeignTrackId = (i+1).ToString(),
+                            AlbumId = 4321,
+                            AbsoluteTrackNumber = i+1,
+                            MediumNumber = 1,
+                            TrackFileId = i+1
+                        });
+            }
         }
 
         [Test]
-        public void should_find_track_in_db_by_tracktitle_longer_then_relaeasetitle()
+        public void should_find_track_in_db_by_tracktitle_longer_then_releasetitle()
         {
-            var track = _trackService.FindTrackByTitle(1234, 4321, 1, 1, "This is the short test title with some bla");
+            var track = _trackService.FindTrackByTitle(1234, 4321, 1, 1, "Courage with some bla");
 
+            track.Should().NotBeNull();
             track.Title.Should().Be(_trackRepository.GetTracksByFileId(1).First().Title);
         }
 
         [Test]
-        public void should_find_track_in_db_by_tracktitle_shorter_then_relaeasetitle()
+        public void should_find_track_in_db_by_tracktitle_shorter_then_releasetitle()
         {
-            var track = _trackService.FindTrackByTitle(1234, 4321, 1, 2, "test title");
+            var track = _trackService.FindTrackByTitle(1234, 4321, 1, 3, "and Bone");
 
-            track.Title.Should().Be(_trackRepository.GetTracksByFileId(2).First().Title);
+            track.Should().NotBeNull();
+            track.Title.Should().Be(_trackRepository.GetTracksByFileId(3).First().Title);
         }
 
         [Test]
         public void should_not_find_track_in_db_by_wrong_title()
         {
-            var track = _trackService.FindTrackByTitle(1234, 4321, 1, 1, "the short title");
+            var track = _trackService.FindTrackByTitle(1234, 4321, 1, 1, "Not a track");
 
             track.Should().BeNull();
         }
+
+        [TestCase("Fesh and Bone", 3)]
+        [TestCase("Atitude", 7)]
+        [TestCase("Smoth cRimnal", 12)]
+        [TestCase("Sticks and Stones (live)", 6)]
+        public void should_find_track_in_db_by_inexact_title(string title, int trackNumber)
+        {
+            var track = _trackService.FindTrackByTitleInexact(1234, 4321, 1, trackNumber, title);
+
+            track.Should().NotBeNull();
+            track.Title.Should().Be(_trackRepository.GetTracksByFileId(trackNumber).First().Title);
+        }
+
+        [TestCase("A random title", 1)]
+        [TestCase("Stones and Sticks", 6)]
+        public void should_not_find_track_in_db_by_different_inexact_title(string title, int trackId)
+        {
+            var track = _trackService.FindTrackByTitleInexact(1234, 4321, 1, trackId, title);
+
+            track.Should().BeNull();
+        }
+
+
     }
 }

--- a/src/NzbDrone.Core/Music/AlbumRepository.cs
+++ b/src/NzbDrone.Core/Music/AlbumRepository.cs
@@ -287,9 +287,12 @@ namespace NzbDrone.Core.Music
 
         public Album FindByTitle(int artistId, string title)
         {
-            title = Parser.Parser.CleanArtistName(title);
-
-            return Query.Where(s => s.CleanTitle == title)
+            var cleanTitle = Parser.Parser.CleanArtistName(title);
+            
+            if (string.IsNullOrEmpty(cleanTitle))
+                cleanTitle = title;
+            
+            return Query.Where(s => s.CleanTitle == cleanTitle || s.Title == title)
                         .AndWhere(s => s.ArtistId == artistId)
                         .FirstOrDefault();
         }

--- a/src/NzbDrone.Core/Music/AlbumRepository.cs
+++ b/src/NzbDrone.Core/Music/AlbumRepository.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using NLog;
 using Marr.Data.QGen;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Datastore.Extensions;
@@ -16,6 +17,7 @@ namespace NzbDrone.Core.Music
         List<Album> GetAlbums(int artistId);
         Album FindByName(string cleanTitle);
         Album FindByTitle(int artistId, string title);
+        Album FindByTitleInexact(int artistId, string title);
         Album FindByArtistAndName(string artistName, string cleanTitle);
         Album FindById(string spotifyId);
         PagingSpec<Album> AlbumsWithoutFiles(PagingSpec<Album> pagingSpec);
@@ -31,13 +33,14 @@ namespace NzbDrone.Core.Music
     public class AlbumRepository : BasicRepository<Album>, IAlbumRepository
     {
         private readonly IMainDatabase _database;
+        private readonly Logger _logger;
 
-        public AlbumRepository(IMainDatabase database, IEventAggregator eventAggregator)
+        public AlbumRepository(IMainDatabase database, IEventAggregator eventAggregator, Logger logger)
             : base(database, eventAggregator)
         {
             _database = database;
+            _logger = logger;
         }
-
 
         public List<Album> GetAlbums(int artistId)
         {
@@ -295,6 +298,39 @@ namespace NzbDrone.Core.Music
             return Query.Where(s => s.CleanTitle == cleanTitle || s.Title == title)
                         .AndWhere(s => s.ArtistId == artistId)
                         .FirstOrDefault();
+        }
+
+        public Album FindByTitleInexact(int artistId, string title)
+        {
+            double fuzzThreshold = 0.7;
+            double fuzzGap = 0.4;
+            var cleanTitle = Parser.Parser.CleanArtistName(title);
+
+            if (string.IsNullOrEmpty(cleanTitle))
+                cleanTitle = title;
+
+            var sortedAlbums = Query.Where(s => s.ArtistId == artistId)
+                .Select(s => new
+                    {
+                        MatchProb = s.CleanTitle.FuzzyMatch(cleanTitle),
+                        Album = s
+                    })
+                .ToList()
+                .OrderByDescending(s => s.MatchProb)
+                .ToList();
+
+            if (!sortedAlbums.Any())
+                return null;
+
+            _logger.Trace("\nFuzzy album match on '{0}':\n{1}",
+                          cleanTitle,
+                          string.Join("\n", sortedAlbums.Select(x => $"{x.Album.CleanTitle}: {x.MatchProb}")));
+
+            if (sortedAlbums[0].MatchProb > fuzzThreshold
+                && (sortedAlbums.Count == 1 || sortedAlbums[0].MatchProb - sortedAlbums[1].MatchProb > fuzzGap))
+                return sortedAlbums[0].Album;
+
+            return null;
         }
 
         public Album FindByArtistAndName(string artistName, string cleanTitle)

--- a/src/NzbDrone.Core/Music/AlbumService.cs
+++ b/src/NzbDrone.Core/Music/AlbumService.cs
@@ -17,7 +17,7 @@ namespace NzbDrone.Core.Music
         List<Album> AddAlbums(List<Album> newAlbums);
         Album FindById(string spotifyId);
         Album FindByTitle(int artistId, string title);
-        Album FindByTitleInexact(string title);
+        Album FindByTitleInexact(int artistId, string title);
         void DeleteAlbum(int albumId, bool deleteFiles);
         List<Album> GetAllAlbums();
         Album UpdateAlbum(Album album);
@@ -87,9 +87,9 @@ namespace NzbDrone.Core.Music
             return _albumRepository.FindByTitle(artistId, title);
         }
 
-        public Album FindByTitleInexact(string title)
+        public Album FindByTitleInexact(int artistId, string title)
         {
-            throw new NotImplementedException();
+            return _albumRepository.FindByTitleInexact(artistId, title);
         }
 
         public List<Album> GetAllAlbums()

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -292,6 +292,12 @@ namespace NzbDrone.Core.Parser
 
             if (album == null)
             {
+                _logger.Debug("Trying inexact album match for {0}", parsedTrackInfo);
+                album = _albumService.FindByTitleInexact(artist.Id, cleanAlbumTitle);
+            }
+
+            if (album == null)
+            {
                 _logger.Debug("Parsed album title not found in Db for {0}", parsedTrackInfo);
                 return null;
             }
@@ -316,6 +322,12 @@ namespace NzbDrone.Core.Parser
                 if (trackInfo == null)
                 {
                     trackInfo = _trackService.FindTrackByTitle(artist.Id, album.Id, parsedTrackInfo.DiscNumber, parsedTrackInfo.TrackNumbers.FirstOrDefault(), parsedTrackInfo.Title);
+                }
+
+                if (trackInfo == null)
+                {
+                    _logger.Debug("Trying inexact track match for {0}", parsedTrackInfo);
+                    trackInfo = _trackService.FindTrackByTitleInexact(artist.Id, album.Id, parsedTrackInfo.DiscNumber, parsedTrackInfo.TrackNumbers.FirstOrDefault(), cleanTrackTitle);
                 }
 
                 if (trackInfo != null)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Add fuzzy matching to album and track names on import.

Fix matching albums when name is entirely special characters

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR

This adds fuzz to album and track title matching when importing.  Means that the import is generally more successful.

This also fixes the case where the album name is entirely special characters, which means that `CleanName` is empty. 
