### PR TITLE
Fixed: Missing album types, typos in type/status

### DIFF
--- a/src/NzbDrone.Core/Music/ReleaseStatus.cs
+++ b/src/NzbDrone.Core/Music/ReleaseStatus.cs
@@ -63,7 +63,7 @@ namespace NzbDrone.Core.Music
         }
 
         public static ReleaseStatus Official => new ReleaseStatus(0, "Official");
-        public static ReleaseStatus Promotional => new ReleaseStatus(1, "Promotional");
+        public static ReleaseStatus Promotion => new ReleaseStatus(1, "Promotion");
         public static ReleaseStatus Bootleg => new ReleaseStatus(2, "Bootleg");
         public static ReleaseStatus Pseudo => new ReleaseStatus(3, "Pseudo");
 
@@ -71,7 +71,7 @@ namespace NzbDrone.Core.Music
         public static readonly List<ReleaseStatus> All = new List<ReleaseStatus>
         {
             Official,
-            Promotional,
+            Promotion,
             Bootleg,
             Pseudo
         };

--- a/src/NzbDrone.Core/Music/SecondaryAlbumType.cs
+++ b/src/NzbDrone.Core/Music/SecondaryAlbumType.cs
@@ -86,8 +86,7 @@ namespace NzbDrone.Core.Music
             Remix,
             DJMix,
             Mixtape,
-            Demo,
-            Audiobook
+            Demo
         };
 
 

--- a/src/NzbDrone.Core/Music/SecondaryAlbumType.cs
+++ b/src/NzbDrone.Core/Music/SecondaryAlbumType.cs
@@ -70,7 +70,7 @@ namespace NzbDrone.Core.Music
         public static SecondaryAlbumType Audiobook => new SecondaryAlbumType(5, "Audiobook");
         public static SecondaryAlbumType Live => new SecondaryAlbumType(6, "Live");
         public static SecondaryAlbumType Remix => new SecondaryAlbumType(7, "Remix");
-        public static SecondaryAlbumType DJMix => new SecondaryAlbumType(8, "DJ-Mix");
+        public static SecondaryAlbumType DJMix => new SecondaryAlbumType(8, "DJ-mix");
         public static SecondaryAlbumType Mixtape => new SecondaryAlbumType(9, "Mixtape/Street");
         public static SecondaryAlbumType Demo => new SecondaryAlbumType(10, "Demo");
 
@@ -85,7 +85,9 @@ namespace NzbDrone.Core.Music
             Live,
             Remix,
             DJMix,
-            Mixtape
+            Mixtape,
+            Demo,
+            Audiobook
         };
 
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixes `DJ-Mix` to `DJ-mix` Secondary Type
Add `Audiobook` Secondary Type - Not quite convinced this is good idea?? Nope
Add `Demo` Secondary Type
Fixes `Promotional` to `Promotion` Release Status

Didn't do a DB migration, user have to re-create or add a new metadata profile to get the new types. Doesn't seem like a huge deal?

#### Issues Fixed or Closed by this PR
Fixes #589  
#453  - This is about as far as I want to go with supporting Audiobooks. Most musicbrainz entries have hundreds of tracks per book and the DB gets flooded fairly quickly which is why this was left out. Thoughts?
* 
