### PR TITLE
Fix more issues with migration 23

### DIFF
--- a/src/NzbDrone.Core.Test/Datastore/Migration/023_add_release_groups_etcFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/Migration/023_add_release_groups_etcFixture.cs
@@ -1,0 +1,236 @@
+using System.Linq;
+using FluentAssertions;
+using FizzWare.NBuilder;
+using NUnit.Framework;
+using NzbDrone.Core.Datastore.Migration;
+using NzbDrone.Core.Music;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Common.Serializer;
+using System.Collections.Generic;
+
+namespace NzbDrone.Core.Test.Datastore.Migration
+{
+    [TestFixture]
+    public class add_release_groups_etcFixture : MigrationTest<add_release_groups_etc>
+    {
+        private void GivenArtist(add_release_groups_etc c, int id, string name)
+        {
+            c.Insert.IntoTable("Artists").Row(new
+                {
+                    Id = id,
+                    ForeignArtistId = id.ToString(),
+                    Name = name,
+                    CleanName = name,
+                    Status = 1,
+                    Images = "",
+                    Path = $"/mnt/data/path/{name}",
+                    Monitored = 1,
+                    AlbumFolder = 1,
+                    LanguageProfileId = 1,
+                    MetadataProfileId = 1
+                });
+        }
+
+        private void GivenAlbum(add_release_groups_etc c, int id, int artistId, string title, string currentRelease)
+        {
+            c.Insert.IntoTable("Albums").Row(new
+                {
+                    Id = id,
+                    ForeignAlbumId = id.ToString(),
+                    ArtistId = artistId,
+                    Title = title,
+                    CleanTitle = title,
+                    Images = "",
+                    Monitored = 1,
+                    AlbumType = "Studio",
+                    Duration = 100,
+                    Media = "",
+                    Releases = "",
+                    CurrentRelease = currentRelease
+                });
+        }
+
+        private void GivenTracks(add_release_groups_etc c, int artistid, int albumid, int firstId, int count)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                var id = firstId + i;
+                c.Insert.IntoTable("Tracks").Row(new
+                    {
+                        Id = id,
+                        ForeignTrackId = id.ToString(),
+                        ArtistId = artistid,
+                        AlbumId = albumid,
+                        Explicit = 0,
+                        Compilation = 0,
+                        Monitored = 0,
+                        Duration = 100,
+                        MediumNumber = 1,
+                        AbsoluteTrackNumber = i,
+                        TrackNumber = i.ToString()
+                    });
+            }
+        }
+
+        private IEnumerable<AlbumRelease> VerifyAlbumReleases(IDirectDataMapper db)
+        {
+            var releases = db.Query<AlbumRelease>("SELECT * FROM AlbumReleases");
+            var albums = db.Query<Album>("SELECT * FROM Albums");
+
+            // we only put in one release per album
+            releases.Count().Should().Be(albums.Count());
+
+            // each album should be linked to exactly one release
+            releases.Select(x => x.AlbumId).SequenceEqual(albums.Select(x => x.Id)).Should().Be(true);
+
+            // each release should have at least one medium
+            releases.Select(x => x.Media.Count).Min().Should().BeGreaterOrEqualTo(1);
+
+            return releases;
+        }
+
+        private void VerifyTracks(IDirectDataMapper db, int albumId, int albumReleaseId, int expectedCount)
+        {
+            var tracks = db.Query<Track>("SELECT Tracks.* FROM Tracks " +
+                                         "JOIN AlbumReleases ON Tracks.AlbumReleaseId = AlbumReleases.Id " +
+                                         "JOIN Albums ON AlbumReleases.AlbumId = Albums.Id " +
+                                         "WHERE Albums.Id = " + albumId).ToList();
+            tracks.Count.Should().Be(expectedCount);
+            tracks.First().AlbumReleaseId.Should().Be(albumReleaseId);
+        }
+        
+        [Test]
+        public void migration_023_simple_case()
+        {
+            var release = Builder<add_release_groups_etc.LegacyAlbumRelease>
+                .CreateNew()
+                .Build();
+            
+            var db = WithMigrationTestDb(c =>
+                {
+                    GivenArtist(c, 1, "TestArtist");
+                    GivenAlbum(c, 1, 1, "TestAlbum", release.ToJson());
+                    GivenTracks(c, 1, 1, 1, 10);
+                });
+
+            VerifyAlbumReleases(db);
+            VerifyTracks(db, 1, 1, 10);
+        }
+
+        [Test]
+        public void migration_023_multiple_media()
+        {
+            var release = Builder<add_release_groups_etc.LegacyAlbumRelease>
+                .CreateNew()
+                .With(e => e.MediaCount = 2)
+                .Build();
+            
+            var db = WithMigrationTestDb(c =>
+                {
+                    GivenArtist(c, 1, "TestArtist");
+                    GivenAlbum(c, 1, 1, "TestAlbum", release.ToJson());
+                    GivenTracks(c, 1, 1, 1, 10);
+                });
+
+            var migrated = VerifyAlbumReleases(db);
+            migrated.First().Media.Count.Should().Be(2);
+            
+            VerifyTracks(db, 1, 1, 10);
+        }
+
+        [Test]
+        public void migration_023_null_title()
+        {
+            var release = Builder<add_release_groups_etc.LegacyAlbumRelease>
+                .CreateNew()
+                .With(e => e.Title = null)
+                .Build();
+
+            var db = WithMigrationTestDb(c =>
+                {
+                    GivenArtist(c, 1, "TestArtist");
+                    GivenAlbum(c, 1, 1, "TestAlbum", release.ToJson());
+                    GivenTracks(c, 1, 1, 1, 10);
+                });
+
+            VerifyAlbumReleases(db);
+            VerifyTracks(db, 1, 1, 10);
+        }
+
+        [Test]
+        public void migration_023_all_default_entries()
+        {
+            var release = new add_release_groups_etc.LegacyAlbumRelease();
+
+            var db = WithMigrationTestDb(c =>
+                {
+                    GivenArtist(c, 1, "TestArtist");
+                    GivenAlbum(c, 1, 1, "TestAlbum", release.ToJson());
+                    GivenTracks(c, 1, 1, 1, 10);
+                });
+
+            VerifyAlbumReleases(db);
+            VerifyTracks(db, 1, 1, 10);
+        }
+
+        [Test]
+        public void migration_023_empty_albumrelease()
+        {
+            var db = WithMigrationTestDb(c =>
+                {
+                    GivenArtist(c, 1, "TestArtist");
+                    GivenAlbum(c, 1, 1, "TestAlbum", "");
+                    GivenTracks(c, 1, 1, 1, 10);
+                });
+
+            VerifyAlbumReleases(db);
+            VerifyTracks(db, 1, 1, 10);
+        }
+
+        [Test]
+        public void migration_023_duplicate_albumrelease()
+        {
+            var release = Builder<add_release_groups_etc.LegacyAlbumRelease>
+                .CreateNew()
+                .Build();
+            
+            var db = WithMigrationTestDb(c =>
+                {
+                    GivenArtist(c, 1, "TestArtist");
+                    GivenAlbum(c, 1, 1, "TestAlbum1", release.ToJson());
+                    GivenTracks(c, 1, 1, 1, 10);
+                    GivenAlbum(c, 2, 1, "TestAlbum2", release.ToJson());
+                    GivenTracks(c, 1, 2, 100, 10);
+
+                });
+
+            VerifyAlbumReleases(db);
+            VerifyTracks(db, 1, 1, 10);
+            VerifyTracks(db, 2, 2, 10);
+        }
+
+        [Test]
+        public void migration_023_duplicate_foreignreleaseid()
+        {
+            var releases = Builder<add_release_groups_etc.LegacyAlbumRelease>
+                .CreateListOfSize(2)
+                .All()
+                .With(e => e.Id = "TestForeignId")
+                .Build();
+            
+            var db = WithMigrationTestDb(c =>
+                {
+                    GivenArtist(c, 1, "TestArtist");
+                    GivenAlbum(c, 1, 1, "TestAlbum1", releases[0].ToJson());
+                    GivenTracks(c, 1, 1, 1, 10);
+                    GivenAlbum(c, 2, 1, "TestAlbum2", releases[1].ToJson());
+                    GivenTracks(c, 1, 2, 100, 10);
+
+                });
+
+            VerifyAlbumReleases(db);
+            VerifyTracks(db, 1, 1, 10);
+            VerifyTracks(db, 2, 2, 10);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/MusicTests/RefreshAlbumServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MusicTests/RefreshAlbumServiceFixture.cs
@@ -56,6 +56,10 @@ namespace NzbDrone.Core.Test.MusicTests
             Mocker.GetMock<IReleaseService>()
                 .Setup(s => s.GetReleasesByAlbum(album1.Id))
                 .Returns(new List<AlbumRelease> { release });
+
+            Mocker.GetMock<IReleaseService>()
+                .Setup(s => s.GetReleasesByForeignReleaseId(It.IsAny<List<string>>()))
+                .Returns(new List<AlbumRelease> { release });
             
             Mocker.GetMock<IProvideAlbumInfo>()
                 .Setup(s => s.GetAlbumInfo(It.IsAny<string>()))

--- a/src/NzbDrone.Core.Test/MusicTests/RefreshArtistServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MusicTests/RefreshArtistServiceFixture.cs
@@ -48,6 +48,10 @@ namespace NzbDrone.Core.Test.MusicTests
             Mocker.GetMock<IAlbumService>()
                 .Setup(s => s.GetAlbumsByArtist(It.IsAny<int>()))
                 .Returns(new List<Album>());
+
+            Mocker.GetMock<IAlbumService>()
+                .Setup(s => s.FindById(It.IsAny<List<string>>()))
+                .Returns(new List<Album>());
             
             Mocker.GetMock<IProvideArtistInfo>()
                   .Setup(s => s.GetArtistInfo(It.IsAny<string>(), It.IsAny<int>()))

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -122,6 +122,7 @@
     <Compile Include="Datastore\MappingExtentionFixture.cs" />
     <Compile Include="Datastore\MarrDataLazyLoadingFixture.cs" />
     <Compile Include="Datastore\Migration\004_add_various_qualities_in_profileFixture.cs" />
+    <Compile Include="Datastore\Migration\023_add_release_groups_etcFixture.cs" />
     <Compile Include="Datastore\ObjectDatabaseFixture.cs" />
     <Compile Include="Datastore\PagingSpecExtensionsTests\PagingOffsetFixture.cs" />
     <Compile Include="Datastore\PagingSpecExtensionsTests\ToSortDirectionFixture.cs" />

--- a/src/NzbDrone.Core/Music/AlbumRepository.cs
+++ b/src/NzbDrone.Core/Music/AlbumRepository.cs
@@ -18,7 +18,8 @@ namespace NzbDrone.Core.Music
         Album FindByName(string cleanTitle);
         Album FindByTitle(int artistMetadataId, string title);
         Album FindByArtistAndName(string artistName, string cleanTitle);
-        Album FindById(string spotifyId);
+        Album FindById(string foreignId);
+        List<Album> FindById(List<string> foreignIds);
         PagingSpec<Album> AlbumsWithoutFiles(PagingSpec<Album> pagingSpec);
         PagingSpec<Album> AlbumsWhereCutoffUnmet(PagingSpec<Album> pagingSpec, List<QualitiesBelowCutoff> qualitiesBelowCutoff, List<LanguagesBelowCutoff> languagesBelowCutoff);
         List<Album> AlbumsBetweenDates(DateTime startDate, DateTime endDate, bool includeUnmonitored);
@@ -56,6 +57,16 @@ namespace NzbDrone.Core.Music
         public Album FindById(string foreignAlbumId)
         {
             return Query.Where(s => s.ForeignAlbumId == foreignAlbumId).SingleOrDefault();
+        }
+
+        public List<Album> FindById(List<string> ids)
+        {
+            string query = string.Format("SELECT Albums.* " +
+                                         "FROM Albums " +
+                                         "WHERE ForeignAlbumId IN ('{0}')",
+                                         string.Join("', '", ids));
+
+            return Query.QueryText(query).ToList();
         }
 
         public PagingSpec<Album> AlbumsWithoutFiles(PagingSpec<Album> pagingSpec)

--- a/src/NzbDrone.Core/Music/AlbumService.cs
+++ b/src/NzbDrone.Core/Music/AlbumService.cs
@@ -17,7 +17,8 @@ namespace NzbDrone.Core.Music
         List<Album> GetAlbumsByArtist(int artistId);
         List<Album> GetAlbumsByArtistMetadataId(int artistMetadataId);
         Album AddAlbum(Album newAlbum, string albumArtistId);
-        Album FindById(string spotifyId);
+        Album FindById(string foreignId);
+        List<Album> FindById(List<string> foreignIds);
         Album FindByTitle(int artistId, string title);
         Album FindByTitleInexact(int artistId, string title);
         void DeleteAlbum(int albumId, bool deleteFiles);
@@ -92,6 +93,11 @@ namespace NzbDrone.Core.Music
         public Album FindById(string lidarrId)
         {
             return _albumRepository.FindById(lidarrId);
+        }
+
+        public List<Album> FindById(List<string> ids)
+        {
+            return _albumRepository.FindById(ids);
         }
 
         public Album FindByTitle(int artistId, string title)

--- a/src/NzbDrone.Core/Music/TrackRepository.cs
+++ b/src/NzbDrone.Core/Music/TrackRepository.cs
@@ -18,6 +18,7 @@ namespace NzbDrone.Core.Music
         List<Track> GetTracksByAlbum(int albumId);
         List<Track> GetTracksByRelease(int albumReleaseId);
         List<Track> GetTracksByForeignReleaseId(string foreignReleaseId);
+        List<Track> GetTracksByForeignTrackIds(List<string> foreignTrackId);
         List<Track> GetTracksByMedium(int albumId, int mediumNumber);
         List<Track> GetTracksByFileId(int fileId);
         List<Track> TracksWithFiles(int artistId);
@@ -93,6 +94,16 @@ namespace NzbDrone.Core.Music
                                          "JOIN Tracks ON Tracks.AlbumReleaseId == AlbumReleases.Id " +
                                          "WHERE AlbumReleases.ForeignReleaseId = '{0}'",
                                          foreignReleaseId);
