### PR TITLE
Fixed: Allow downloading any search result

### DIFF
--- a/frontend/src/Activity/Queue/QueueRow.css
+++ b/frontend/src/Activity/Queue/QueueRow.css
@@ -19,5 +19,5 @@
 .actions {
   composes: cell from 'Components/Table/Cells/TableRowCell.css';
 
-  width: 70px;
+  width: 90px;
 }

--- a/frontend/src/Activity/Queue/QueueRow.js
+++ b/frontend/src/Activity/Queue/QueueRow.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { icons, kinds } from 'Helpers/Props';
+import { icons, kinds, tooltipPositions } from 'Helpers/Props';
 import IconButton from 'Components/Link/IconButton';
 import SpinnerIconButton from 'Components/Link/SpinnerIconButton';
 import ProgressBar from 'Components/ProgressBar';
@@ -8,6 +8,8 @@ import TableRow from 'Components/Table/TableRow';
 import RelativeDateCellConnector from 'Components/Table/Cells/RelativeDateCellConnector';
 import TableRowCell from 'Components/Table/Cells/TableRowCell';
 import TableSelectCell from 'Components/Table/Cells/TableSelectCell';
+import Icon from 'Components/Icon';
+import Popover from 'Components/Tooltip/Popover';
 import ProtocolLabel from 'Activity/Queue/ProtocolLabel';
 import AlbumTitleLink from 'Album/AlbumTitleLink';
 import TrackQuality from 'Album/TrackQuality';
@@ -74,6 +76,7 @@ class QueueRow extends Component {
       protocol,
       indexer,
       downloadClient,
+      downloadForced,
       estimatedCompletionTime,
       timeleft,
       size,
@@ -250,6 +253,21 @@ class QueueRow extends Component {
                   className={styles.actions}
                 >
                   {
+                    downloadForced &&
+                      <Popover
+                        anchor={
+                          <Icon
+                            name={icons.DANGER}
+                            kind={kinds.DANGER}
+                          />
+                        }
+                        title="Manual Download"
+                        body="This release failed parsing checks and was manually downloaded from an interactive search.  Import is likely to fail."
+                        position={tooltipPositions.LEFT}
+                      />
+                  }
+
+                  {
                     showInteractiveImport &&
                       <IconButton
                         name={icons.INTERACTIVE}
@@ -313,6 +331,7 @@ QueueRow.propTypes = {
   protocol: PropTypes.string.isRequired,
   indexer: PropTypes.string,
   downloadClient: PropTypes.string,
+  downloadForced: PropTypes.bool.isRequired,
   estimatedCompletionTime: PropTypes.string,
   timeleft: PropTypes.string,
   size: PropTypes.number,

--- a/frontend/src/Activity/Queue/RemoveQueueItemModal.js
+++ b/frontend/src/Activity/Queue/RemoveQueueItemModal.js
@@ -79,7 +79,7 @@ class RemoveQueueItemModal extends Component {
                 type={inputTypes.CHECK}
                 name="blacklist"
                 value={blacklist}
-                helpText="Prevents Lidarr from automatically grabbing this album again"
+                helpText="Prevents Lidarr from automatically grabbing these files again"
                 onChange={this.onBlacklistChange}
               />
             </FormGroup>

--- a/frontend/src/InteractiveSearch/InteractiveSearchRow.js
+++ b/frontend/src/InteractiveSearch/InteractiveSearchRow.js
@@ -156,14 +156,13 @@ class InteractiveSearchRow extends Component {
 
         <TableRowCell className={styles.download}>
           {
-            downloadAllowed &&
-              <SpinnerIconButton
-                name={getDownloadIcon(isGrabbing, isGrabbed, grabError)}
-                kind={grabError ? kinds.DANGER : kinds.DEFAULT}
-                title={getDownloadTooltip(isGrabbing, isGrabbed, grabError)}
-                isSpinning={isGrabbing}
-                onPress={this.onGrabPress}
-              />
+            <SpinnerIconButton
+              name={getDownloadIcon(isGrabbing, isGrabbed, grabError)}
+              kind={grabError || !downloadAllowed ? kinds.DANGER : kinds.DEFAULT}
+              title={getDownloadTooltip(isGrabbing, isGrabbed, grabError)}
+              isSpinning={isGrabbing}
+              onPress={this.onGrabPress}
+            />
           }
         </TableRowCell>
       </TableRow>

--- a/src/Lidarr.Api.V1/Indexers/ReleaseModule.cs
+++ b/src/Lidarr.Api.V1/Indexers/ReleaseModule.cs
@@ -46,7 +46,6 @@ namespace Lidarr.Api.V1.Indexers
             GetResourceAll = GetReleases;
             Post["/"] = x => DownloadRelease(this.Bind<ReleaseResource>());
 
-            PostValidator.RuleFor(s => s.DownloadAllowed).Equal(true);
             PostValidator.RuleFor(s => s.IndexerId).ValidId();
             PostValidator.RuleFor(s => s.Guid).NotEmpty();
 

--- a/src/Lidarr.Api.V1/Queue/QueueResource.cs
+++ b/src/Lidarr.Api.V1/Queue/QueueResource.cs
@@ -30,6 +30,7 @@ namespace Lidarr.Api.V1.Queue
         public DownloadProtocol Protocol { get; set; }
         public string DownloadClient { get; set; }
         public string Indexer { get; set; }
+        public bool DownloadForced { get; set; }
     }
 
     public static class QueueResourceMapper
@@ -58,7 +59,8 @@ namespace Lidarr.Api.V1.Queue
                 DownloadId = model.DownloadId,
                 Protocol = model.Protocol,
                 DownloadClient = model.DownloadClient,
-                Indexer = model.Indexer
+                Indexer = model.Indexer,
+                DownloadForced = model.DownloadForced
             };
         }
 

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/PrioritizeDownloadDecisionFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/PrioritizeDownloadDecisionFixture.cs
@@ -62,6 +62,8 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                                                     Cutoff = Language.Spanish
                                                 }).Build();
 
+            remoteAlbum.DownloadAllowed = true;
+
             return remoteAlbum;
         }
 

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
@@ -100,7 +100,6 @@ namespace NzbDrone.Core.DecisionEngine
                                     remoteAlbum.Artist = searchCriteria.Artist;
                                     remoteAlbum.Albums = searchCriteria.Albums;
                                 }
