### PR TITLE
Fixed: partial album imports stay in queue, prompting manual import

### DIFF
--- a/frontend/src/Activity/History/Details/HistoryDetails.js
+++ b/frontend/src/Activity/History/Details/HistoryDetails.js
@@ -251,6 +251,7 @@ function HistoryDetails(props) {
       </DescriptionList>
     );
   }
+
   if (eventType === 'albumImportIncomplete') {
     const {
       statusMessages
@@ -268,6 +269,90 @@ function HistoryDetails(props) {
             <DescriptionListItem
               title="Import failures"
               data={getDetailedPopoverBody(JSON.parse(statusMessages))}
+            />
+        }
+      </DescriptionList>
+    );
+  }
+
+  if (eventType === 'downloadComplete') {
+    const {
+      indexer,
+      releaseGroup,
+      nzbInfoUrl,
+      downloadClient,
+      downloadId,
+      age,
+      ageHours,
+      ageMinutes,
+      publishedDate
+    } = data;
+
+    return (
+      <DescriptionList>
+        <DescriptionListItem
+          title="Name"
+          data={sourceTitle}
+        />
+
+        {
+          !!indexer &&
+            <DescriptionListItem
+              title="Indexer"
+              data={indexer}
+            />
+        }
+
+        {
+          !!releaseGroup &&
+            <DescriptionListItem
+              title="Release Group"
+              data={releaseGroup}
+            />
+        }
+
+        {
+          !!nzbInfoUrl &&
+            <span>
+              <DescriptionListItemTitle>
+                Info URL
+              </DescriptionListItemTitle>
+
+              <DescriptionListItemDescription>
+                <Link to={nzbInfoUrl}>{nzbInfoUrl}</Link>
+              </DescriptionListItemDescription>
+            </span>
+        }
+
+        {
+          !!downloadClient &&
+            <DescriptionListItem
+              title="Download Client"
+              data={downloadClient}
+            />
+        }
+
+        {
+          !!downloadId &&
+            <DescriptionListItem
+              title="Grab ID"
+              data={downloadId}
+            />
+        }
+
+        {
+          !!indexer &&
+            <DescriptionListItem
+              title="Age (when grabbed)"
+              data={formatAge(age, ageHours, ageMinutes)}
+            />
+        }
+
+        {
+          !!publishedDate &&
+            <DescriptionListItem
+              title="Published Date"
+              data={formatDateTime(publishedDate, shortDateFormat, timeFormat, { includeSeconds: true })}
             />
         }
       </DescriptionList>

--- a/frontend/src/Activity/History/Details/HistoryDetails.js
+++ b/frontend/src/Activity/History/Details/HistoryDetails.js
@@ -8,6 +8,33 @@ import DescriptionListItem from 'Components/DescriptionList/DescriptionListItem'
 import DescriptionListItemTitle from 'Components/DescriptionList/DescriptionListItemTitle';
 import DescriptionListItemDescription from 'Components/DescriptionList/DescriptionListItemDescription';
 
+function getDetailedPopoverBody(statusMessages) {
+  return (
+    <div>
+      {
+        statusMessages.map(({ title, messages }) => {
+          return (
+            <div key={title}>
+              {title}
+              <ul>
+                {
+                  messages.map((message) => {
+                    return (
+                      <li key={message}>
+                        {message}
+                      </li>
+                    );
+                  })
+                }
+              </ul>
+            </div>
+          );
+        })
+      }
+    </div>
+  );
+}
+
 function HistoryDetails(props) {
   const {
     eventType,
@@ -221,6 +248,28 @@ function HistoryDetails(props) {
           title="Destination Relative Path"
           data={relativePath}
         />
+      </DescriptionList>
+    );
+  }
+  if (eventType === 'albumImportIncomplete') {
+    const {
+      statusMessages
+    } = data;
+
+    return (
+      <DescriptionList>
+        <DescriptionListItem
+          title="Name"
+          data={sourceTitle}
+        />
+
+        {
+          !!statusMessages &&
+            <DescriptionListItem
+              title="Import failures"
+              data={getDetailedPopoverBody(JSON.parse(statusMessages))}
+            />
+        }
       </DescriptionList>
     );
   }

--- a/frontend/src/Activity/History/Details/HistoryDetailsModal.js
+++ b/frontend/src/Activity/History/Details/HistoryDetailsModal.js
@@ -23,6 +23,8 @@ function getHeaderTitle(eventType) {
       return 'Track File Deleted';
     case 'trackFileRenamed':
       return 'Track File Renamed';
+    case 'albumImportIncomplete':
+      return 'Album Import Incomplete';
     default:
       return 'Unknown';
   }

--- a/frontend/src/Activity/History/Details/HistoryDetailsModal.js
+++ b/frontend/src/Activity/History/Details/HistoryDetailsModal.js
@@ -25,6 +25,8 @@ function getHeaderTitle(eventType) {
       return 'Track File Renamed';
     case 'albumImportIncomplete':
       return 'Album Import Incomplete';
+    case 'downloadComplete':
+      return 'Download Completed';
     default:
       return 'Unknown';
   }

--- a/frontend/src/Activity/History/HistoryEventTypeCell.js
+++ b/frontend/src/Activity/History/HistoryEventTypeCell.js
@@ -19,6 +19,8 @@ function getIconName(eventType) {
       return icons.DELETE;
     case 'trackFileRenamed':
       return icons.ORGANIZE;
+    case 'albumImportIncomplete':
+      return icons.DOWNLOADED;
     default:
       return icons.UNKNOWN;
   }
@@ -28,6 +30,8 @@ function getIconKind(eventType) {
   switch (eventType) {
     case 'downloadFailed':
       return kinds.DANGER;
+    case 'albumImportIncomplete':
+      return kinds.WARNING;
     default:
       return kinds.DEFAULT;
   }
@@ -47,6 +51,8 @@ function getTooltip(eventType, data) {
       return 'Track file deleted';
     case 'trackFileRenamed':
       return 'Track file renamed';
+    case 'albumImportIncomplete':
+      return 'Files downloaded but not all could be imported';
     default:
       return 'Unknown event';
   }

--- a/frontend/src/Activity/History/HistoryEventTypeCell.js
+++ b/frontend/src/Activity/History/HistoryEventTypeCell.js
@@ -21,6 +21,8 @@ function getIconName(eventType) {
       return icons.ORGANIZE;
     case 'albumImportIncomplete':
       return icons.DOWNLOADED;
+    case 'downloadComplete':
+      return icons.DOWNLOADED;
     default:
       return icons.UNKNOWN;
   }
@@ -53,6 +55,8 @@ function getTooltip(eventType, data) {
       return 'Track file renamed';
     case 'albumImportIncomplete':
       return 'Files downloaded but not all could be imported';
+    case 'downloadComplete':
+      return 'Download completed and successfully imported';
     default:
       return 'Unknown event';
   }

--- a/frontend/src/Store/Actions/historyActions.js
+++ b/frontend/src/Store/Actions/historyActions.js
@@ -142,6 +142,17 @@ export const defaultState = {
       ]
     },
     {
+      key: 'downloadComplete',
+      label: 'Download Completed',
+      filters: [
+        {
+          key: 'eventType',
+          value: '8',
+          type: filterTypes.EQUAL
+        }
+      ]
+    },
+    {
       key: 'deleted',
       label: 'Deleted',
       filters: [

--- a/frontend/src/Store/Actions/historyActions.js
+++ b/frontend/src/Store/Actions/historyActions.js
@@ -121,11 +121,22 @@ export const defaultState = {
     },
     {
       key: 'failed',
-      label: 'Failed',
+      label: 'Download Failed',
       filters: [
         {
           key: 'eventType',
           value: '4',
+          type: filterTypes.EQUAL
+        }
+      ]
+    },
+    {
+      key: 'importFailed',
+      label: 'Import Failed',
+      filters: [
+        {
+          key: 'eventType',
+          value: '7',
           type: filterTypes.EQUAL
         }
       ]

--- a/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceFixture.cs
@@ -61,12 +61,23 @@ namespace NzbDrone.Core.Test.Download
 
         }
 
+        private Album CreateAlbum(int id, int trackCount)
+        {
+            return new Album {
+                Id = id,
+                CurrentRelease = new AlbumRelease
+                {
+                    TrackCount = trackCount
+                }
+            };
+        }
+
         private RemoteAlbum BuildRemoteAlbum()
         {
             return new RemoteAlbum
             {
                 Artist = new Artist(),
-                Albums = new List<Album> { new Album { Id = 1 } }
+                Albums = new List<Album> { CreateAlbum(1, 1) }
             };
         }
 
@@ -91,6 +102,7 @@ namespace NzbDrone.Core.Test.Download
 
         private void GivenABadlyNamedDownload()
         {
+            _trackedDownload.RemoteAlbum.Artist = null;
             _trackedDownload.DownloadItem.DownloadId = "1234";
             _trackedDownload.DownloadItem.Title = "Droned Pilot"; // Set a badly named download
             Mocker.GetMock<IHistoryService>()
@@ -253,15 +265,17 @@ namespace NzbDrone.Core.Test.Download
 
             _trackedDownload.RemoteAlbum.Albums = new List<Album>
             {
-                new Album()
+                CreateAlbum(1, 3)
             };
 
             Mocker.GetMock<IDownloadedTracksImportService>()
                   .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<ImportMode>(), It.IsAny<Artist>(), It.IsAny<DownloadClientItem>()))
                   .Returns(new List<ImportResult>
                            {
-                               new ImportResult(new ImportDecision(new LocalTrack {Path = @"C:\TestPath\Droned.S01E01.mkv"})),
-                               new ImportResult(new ImportDecision(new LocalTrack{Path = @"C:\TestPath\Droned.S01E01.mkv"}),"Test Failure")
+                               new ImportResult(new ImportDecision(new LocalTrack {Path = @"C:\TestPath\Droned.S01E01.mkv".AsOsAgnostic()})),
+                               new ImportResult(new ImportDecision(new LocalTrack {Path = @"C:\TestPath\Droned.S01E01.mkv".AsOsAgnostic()})),
+                               new ImportResult(new ImportDecision(new LocalTrack {Path = @"C:\TestPath\Droned.S01E01.mkv".AsOsAgnostic()})),
+                               new ImportResult(new ImportDecision(new LocalTrack {Path = @"C:\TestPath\Droned.S01E01.mkv".AsOsAgnostic()}), "Test Failure")
                            });
 
             Subject.Process(_trackedDownload);
@@ -274,18 +288,20 @@ namespace NzbDrone.Core.Test.Download
         {
             _trackedDownload.RemoteAlbum.Albums = new List<Album>
             {
-                new Album(),
-                new Album(),
-                new Album()
+                CreateAlbum(1, 1),
+                CreateAlbum(1, 2),
+                CreateAlbum(1, 1)
             };
 
             Mocker.GetMock<IDownloadedTracksImportService>()
                   .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<ImportMode>(), It.IsAny<Artist>(), It.IsAny<DownloadClientItem>()))
                   .Returns(new List<ImportResult>
                            {
-                               new ImportResult(new ImportDecision(new LocalTrack {Path = @"C:\TestPath\Droned.S01E01.mkv"})),
-                               new ImportResult(new ImportDecision(new LocalTrack{Path = @"C:\TestPath\Droned.S01E01.mkv"}),"Test Failure"),
-                               new ImportResult(new ImportDecision(new LocalTrack{Path = @"C:\TestPath\Droned.S01E01.mkv"}),"Test Failure")
+                               new ImportResult(new ImportDecision(new LocalTrack {Path = @"C:\TestPath\Droned.S01E01.mkv".AsOsAgnostic()})),
+                               new ImportResult(new ImportDecision(new LocalTrack {Path = @"C:\TestPath\Droned.S01E01.mkv".AsOsAgnostic()})),
+                               new ImportResult(new ImportDecision(new LocalTrack {Path = @"C:\TestPath\Droned.S01E01.mkv".AsOsAgnostic()})),
+                               new ImportResult(new ImportDecision(new LocalTrack {Path = @"C:\TestPath\Droned.S01E01.mkv".AsOsAgnostic()}), "Test Failure"),
+                               new ImportResult(new ImportDecision(new LocalTrack {Path = @"C:\TestPath\Droned.S01E01.mkv".AsOsAgnostic()}), "Test Failure")
                            });
 
 
@@ -338,6 +354,7 @@ namespace NzbDrone.Core.Test.Download
         [Test]
         public void should_not_import_when_there_is_a_title_mismatch()
         {
+            _trackedDownload.RemoteAlbum.Artist = null;
             Mocker.GetMock<IParsingService>()
                   .Setup(s => s.GetArtist("Drone.S01E01.HDTV"))
                   .Returns((Artist)null);
@@ -352,7 +369,7 @@ namespace NzbDrone.Core.Test.Download
         {
             _trackedDownload.RemoteAlbum.Albums = new List<Album>
             {
-                new Album()
+                CreateAlbum(0, 1)
             };
 
             Mocker.GetMock<IDownloadedTracksImportService>()

--- a/src/NzbDrone.Core/Download/CompletedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/CompletedDownloadService.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Linq;
 using NLog;
-using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Configuration;
@@ -114,7 +113,8 @@ namespace NzbDrone.Core.Download
                 return;
             }
 
-            if (importResults.Count(c => c.Result == ImportResultType.Imported) >= Math.Max(1, trackedDownload.RemoteAlbum.Albums.Sum(x => x.CurrentRelease.TrackCount)))
+            if (importResults.All(c => c.Result == ImportResultType.Imported)
+                || importResults.Count(c => c.Result == ImportResultType.Imported) >= Math.Max(1, trackedDownload.RemoteAlbum.Albums.Sum(x => x.CurrentRelease.TrackCount)))
             {
                 trackedDownload.State = TrackedDownloadStage.Imported;
                 _eventAggregator.PublishEvent(new DownloadCompletedEvent(trackedDownload));
@@ -132,7 +132,6 @@ namespace NzbDrone.Core.Download
                 trackedDownload.Warn(statusMessages);
                 _eventAggregator.PublishEvent(new AlbumImportIncompleteEvent(trackedDownload));
             }
-
         }
     }
 }

--- a/src/NzbDrone.Core/Download/TrackedDownloads/DownloadMonitoringService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/DownloadMonitoringService.cs
@@ -152,7 +152,8 @@ namespace NzbDrone.Core.Download.TrackedDownloads
         private bool DownloadIsTrackable(TrackedDownload trackedDownload)
         {
             // If the download has already been imported or failed don't track it
-            if (trackedDownload.State != TrackedDownloadStage.Downloading)
+            if (trackedDownload.State == TrackedDownloadStage.DownloadFailed
+                || trackedDownload.State == TrackedDownloadStage.Imported)
             {
                 return false;
             }

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownload.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownload.cs
@@ -36,8 +36,9 @@ namespace NzbDrone.Core.Download.TrackedDownloads
     public enum TrackedDownloadStage
     {
         Downloading,
+        DownloadFailed,
         Imported,
-        DownloadFailed
+        ImportFailed
     }
 
     public enum TrackedDownloadStatus

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownload.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownload.cs
@@ -37,8 +37,9 @@ namespace NzbDrone.Core.Download.TrackedDownloads
     {
         Downloading,
         DownloadFailed,
-        Imported,
-        ImportFailed
+        Importing,
+        ImportFailed,
+        Imported
     }
 
     public enum TrackedDownloadStatus

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadStatusMessage.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadStatusMessage.cs
@@ -21,7 +21,7 @@ namespace NzbDrone.Core.Download.TrackedDownloads
         }
 
         //Constructor for use when deserializing JSON
-        private TrackedDownloadStatusMessage()
+        public TrackedDownloadStatusMessage()
         {
         }
     }

