### PR TITLE
Fixed: Don't assume no disc number implies disc 1

### DIFF
--- a/src/NzbDrone.Core.Test/MusicTests/TitleMatchingTests/TitleMatchingFixture.cs
+++ b/src/NzbDrone.Core.Test/MusicTests/TitleMatchingTests/TitleMatchingFixture.cs
@@ -41,12 +41,33 @@ namespace NzbDrone.Core.Test.MusicTests.TitleMatchingTests
             for (int i = 0; i < trackNames.Count; i++) {
                 _trackRepository.Insert(new Track
                         {
+                            ArtistId = 1234,
                             Title = trackNames[i],
                             ForeignTrackId = (i+1).ToString(),
                             AlbumId = 4321,
                             AbsoluteTrackNumber = i+1,
-                            MediumNumber = 1,
-                            TrackFileId = i+1
+                            MediumNumber = 1
+                        });
+            }
+        }
+
+        private void GivenSecondDisc()
+        {
+            var trackNames = new List<string> {
+                "first track",
+                "another entry",
+                "random name"
+            };
+
+            for (int i = 0; i < trackNames.Count; i++) {
+                _trackRepository.Insert(new Track
+                        {
+                            ArtistId = 1234,
+                            Title = trackNames[i],
+                            ForeignTrackId = (100+i+1).ToString(),
+                            AlbumId = 4321,
+                            AbsoluteTrackNumber = i+1,
+                            MediumNumber = 2
                         });
             }
         }
@@ -57,7 +78,7 @@ namespace NzbDrone.Core.Test.MusicTests.TitleMatchingTests
             var track = _trackService.FindTrackByTitle(1234, 4321, 1, 1, "Courage with some bla");
 
             track.Should().NotBeNull();
-            track.Title.Should().Be(_trackRepository.GetTracksByFileId(1).First().Title);
+            track.Title.Should().Be(_trackRepository.Find(1234, 4321, 1, 1).Title);
         }
 
         [Test]
@@ -66,7 +87,7 @@ namespace NzbDrone.Core.Test.MusicTests.TitleMatchingTests
             var track = _trackService.FindTrackByTitle(1234, 4321, 1, 3, "and Bone");
 
             track.Should().NotBeNull();
-            track.Title.Should().Be(_trackRepository.GetTracksByFileId(3).First().Title);
+            track.Title.Should().Be(_trackRepository.Find(1234, 4321, 1, 3).Title);
         }
 
         [Test]
@@ -77,6 +98,47 @@ namespace NzbDrone.Core.Test.MusicTests.TitleMatchingTests
             track.Should().BeNull();
         }
 
+        [TestCase("Courage", 1, 1)]
+        [TestCase("first track", 2, 1)]
+        [TestCase("another entry", 2, 2)]
+        [TestCase("random name", 2, 3)]
+        public void should_find_track_on_second_disc_when_disc_tag_missing(string title, int discNumber, int trackNumber)
+        {
+            GivenSecondDisc();
+            var track = _trackService.FindTrackByTitle(1234, 4321, 0, trackNumber, title);
+            var expected = _trackRepository.Find(1234, 4321, discNumber, trackNumber);
+
+            track.Should().NotBeNull();
+            expected.Should().NotBeNull();
+
+            track.Title.Should().Be(expected.Title);
+        }
+
+        [Test]
+        public void should_find_track_from_earlier_disc_if_title_identical_and_disc_tag_missing()
+        {
+            GivenSecondDisc();
+            _trackRepository.Insert(new Track
+                {
+                    ArtistId = 1234,
+                    Title = "Courage",
+                    ForeignTrackId = "999",
+                    AlbumId = 4321,
+                    AbsoluteTrackNumber = 5,
+                    MediumNumber = 2,
+                });
+
+            var track = _trackService.FindTrackByTitle(1234, 4321, 0, 1, "Courage");
+            track.Should().NotBeNull();
+            track.Title.Should().Be("Courage");
+            track.MediumNumber.Should().Be(1);
+
+            var track2 = _trackService.FindTrackByTitle(1234, 4321, 2, 5, "Courage");
+            track2.Should().NotBeNull();
+            track2.Title.Should().Be("Courage");
+            track2.MediumNumber.Should().Be(2);
+        }
+
         [TestCase("Fesh and Bone", 3)]
         [TestCase("Atitude", 7)]
         [TestCase("Smoth cRimnal", 12)]
