### PR TITLE
Remove typographic apostrophe

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerSearchTests/SearchDefinitionFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerSearchTests/SearchDefinitionFixture.cs
@@ -22,6 +22,8 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         [TestCase("American III: Solitary Man", "American+III+Solitary+Man")]
         [TestCase("Sad Clowns & Hillbillies", "Sad+Clowns+Hillbillies")]
         [TestCase("¿Quién sabe?", "Quien+sabe")]
+        [TestCase("Seal the Deal & Let’s Boogie", "Seal+the+Deal+Lets+Boogie")]
+        [TestCase("Section.80", "Section80")]
         public void should_replace_some_special_characters(string album, string expected)
         {
             Subject.AlbumTitle = album;

--- a/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
@@ -9,7 +9,7 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
 {
     public abstract class SearchCriteriaBase
     {
-        private static readonly Regex SpecialCharacter = new Regex(@"[`'.]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex SpecialCharacter = new Regex(@"[`'’.]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex NonWord = new Regex(@"[\W]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex BeginningThe = new Regex(@"^the\s", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 


### PR DESCRIPTION
#### Database Migration
YES | NO

#### Description
This is the [preferred apostrophe on musicbrainz](https://beta.musicbrainz.org/doc/Style/Miscellaneous). 


#### Todos
- [x] Tests