-                                remoteAlbum.DownloadAllowed = false;
                             }
                             else if (remoteAlbum.Albums.Empty())
                             {
@@ -109,7 +108,6 @@ namespace NzbDrone.Core.DecisionEngine
                                 {
                                     remoteAlbum.Albums = searchCriteria.Albums;
                                 }
-                                remoteAlbum.DownloadAllowed = false;
                             }
                             else
                             {

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
@@ -94,10 +94,22 @@ namespace NzbDrone.Core.DecisionEngine
                             if (remoteAlbum.Artist == null)
                             {
                                 decision = new DownloadDecision(remoteAlbum, new Rejection("Unknown Artist"));
+                                // shove in the searched artist in case of forced download in interactive search
+                                if (searchCriteria != null)
+                                {
+                                    remoteAlbum.Artist = searchCriteria.Artist;
+                                    remoteAlbum.Albums = searchCriteria.Albums;
+                                }
+                                remoteAlbum.DownloadAllowed = false;
                             }
                             else if (remoteAlbum.Albums.Empty())
                             {
                                 decision = new DownloadDecision(remoteAlbum, new Rejection("Unable to parse albums from release name"));
+                                if (searchCriteria != null)
+                                {
+                                    remoteAlbum.Albums = searchCriteria.Albums;
+                                }
+                                remoteAlbum.DownloadAllowed = false;
                             }
                             else
                             {

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionPriorizationService.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionPriorizationService.cs
@@ -21,13 +21,13 @@ namespace NzbDrone.Core.DecisionEngine
 
         public List<DownloadDecision> PrioritizeDecisions(List<DownloadDecision> decisions)
         {
-            return decisions.Where(c => c.RemoteAlbum.Artist != null)
+            return decisions.Where(c => c.RemoteAlbum.DownloadAllowed)
                             .GroupBy(c => c.RemoteAlbum.Artist.Id, (artistId, downloadDecisions) =>
                                 {
                                     return downloadDecisions.OrderByDescending(decision => decision, new DownloadDecisionComparer(_delayProfileService));
                                 })
                             .SelectMany(c => c)
-                            .Union(decisions.Where(c => c.RemoteAlbum.Artist == null))
+                            .Union(decisions.Where(c => !c.RemoteAlbum.DownloadAllowed))
                             .ToList();
         }
     }

--- a/src/NzbDrone.Core/History/HistoryService.cs
+++ b/src/NzbDrone.Core/History/HistoryService.cs
@@ -162,6 +162,7 @@ namespace NzbDrone.Core.History
                 history.Data.Add("DownloadUrl", message.Album.Release.DownloadUrl);
                 history.Data.Add("Guid", message.Album.Release.Guid);
                 history.Data.Add("Protocol", ((int)message.Album.Release.DownloadProtocol).ToString());
+                history.Data.Add("DownloadForced", (!message.Album.DownloadAllowed).ToString());
 
                 if (!message.Album.ParsedAlbumInfo.ReleaseHash.IsNullOrWhiteSpace())
                 {

--- a/src/NzbDrone.Core/Queue/Queue.cs
+++ b/src/NzbDrone.Core/Queue/Queue.cs
@@ -28,5 +28,6 @@ namespace NzbDrone.Core.Queue
         public string DownloadClient { get; set; }
         public string Indexer { get; set; }
         public string ErrorMessage { get; set; }
+        public bool DownloadForced { get; set; }
     }
 }


### PR DESCRIPTION

#### Database Migration
NO

#### Description
Allows you to download any search result in the interactive search dialog, even if the album or artist couldn't be parsed. Ones that couldn't be parsed get a red icon. 

#### Issues Fixed or Closed by this PR

* #441 
