### PR TITLE
Update Apollo with Orpheus

### DIFF
--- a/src/NzbDrone.Core/Indexers/Gazelle/Gazelle.cs
+++ b/src/NzbDrone.Core/Indexers/Gazelle/Gazelle.cs
@@ -48,7 +48,7 @@ namespace NzbDrone.Core.Indexers.Gazelle
         {
             get
             {
-                yield return GetDefinition("Apollo.Rip", GetSettings("https://apollo.rip"));
+                yield return GetDefinition("Orpheus Network", GetSettings("https://orpheus.network"));
                 yield return GetDefinition("REDacted", GetSettings("https://redacted.ch"));
                 yield return GetDefinition("Not What CD", GetSettings("https://notwhat.cd"));
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
After Apollo.Rip went down a few months ago, Orpheus has come up with the same DB as Apollo except under a different URL. It uses the Gazelle API, which means the same configuration will work with Apollo.