@@ -84,9 +146,28 @@ namespace NzbDrone.Core.Test.MusicTests.TitleMatchingTests
         public void should_find_track_in_db_by_inexact_title(string title, int trackNumber)
         {
             var track = _trackService.FindTrackByTitleInexact(1234, 4321, 1, trackNumber, title);
+            var expected = _trackRepository.Find(1234, 4321, 1, trackNumber);
 
             track.Should().NotBeNull();
-            track.Title.Should().Be(_trackRepository.GetTracksByFileId(trackNumber).First().Title);
+            expected.Should().NotBeNull();
+
+            track.Title.Should().Be(expected.Title);
+        }
+
+        [TestCase("Courage!", 1, 1)]
+        [TestCase("first trakc", 2, 1)]
+        [TestCase("anoth entry", 2, 2)]
+        [TestCase("random.name", 2, 3)]
+        public void should_find_track_in_db_by_inexact_title_when_disc_tag_missing(string title, int discNumber, int trackNumber)
+        {
+            GivenSecondDisc();
+            var track = _trackService.FindTrackByTitleInexact(1234, 4321, 0, trackNumber, title);
+            var expected = _trackRepository.Find(1234, 4321, discNumber, trackNumber);
+
+            track.Should().NotBeNull();
+            expected.Should().NotBeNull();
+
+            track.Title.Should().Be(expected.Title);
         }
 
         [TestCase("A random title", 1)]

--- a/src/NzbDrone.Core/Music/TrackRepository.cs
+++ b/src/NzbDrone.Core/Music/TrackRepository.cs
@@ -61,6 +61,11 @@ namespace NzbDrone.Core.Music
 
         public List<Track> GetTracksByMedium(int albumId, int mediumNumber)
         {
+            if (mediumNumber < 1)
+            {
+                return GetTracksByAlbum(albumId);
+            }
+
             return Query.Where(s => s.AlbumId == albumId)
                         .AndWhere(s => s.MediumNumber == mediumNumber)
                         .ToList();

--- a/src/NzbDrone.Core/Music/TrackService.cs
+++ b/src/NzbDrone.Core/Music/TrackService.cs
@@ -99,7 +99,7 @@ namespace NzbDrone.Core.Music
                     Track = track
                 };
 
-            return matches.OrderByDescending(e => e.NormalizedLength).FirstOrDefault()?.Track;
+            return matches.OrderByDescending(e => e.NormalizedLength).ThenBy(e => e.Track.MediumNumber).FirstOrDefault()?.Track;
         }
 
         public Track FindTrackByTitleInexact(int artistId, int albumId, int mediumNumber, int trackNumber, string releaseTitle)
@@ -114,7 +114,7 @@ namespace NzbDrone.Core.Music
                 let normalizedTitle = Parser.Parser.NormalizeTrackTitle(track.Title).Replace(".", " ")
                 let matchProb = normalizedTitle.FuzzyMatch(normalizedReleaseTitle)
                 where track.Title.Length > 0
-                orderby matchProb descending
+                orderby matchProb descending, track.MediumNumber
                 select new
                 {
                     MatchProb = matchProb,

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -619,7 +619,7 @@ namespace NzbDrone.Core.Parser
 
             var trackNumber = file.Tag.Track;
             var trackTitle = file.Tag.Title;
-            var discNumber = (file.Tag.Disc > 0) ? Convert.ToInt32(file.Tag.Disc) : 1;
+            var discNumber = (file.Tag.Disc > 0) ? Convert.ToInt32(file.Tag.Disc) : 0;
 
             var artist = file.Tag.FirstAlbumArtist;
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Lots of multi-disc releases don't seem to have the disc number tag set.  At the moment, Lidarr sets the disc number to 1 if the disc number tag is missing.  It then only checks against tracks on the first disc when trying to import.

This change alters the track finding logic so that it checks against all tracks in a release if the disc number tag is missing.  If multiple tracks have the same name it will return the track from the earlier disc.

#### Todos
- [x] Tests


#### Issues Fixed or Closed by this PR
* #465