+
+            return Query.QueryText(query).ToList();
+        }
+
+        public List<Track> GetTracksByForeignTrackIds(List<string> ids)
+        {
+            string query = string.Format("SELECT Tracks.* " +
+                                         "FROM Tracks " +
+                                         "WHERE ForeignTrackId IN ('{0}')",
+                                         string.Join("', '", ids));
 
             return Query.QueryText(query).ToList();
         }

--- a/src/NzbDrone.Core/Music/TrackService.cs
+++ b/src/NzbDrone.Core/Music/TrackService.cs
@@ -25,6 +25,7 @@ namespace NzbDrone.Core.Music
         List<Track> GetTracksByAlbum(int albumId);
         List<Track> GetTracksByRelease(int albumReleaseId);
         List<Track> GetTracksByForeignReleaseId(string foreignReleaseId);
+        List<Track> GetTracksByForeignTrackIds(List<string> ids);
         List<Track> TracksWithFiles(int artistId);
         List<Track> GetTracksByFileId(int trackFileId);
         void UpdateTrack(Track track);
@@ -84,6 +85,11 @@ namespace NzbDrone.Core.Music
         public List<Track> GetTracksByForeignReleaseId(string foreignReleaseId)
         {
             return _trackRepository.GetTracksByForeignReleaseId(foreignReleaseId);
+        }
+
+        public List<Track> GetTracksByForeignTrackIds(List<string> ids)
+        {
+            return _trackRepository.GetTracksByForeignTrackIds(ids);
         }
 
         public Track FindTrackByTitle(int artistId, int albumId, int mediumNumber, int trackNumber, string releaseTitle)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixes a couple more issues that have shown up in sentry:
1. where `CurrentRelease` is completely null
1. where we have duplicate `ForeignReleaseId` (the previous fix would trip up when trying to assign `ReleaseId` to each `Track`

In 1., I have put in a dummy release so that the migration succeeds and the first medium's tracks will show up in the UI.  This will get deleted and re-created by the metadata refresh (as will all the associated tracks and mapped trackfiles).  For 2. I have put in a fake `ForeignReleaseId` - we know the `AlbumId` is unique so I've used that.  Again, this means the release and any tracks/trackfiles will be deleted and recreated but I can't think of a way we can avoid that.

The second commit fixes up the metadata refreshes.  It makes sure that we deal with the case where we have an item in the database but linked against a different parent.  We were previously querying for items by their parent (i.e. the item had to have the correct `parentId`) so we could end up trying to insert an item that already exists under a different (outdated) parent.

The new version gets items by both `foreignId` and `parent` to make sure that we capture both cases.  Then make sure to delete any that should no longer be present (because they have been deleted or moved to a new parent) before inserting new ones.

I think this will also fix `LIDARR-1A` about unique constraint failing on metadata insert.