--- a/src/NzbDrone.Core/History/History.cs
+++ b/src/NzbDrone.Core/History/History.cs
@@ -42,6 +42,7 @@ namespace NzbDrone.Core.History
         DownloadFailed = 4,
         TrackFileDeleted = 5,
         TrackFileRenamed = 6,
-        AlbumImportIncomplete = 7
+        AlbumImportIncomplete = 7,
+        DownloadComplete = 8
     }
 }

--- a/src/NzbDrone.Core/History/History.cs
+++ b/src/NzbDrone.Core/History/History.cs
@@ -41,6 +41,7 @@ namespace NzbDrone.Core.History
         DownloadFolderImported = 3,
         DownloadFailed = 4,
         TrackFileDeleted = 5,
-        TrackFileRenamed = 6
+        TrackFileRenamed = 6,
+        AlbumImportIncomplete = 7
     }
 }

--- a/src/NzbDrone.Core/History/HistoryService.cs
+++ b/src/NzbDrone.Core/History/HistoryService.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Marr.Data.QGen;
 using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Datastore;
@@ -11,10 +10,7 @@ using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.Events;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Parser.Model;
-using NzbDrone.Core.Profiles.Qualities;
-using NzbDrone.Core.Profiles.Languages;
 using NzbDrone.Core.Languages;
