### PR TITLE
Fixed: Ignore .partial~ files

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
@@ -64,7 +64,7 @@ namespace NzbDrone.Core.MediaFiles
             _logger = logger;
         }
         private static readonly Regex ExcludedSubFoldersRegex = new Regex(@"(?:\\|\/|^)(?:extras|@eadir|extrafanart|plex versions|\.[^\\/]+)(?:\\|\/)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex ExcludedFilesRegex = new Regex(@"^\._|^Thumbs\.db$|^\.DS_store$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex ExcludedFilesRegex = new Regex(@"^\._|^Thumbs\.db$|^\.DS_store$|\.partial~$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         public void Scan(Artist artist)
         {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The extra file importer will try to import in-transit audio files which can mean they never get properly renamed. This makes everything ignore the partial files.
