### PR TITLE
Fixed: Better release parsing in case incorrect parse

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -182,6 +182,8 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Black Sabbath Black Sabbath FLAC")]
         [TestCase("BlaCk SabBaTh Black SabBatH FLAC")]
         [TestCase("Black Sabbath FLAC Black Sabbath")]
+        [TestCase("Black.Sabbath-FLAC-Black.Sabbath")]
+        [TestCase("Black_Sabbath-FLAC-Black_Sabbath")]
         public void should_parse_artist_name_and_album_title_by_search_criteria(string releaseTitle)
         {
             GivenSearchCriteria("Black Sabbath", "Black Sabbath");

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
@@ -89,6 +89,21 @@ namespace NzbDrone.Core.DecisionEngine
                         if (!parsedAlbumInfo.ArtistName.IsNullOrWhiteSpace())
                         {
                             var remoteAlbum = _parsingService.Map(parsedAlbumInfo, searchCriteria);
+
+                            // try parsing again using the search criteria, in case it parsed but parsed incorrectly
+                            if ((remoteAlbum.Artist == null || remoteAlbum.Albums.Empty()) && searchCriteria != null)
+                            {
+                                _logger.Debug("Artist/Album null for {0}, reparsing with search criteria", report.Title);
+                                var parsedAlbumInfoWithCriteria = Parser.Parser.ParseAlbumTitleWithSearchCriteria(report.Title,
+                                                                                                                  searchCriteria.Artist,
+                                                                                                                  searchCriteria.Albums);
+
+                                if (parsedAlbumInfoWithCriteria != null && parsedAlbumInfoWithCriteria.ArtistName.IsNotNullOrWhiteSpace())
+                                {
+                                    remoteAlbum = _parsingService.Map(parsedAlbumInfoWithCriteria, searchCriteria);
+                                }
+                            }
+
                             remoteAlbum.Release = report;
 
                             if (remoteAlbum.Artist == null)

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -334,8 +334,8 @@ namespace NzbDrone.Core.Parser
             {
                 if (!ValidateBeforeParsing(title)) return null;
 
-                Logger.Debug("Parsing string '{0}'", title);
-
+                Logger.Debug("Parsing string '{0}' using search criteria artist: '{1}' album: '{2}'",
+                             title, artist.Name, string.Join(", ", album.Select(a => a.Title)));
 
                 if (ReversedTitleRegex.IsMatch(title))
                 {
@@ -355,8 +355,8 @@ namespace NzbDrone.Core.Parser
 
                 simpleTitle = CleanTorrentSuffixRegex.Replace(simpleTitle, string.Empty);
 
-                var escapedArtist = Regex.Escape(artist.Name);
-                var escapedAlbums = Regex.Escape(string.Join("|", album.Select(s => s.Title).ToList()));
+                var escapedArtist = Regex.Escape(artist.Name).Replace(@"\ ", @"[\W_]");
+                var escapedAlbums = Regex.Escape(string.Join("|", album.Select(s => s.Title).ToList())).Replace(@"\ ", @"[\W_]");;
 
                 var releaseRegex = new Regex(@"^(\W*|\b)(?<artist>" + escapedArtist + @")(\W*|\b).*(\W*|\b)(?<album>" + escapedAlbums + @")(\W*|\b)", RegexOptions.IgnoreCase);
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Re-run the release parsing using the search criteria if the release parsed but we couldn't match it to an album/artist.  This particularly helps when the artist contains a `-` like `American Hi-Fi-The Art Of Losing-2003-NHH INT` where the artist is parsed as `American Hi` and the album as `Fi` the first time.

#### Todos
- [x] Tests