-using NzbDrone.Core.Music;
 using NzbDrone.Core.Music.Events;
 using NzbDrone.Core.Qualities;
 using NzbDrone.Common.Serializer;
@@ -39,6 +35,7 @@ namespace NzbDrone.Core.History
                                   IHandle<AlbumImportIncompleteEvent>,
                                   IHandle<TrackImportedEvent>,
                                   IHandle<DownloadFailedEvent>,
+                                  IHandle<DownloadCompletedEvent>,
                                   IHandle<TrackFileDeletedEvent>,
                                   IHandle<TrackFileRenamedEvent>,
                                   IHandle<ArtistDeletedEvent>
@@ -261,6 +258,26 @@ namespace NzbDrone.Core.History
 
                 history.Data.Add("DownloadClient", message.DownloadClient);
                 history.Data.Add("Message", message.Message);
+
+                _historyRepository.Insert(history);
+            }
+        }
+
+        public void Handle(DownloadCompletedEvent message)
+        {
+            foreach (var album in message.TrackedDownload.RemoteAlbum.Albums)
+            {
+                var history = new History
+                {
+                    EventType = HistoryEventType.DownloadComplete,
+                    Date = DateTime.UtcNow,
+                    Quality = message.TrackedDownload.RemoteAlbum.ParsedAlbumInfo?.Quality ?? new QualityModel(),
+                    SourceTitle = message.TrackedDownload.DownloadItem.Title,
+                    ArtistId = album.ArtistId,
+                    AlbumId = album.Id,
+                    DownloadId = message.TrackedDownload.DownloadItem.DownloadId,
+                    Language = message.TrackedDownload.RemoteAlbum.ParsedAlbumInfo?.Language ?? Language.English
+                };
 
                 _historyRepository.Insert(history);
             }

--- a/src/NzbDrone.Core/MediaFiles/Events/AlbumImportIncompleteEvent.cs
+++ b/src/NzbDrone.Core/MediaFiles/Events/AlbumImportIncompleteEvent.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using NzbDrone.Common.Messaging;
+using NzbDrone.Core.Download.TrackedDownloads;
+using NzbDrone.Core.Music;
+
+namespace NzbDrone.Core.MediaFiles.Events
+{
+    public class AlbumImportIncompleteEvent : IEvent
+    {
+        public TrackedDownload TrackedDownload { get; private set; }
+
+        public AlbumImportIncompleteEvent(TrackedDownload trackedDownload)
+        {
+            TrackedDownload = trackedDownload;
+        }
+    }
+}

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -709,6 +709,7 @@
     <Compile Include="MediaFiles\Commands\DownloadedAlbumsScanCommand.cs" />
     <Compile Include="MediaFiles\Commands\RenameArtistCommand.cs" />
     <Compile Include="MediaFiles\Events\AlbumImportedEvent.cs" />
+    <Compile Include="MediaFiles\Events\AlbumImportIncompleteEvent.cs" />
     <Compile Include="MediaFiles\Events\TrackFileRenamedEvent.cs" />
     <Compile Include="MediaFiles\Events\TrackFolderCreatedEvent.cs" />
     <Compile Include="MediaFiles\Events\TrackImportFailedEvent.cs" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
At the moment, if one track imports from a download then it is removed from the queue and deemed successful.  You have to go the artist page to see that you don't actually have all the tracks, and the unimported tracks are left floating in the download folder.

This change adds a new history event "Album Import Incomplete" that Lidarr can use to track that the download was unsuccessful and keep the item in the queue with the manual import button displayed. 

Partially imported downloads will remain in the queue until they are manually removed or a track is manually imported.

#### Todos
- [x] Tests


#### Issues Fixed or Closed by this PR

* #192 
* #296 