### PR TITLE
Cache result of GetAllArtists

### DIFF
--- a/src/NzbDrone.Common.Test/CacheTests/CachedFixture.cs
+++ b/src/NzbDrone.Common.Test/CacheTests/CachedFixture.cs
@@ -102,6 +102,33 @@ namespace NzbDrone.Common.Test.CacheTests
 
             hitCount.Should().BeInRange(3, 6);
         }
+
+        [Test]
+        public void should_clear_expired_when_they_expire()
+        {
+            int hitCount = 0;
+            var _mockCachedString = new Cached<string>();
+
+            Func<string> testfunc = () => {
+                hitCount++;
+                return null;
+            };
+
+            _cachedString.Values.Should().HaveCount(0);
+            
+            _cachedString.Get("key", testfunc, TimeSpan.FromMilliseconds(300));
+
+            Thread.Sleep(100);
+            
+            _cachedString.Values.Should().HaveCount(1);
+
+            _cachedString.Get("key", testfunc, TimeSpan.FromMilliseconds(300));
+
+            Thread.Sleep(300);
+
+            _cachedString.Values.Should().HaveCount(0);
+            hitCount.Should().Be(1);
+        }
     }
 
     public class Worker

--- a/src/NzbDrone.Common/Cache/Cached.cs
+++ b/src/NzbDrone.Common/Cache/Cached.cs
@@ -40,6 +40,11 @@ namespace NzbDrone.Common.Cache
         {
             Ensure.That(key, () => key).IsNotNullOrWhiteSpace();
             _store[key] = new CacheItem(value, lifetime);
+
+            if (lifetime != null)
+            {
+                System.Threading.Tasks.Task.Delay(lifetime.Value).ContinueWith(t => _store.TryRemove(key, out var temp));
+            }
         }
 
         public T Find(string key)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Searching for an artist using `FindByNameInexact` requires loading all the artists from the DB.  This slows down the RSS scan a lot since most releases won't match an artist and therefore will trigger the inexact search.

This PR speeds up the RSS sync again by caching the artists for 30 seconds the first time it's called.  The cache gets invalidated if we update/add/remove any artists. 

I have tweaked the `Cached` implementation to automatically remove entries once they expire. Previously they would  hang around until the next attempt to retrieve the cached value, at which point they would be updated.

#### Todos
- [x] Tests

