### PR TITLE
Fixed: Allow release if tracks are missing

### DIFF
--- a/src/NzbDrone.Core/Music/TrackRepository.cs
+++ b/src/NzbDrone.Core/Music/TrackRepository.cs
@@ -21,6 +21,7 @@ namespace NzbDrone.Core.Music
         List<Track> GetTracksByMedium(int albumId, int mediumNumber);
         List<Track> GetTracksByFileId(int fileId);
         List<Track> TracksWithFiles(int artistId);
+        List<Track> TracksWithoutFiles(int albumId);
         void SetFileId(int trackId, int fileId);
     }
 
@@ -133,6 +134,21 @@ namespace NzbDrone.Core.Music
                                          "WHERE Artists.Id == {0} " +
                                          "AND AlbumReleases.Monitored = 1 ",
                                          artistId);
+
+            return Query.QueryText(query).ToList();
+        }
+
+        public List<Track> TracksWithoutFiles(int albumId)
+        {
+            string query = string.Format("SELECT Tracks.* " +
+                                         "FROM Albums " +
+                                         "JOIN AlbumReleases ON AlbumReleases.AlbumId == Albums.Id " +
+                                         "JOIN Tracks ON Tracks.AlbumReleaseId == AlbumReleases.Id " +
+                                         "LEFT OUTER JOIN TrackFiles ON TrackFiles.Id == Tracks.TrackFileId " +
+                                         "WHERE Albums.Id == {0} " +
+                                         "AND AlbumReleases.Monitored = 1 " +
+                                         "AND TrackFiles.Id IS NULL",
+                                         albumId);
 
             return Query.QueryText(query).ToList();
         }

--- a/src/NzbDrone.Core/Music/TrackService.cs
+++ b/src/NzbDrone.Core/Music/TrackService.cs
@@ -26,6 +26,7 @@ namespace NzbDrone.Core.Music
         List<Track> GetTracksByRelease(int albumReleaseId);
         List<Track> GetTracksByForeignReleaseId(string foreignReleaseId);
         List<Track> TracksWithFiles(int artistId);
+        List<Track> TracksWithoutFiles(int albumId);
         List<Track> GetTracksByFileId(int trackFileId);
         void UpdateTrack(Track track);
         void UpdateTracks(List<Track> tracks);
@@ -163,6 +164,11 @@ namespace NzbDrone.Core.Music
         public List<Track> TracksWithFiles(int artistId)
         {
             return _trackRepository.TracksWithFiles(artistId);
+        }
+
+        public List<Track> TracksWithoutFiles(int albumId)
+        {
+            return _trackRepository.TracksWithoutFiles(albumId);
         }
 
         public List<Track> GetTracksByFileId(int trackFileId)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
At the moment a release is rejected from search if it isn't a quality upgrade.  This PR changes it to allow a release that isn't an upgrade if there are missing files on disk.

#### Todos
- [x] Tests

