### PR TITLE
New: Select album release from manual import

### DIFF
--- a/frontend/src/Components/Form/AlbumReleaseSelectInputConnector.js
+++ b/frontend/src/Components/Form/AlbumReleaseSelectInputConnector.js
@@ -44,7 +44,7 @@ class AlbumReleaseSelectInputConnector extends Component {
       albumReleases
     } = this.props;
 
-    let updatedReleases = _.map(albumReleases.value, (e) => ({ ...e, monitored: false }));
+    const updatedReleases = _.map(albumReleases.value, (e) => ({ ...e, monitored: false }));
     _.find(updatedReleases, { foreignReleaseId: value }).monitored = true;
 
     this.props.onChange({ name, value: updatedReleases });

--- a/frontend/src/InteractiveImport/Album/SelectAlbumModalContentConnector.js
+++ b/frontend/src/InteractiveImport/Album/SelectAlbumModalContentConnector.js
@@ -65,6 +65,7 @@ class SelectAlbumModalContentConnector extends Component {
       this.props.updateInteractiveImportItem({
         id,
         album,
+        albumReleaseId: undefined,
         tracks: [],
         rejections: []
       });

--- a/frontend/src/InteractiveImport/AlbumRelease/SelectAlbumReleaseModal.js
+++ b/frontend/src/InteractiveImport/AlbumRelease/SelectAlbumReleaseModal.js
@@ -1,0 +1,37 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import Modal from 'Components/Modal/Modal';
+import SelectAlbumReleaseModalContentConnector from './SelectAlbumReleaseModalContentConnector';
+
+class SelectAlbumReleaseModal extends Component {
+
+  //
+  // Render
+
+  render() {
+    const {
+      isOpen,
+      onModalClose,
+      ...otherProps
+    } = this.props;
+
+    return (
+      <Modal
+        isOpen={isOpen}
+        onModalClose={onModalClose}
+      >
+        <SelectAlbumReleaseModalContentConnector
+          {...otherProps}
+          onModalClose={onModalClose}
+        />
+      </Modal>
+    );
+  }
+}
+
+SelectAlbumReleaseModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onModalClose: PropTypes.func.isRequired
+};
+
+export default SelectAlbumReleaseModal;

--- a/frontend/src/InteractiveImport/AlbumRelease/SelectAlbumReleaseModalContent.css
+++ b/frontend/src/InteractiveImport/AlbumRelease/SelectAlbumReleaseModalContent.css
@@ -1,0 +1,18 @@
+.modalBody {
+  composes: modalBody from 'Components/Modal/ModalBody.css';
+
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+}
+
+.filterInput {
+  composes: input from 'Components/Form/TextInput.css';
+
+  flex: 0 0 auto;
+  margin-bottom: 20px;
+}
+
+.scroller {
+  flex: 1 1 auto;
+}

--- a/frontend/src/InteractiveImport/AlbumRelease/SelectAlbumReleaseModalContent.js
+++ b/frontend/src/InteractiveImport/AlbumRelease/SelectAlbumReleaseModalContent.js
@@ -1,0 +1,91 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import Button from 'Components/Link/Button';
+import { scrollDirections } from 'Helpers/Props';
+import ModalContent from 'Components/Modal/ModalContent';
+import ModalHeader from 'Components/Modal/ModalHeader';
+import ModalBody from 'Components/Modal/ModalBody';
+import ModalFooter from 'Components/Modal/ModalFooter';
+import Table from 'Components/Table/Table';
+import TableBody from 'Components/Table/TableBody';
+import Scroller from 'Components/Scroller/Scroller';
+import TextInput from 'Components/Form/TextInput';
+import LoadingIndicator from 'Components/Loading/LoadingIndicator';
+import SelectAlbumReleaseRow from './SelectAlbumReleaseRow';
+import styles from './SelectAlbumReleaseModalContent.css';
+
+const columns = [
+  {
+    name: 'album',
+    label: 'Album',
+    isVisible: true
+  },
+  {
+    name: 'release',
+    label: 'Album Release',
+    isVisible: true
+  }
+];
+
+class SelectAlbumReleaseModalContent extends Component {
+
+  //
+  // Render
+
+  render() {
+    const {
+      albums,
+      onAlbumReleaseSelect,
+      onModalClose,
+      ...otherProps
+    } = this.props;
+
+    return (
+      <ModalContent onModalClose={onModalClose}>
+        <ModalHeader>
+          Manual Import - Select AlbumRelease
+        </ModalHeader>
+
+        <ModalBody
+          className={styles.modalBody}
+          scrollDirection={scrollDirections.NONE}
+        >
+          <Table
+            columns={columns}
+            {...otherProps}
+          >
+            <TableBody>
+              {
+                albums.map((item) => {
+                  return (
+                    <SelectAlbumReleaseRow
+                      key={item.album.id}
+                      matchedReleaseId={item.matchedReleaseId}
+                      columns={columns}
+                      onAlbumReleaseSelect={onAlbumReleaseSelect}
+                      {...item.album}
+                    />
+                  );
+                })
+              }
+            </TableBody>
+          </Table>
+        </ModalBody>
+
+        <ModalFooter>
+          <Button onPress={onModalClose}>
+            Cancel
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    );
+  }
+}
+
+SelectAlbumReleaseModalContent.propTypes = {
+  albums: PropTypes.arrayOf(PropTypes.object).isRequired,
+  onAlbumReleaseSelect: PropTypes.func.isRequired,
+  onModalClose: PropTypes.func.isRequired
+};
+
+export default SelectAlbumReleaseModalContent;

--- a/frontend/src/InteractiveImport/AlbumRelease/SelectAlbumReleaseModalContentConnector.js
+++ b/frontend/src/InteractiveImport/AlbumRelease/SelectAlbumReleaseModalContentConnector.js
@@ -1,0 +1,67 @@
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
+import {
+  updateInteractiveImportItem,
+  saveInteractiveImportItem
+} from 'Store/Actions/interactiveImportActions';
+import SelectAlbumReleaseModalContent from './SelectAlbumReleaseModalContent';
+
+function createMapStateToProps() {
+  return {};
+}
+
+const mapDispatchToProps = {
+  updateInteractiveImportItem,
+  saveInteractiveImportItem
+};
+
+class SelectAlbumReleaseModalContentConnector extends Component {
+
+  //
+  // Listeners
+
+  // onSortPress = (sortKey, sortDirection) => {
+  //   this.props.setInteractiveImportAlbumsSort({ sortKey, sortDirection });
+  // }
+
+  onAlbumReleaseSelect = (albumId, albumReleaseId) => {
+    const ids = this.props.importIdsByAlbum[albumId];
+
+    ids.forEach((id) => {
+      this.props.updateInteractiveImportItem({
+        id,
+        albumReleaseId,
+        tracks: [],
+        rejections: []
+      });
+    });
+
+    this.props.saveInteractiveImportItem({ id: ids });
+
+    this.props.onModalClose(true);
+  }
+
+  //
+  // Render
+
+  render() {
+    return (
+      <SelectAlbumReleaseModalContent
+        {...this.props}
+        onAlbumReleaseSelect={this.onAlbumReleaseSelect}
+      />
+    );
+  }
+}
+
+SelectAlbumReleaseModalContentConnector.propTypes = {
+  importIdsByAlbum: PropTypes.object.isRequired,
+  albums: PropTypes.arrayOf(PropTypes.object).isRequired,
+  updateInteractiveImportItem: PropTypes.func.isRequired,
+  onModalClose: PropTypes.func.isRequired
+};
+
+export default connect(createMapStateToProps, mapDispatchToProps)(SelectAlbumReleaseModalContentConnector);

--- a/frontend/src/InteractiveImport/AlbumRelease/SelectAlbumReleaseRow.css
+++ b/frontend/src/InteractiveImport/AlbumRelease/SelectAlbumReleaseRow.css
@@ -1,0 +1,3 @@
+.albumRow {
+  cursor: pointer;
+}

--- a/frontend/src/InteractiveImport/AlbumRelease/SelectAlbumReleaseRow.js
+++ b/frontend/src/InteractiveImport/AlbumRelease/SelectAlbumReleaseRow.js
@@ -1,0 +1,99 @@
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { kinds, sizes, inputTypes } from 'Helpers/Props';
+import TableRow from 'Components/Table/TableRow';
+import TableRowCell from 'Components/Table/Cells/TableRowCell';
+import RelativeDateCellConnector from 'Components/Table/Cells/RelativeDateCellConnector';
+import Label from 'Components/Label';
+import FormInputGroup from 'Components/Form/FormInputGroup';
+import titleCase from 'Utilities/String/titleCase';
+import styles from './SelectAlbumReleaseRow.css';
+
+class SelectAlbumReleaseRow extends Component {
+
+  //
+  // Listeners
+
+  onInputChange = ({ name, value }) => {
+    this.props.onAlbumReleaseSelect(parseInt(name), parseInt(value));
+  }
+
+  //
+  // Render
+
+  render() {
+    const {
+      id,
+      matchedReleaseId,
+      title,
+      disambiguation,
+      releases,
+      columns
+    } = this.props;
+
+    const extendedTitle = disambiguation ? `${title} (${disambiguation})` : title;
+
+    return (
+      <TableRow>
+        {
+          columns.map((column) => {
+            const {
+              name,
+              isVisible
+            } = column;
+
+            if (!isVisible) {
+              return null;
+            }
+
+            if (name === 'album') {
+              return (
+                <TableRowCell key={name}>
+                  {extendedTitle}
+                </TableRowCell>
+              );
+            }
+
+            if (name === 'release') {
+              return (
+                <TableRowCell key={name}>
+                  <FormInputGroup
+                    type={inputTypes.SELECT}
+                    name={id.toString()}
+                    values={_.map(releases, (r) => ({
+                      key: r.id,
+                      value: `${r.title}` +
+                        `${r.disambiguation ? ' (' : ''}${titleCase(r.disambiguation)}${r.disambiguation ? ')' : ''}` +
+                        `, ${r.mediumCount} med, ${r.trackCount} tracks` +
+                        `${r.country.length > 0 ? ', ' : ''}${r.country}` +
+                        `${r.format ? ', [' : ''}${r.format}${r.format ? ']' : ''}` +
+                        `${r.monitored ? ', Monitored' : ''}`
+                    }))}
+                    value={matchedReleaseId}
+                    onChange={this.onInputChange}
+                  />
+                </TableRowCell>
+              );
+            }
+
+            return null;
+          })
+        }
+      </TableRow>
+
+    );
+  }
+}
+
+SelectAlbumReleaseRow.propTypes = {
+  id: PropTypes.number.isRequired,
+  matchedReleaseId: PropTypes.number.isRequired,
+  title: PropTypes.string.isRequired,
+  disambiguation: PropTypes.string.isRequired,
+  releases: PropTypes.arrayOf(PropTypes.object).isRequired,
+  onAlbumReleaseSelect: PropTypes.func.isRequired,
+  columns: PropTypes.arrayOf(PropTypes.object).isRequired
+};
+
+export default SelectAlbumReleaseRow;

--- a/frontend/src/InteractiveImport/Artist/SelectArtistModalContentConnector.js
+++ b/frontend/src/InteractiveImport/Artist/SelectArtistModalContentConnector.js
@@ -46,6 +46,7 @@ class SelectArtistModalContentConnector extends Component {
         id,
         artist,
         album: undefined,
+        albumReleaseId: undefined,
         tracks: [],
         rejections: []
       });

--- a/frontend/src/InteractiveImport/Confirmation/ConfirmImportModal.js
+++ b/frontend/src/InteractiveImport/Confirmation/ConfirmImportModal.js
@@ -1,0 +1,37 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import Modal from 'Components/Modal/Modal';
+import ConfirmImportModalContentConnector from './ConfirmImportModalContentConnector';
+
+class ConfirmImportModal extends Component {
+
+  //
+  // Render
+
+  render() {
+    const {
+      isOpen,
+      onModalClose,
+      ...otherProps
+    } = this.props;
+
+    return (
+      <Modal
+        isOpen={isOpen}
+        onModalClose={onModalClose}
+      >
+        <ConfirmImportModalContentConnector
+          {...otherProps}
+          onModalClose={onModalClose}
+        />
+      </Modal>
+    );
+  }
+}
+
+ConfirmImportModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onModalClose: PropTypes.func.isRequired
+};
+
+export default ConfirmImportModal;

--- a/frontend/src/InteractiveImport/Confirmation/ConfirmImportModalContent.js
+++ b/frontend/src/InteractiveImport/Confirmation/ConfirmImportModalContent.js
@@ -1,0 +1,135 @@
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import Button from 'Components/Link/Button';
+import LoadingIndicator from 'Components/Loading/LoadingIndicator';
+import { kinds } from 'Helpers/Props';
+import ModalContent from 'Components/Modal/ModalContent';
+import ModalHeader from 'Components/Modal/ModalHeader';
+import ModalBody from 'Components/Modal/ModalBody';
+import ModalFooter from 'Components/Modal/ModalFooter';
+import Alert from 'Components/Alert';
+
+function formatAlbumFiles(items, album) {
+
+  return (
+    <div key={album.id}>
+      <b> {album.title} </b>
+      <ul>
+        {
+          _.sortBy(items, 'path').map((item) => {
+            return (
+              <li key={item.id}>
+                {item.path}
+              </li>
+            );
+          })
+        }
+      </ul>
+    </div>
+  );
+
+}
+
+class ConfirmImportModalContent extends Component {
+
+  //
+  // Lifecycle
+
+  componentDidUpdate(prevProps) {
+    const {
+      items,
+      isFetching,
+      isPopulated
+    } = this.props;
+
+    if (!isFetching && isPopulated && !items.length) {
+      this.props.onModalClose();
+      this.props.onConfirmImportPress();
+    }
+  }
+
+  //
+  // Render
+
+  render() {
+    const {
+      albums,
+      items,
+      onConfirmImportPress,
+      onModalClose,
+      isFetching,
+      isPopulated
+    } = this.props;
+
+    // don't render if nothing to do
+    if (!isFetching && isPopulated && !items.length) {
+      return null;
+    }
+
+    return (
+      <ModalContent onModalClose={onModalClose}>
+
+        {
+          !isFetching && isPopulated &&
+          <ModalHeader>
+            Are you sure?
+          </ModalHeader>
+        }
+
+        <ModalBody>
+          {
+            isFetching &&
+              <LoadingIndicator />
+          }
+
+          {
+            !isFetching && isPopulated &&
+              <div>
+                <Alert>
+                  You are already have files matched against a different release for the following albums.  If you continue, the existing files listed below <b>will be deleted</b> and the new files imported in their place.
+
+                  To avoid deleting existing files, press 'Cancel' and use 'Select Album Release' to select the currently monitored release.
+                </Alert>
+
+                { _.chain(items)
+                  .groupBy('albumId')
+                  .mapValues((value, key) => formatAlbumFiles(value, _.find(albums, (a) => a.id === parseInt(key))))
+                  .values()
+                  .value() }
+              </div>
+          }
+        </ModalBody>
+
+        {
+          !isFetching && isPopulated &&
+            <ModalFooter>
+              <Button onPress={onModalClose}>
+                Cancel
+              </Button>
+
+              <Button
+                kind={kinds.PRIMARY}
+                onPress={onConfirmImportPress}
+              >
+                Proceed
+              </Button>
+
+            </ModalFooter>
+        }
+
+      </ModalContent>
+    );
+  }
+}
+
+ConfirmImportModalContent.propTypes = {
+  albums: PropTypes.arrayOf(PropTypes.object).isRequired,
+  items: PropTypes.arrayOf(PropTypes.object).isRequired,
+  isFetching: PropTypes.bool.isRequired,
+  isPopulated: PropTypes.bool.isRequired,
+  onConfirmImportPress: PropTypes.func.isRequired,
+  onModalClose: PropTypes.func.isRequired
+};
+
+export default ConfirmImportModalContent;

--- a/frontend/src/InteractiveImport/Confirmation/ConfirmImportModalContentConnector.js
+++ b/frontend/src/InteractiveImport/Confirmation/ConfirmImportModalContentConnector.js
@@ -1,0 +1,61 @@
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
+import { fetchInteractiveImportTrackFiles, clearInteractiveImportTrackFiles } from 'Store/Actions/interactiveImportActions';
+import createClientSideCollectionSelector from 'Store/Selectors/createClientSideCollectionSelector';
+import ConfirmImportModalContent from './ConfirmImportModalContent';
+
+function createMapStateToProps() {
+  return createSelector(
+    createClientSideCollectionSelector('interactiveImport.trackFiles'),
+    (trackFiles) => {
+      return trackFiles;
+    }
+  );
+}
+
+const mapDispatchToProps = {
+  fetchInteractiveImportTrackFiles,
+  clearInteractiveImportTrackFiles
+};
+
+class ConfirmImportModalContentConnector extends Component {
+
+  //
+  // Lifecycle
+
+  componentDidMount() {
+    const {
+      albums
+    } = this.props;
+
+    this.props.fetchInteractiveImportTrackFiles({ albumId: albums.map((x) => x.id) });
+  }
+
+  componentWillUnmount() {
+    this.props.clearInteractiveImportTrackFiles();
+  }
+
+  //
+  // Render
+
+  render() {
+    return (
+      <ConfirmImportModalContent
+        {...this.props}
+      />
+    );
+  }
+}
+
+ConfirmImportModalContentConnector.propTypes = {
+  albums: PropTypes.arrayOf(PropTypes.object).isRequired,
+  items: PropTypes.arrayOf(PropTypes.object).isRequired,
+  fetchInteractiveImportTrackFiles: PropTypes.func.isRequired,
+  clearInteractiveImportTrackFiles: PropTypes.func.isRequired,
+  onModalClose: PropTypes.func.isRequired
+};
+
+export default connect(createMapStateToProps, mapDispatchToProps)(ConfirmImportModalContentConnector);

--- a/frontend/src/InteractiveImport/Interactive/InteractiveImportModalContent.css
+++ b/frontend/src/InteractiveImport/Interactive/InteractiveImportModalContent.css
@@ -19,13 +19,13 @@
 .centerButtons,
 .rightButtons {
   display: flex;
-  flex: 1 2 25%;
+  flex: 1 2 20%;
   flex-wrap: wrap;
 }
 
 .centerButtons {
   justify-content: center;
-  flex: 2 1 50%;
+  flex: 2 1 60%;
 }
 
 .rightButtons {

--- a/frontend/src/InteractiveImport/Interactive/InteractiveImportModalContentConnector.js
+++ b/frontend/src/InteractiveImport/Interactive/InteractiveImportModalContentConnector.js
@@ -3,7 +3,14 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
-import { fetchInteractiveImportItems, setInteractiveImportSort, clearInteractiveImport, setInteractiveImportMode, updateInteractiveImportItem } from 'Store/Actions/interactiveImportActions';
+import {
+  fetchInteractiveImportItems,
+  setInteractiveImportSort,
+  clearInteractiveImport,
+  setInteractiveImportMode,
+  updateInteractiveImportItem,
+  saveInteractiveImportItem
+} from 'Store/Actions/interactiveImportActions';
 import createClientSideCollectionSelector from 'Store/Selectors/createClientSideCollectionSelector';
 import { executeCommand } from 'Store/Actions/commandActions';
 import * as commandNames from 'Commands/commandNames';
@@ -24,6 +31,7 @@ const mapDispatchToProps = {
   setInteractiveImportMode,
   clearInteractiveImport,
   updateInteractiveImportItem,
+  saveInteractiveImportItem,
   executeCommand
 };
 

--- a/frontend/src/Store/Actions/interactiveImportActions.js
+++ b/frontend/src/Store/Actions/interactiveImportActions.js
@@ -17,6 +17,7 @@ import { set, update } from './baseActions';
 export const section = 'interactiveImport';
 
 const albumsSection = `${section}.albums`;
+const trackFilesSection = `${section}.trackFiles`;
 
 //
 // State
@@ -54,7 +55,16 @@ export const defaultState = {
     isPopulated: false,
     error: null,
     sortKey: 'albumTitle',
-    sortDirection: sortDirections.DESCENDING,
+    sortDirection: sortDirections.ASCENDING,
+    items: []
+  },
+
+  trackFiles: {
+    isFetching: false,
+    isPopulated: false,
+    error: null,
+    sortKey: 'relataivePath',
+    sortDirection: sortDirections.ASCENDING,
     items: []
   }
 };
@@ -80,6 +90,9 @@ export const FETCH_INTERACTIVE_IMPORT_ALBUMS = 'FETCH_INTERACTIVE_IMPORT_ALBUMS'
 export const SET_INTERACTIVE_IMPORT_ALBUMS_SORT = 'SET_INTERACTIVE_IMPORT_ALBUMS_SORT';
 export const CLEAR_INTERACTIVE_IMPORT_ALBUMS = 'CLEAR_INTERACTIVE_IMPORT_ALBUMS';
 
+export const FETCH_INTERACTIVE_IMPORT_TRACKFILES = 'FETCH_INTERACTIVE_IMPORT_TRACKFILES';
+export const CLEAR_INTERACTIVE_IMPORT_TRACKFILES = 'CLEAR_INTERACTIVE_IMPORT_TRACKFILES';
+
 //
 // Action Creators
 
@@ -95,6 +108,9 @@ export const setInteractiveImportMode = createAction(SET_INTERACTIVE_IMPORT_MODE
 export const fetchInteractiveImportAlbums = createThunk(FETCH_INTERACTIVE_IMPORT_ALBUMS);
 export const setInteractiveImportAlbumsSort = createAction(SET_INTERACTIVE_IMPORT_ALBUMS_SORT);
 export const clearInteractiveImportAlbums = createAction(CLEAR_INTERACTIVE_IMPORT_ALBUMS);
+
+export const fetchInteractiveImportTrackFiles = createThunk(FETCH_INTERACTIVE_IMPORT_TRACKFILES);
+export const clearInteractiveImportTrackFiles = createAction(CLEAR_INTERACTIVE_IMPORT_TRACKFILES);
 
 //
 // Action Handlers
@@ -137,7 +153,9 @@ export const actionHandlers = handleThunks({
 
   [SAVE_INTERACTIVE_IMPORT_ITEM]: createSaveProviderHandler(section, '/manualimport'),
 
-  [FETCH_INTERACTIVE_IMPORT_ALBUMS]: createFetchHandler('interactiveImport.albums', '/album')
+  [FETCH_INTERACTIVE_IMPORT_ALBUMS]: createFetchHandler(albumsSection, '/album'),
+
+  [FETCH_INTERACTIVE_IMPORT_TRACKFILES]: createFetchHandler(trackFilesSection, '/trackFile')
 });
 
 //
@@ -204,6 +222,12 @@ export const reducers = createHandleActions({
   [CLEAR_INTERACTIVE_IMPORT_ALBUMS]: (state) => {
     return updateSectionState(state, albumsSection, {
       ...defaultState.albums
+    });
+  },
+
+  [CLEAR_INTERACTIVE_IMPORT_TRACKFILES]: (state) => {
+    return updateSectionState(state, trackFilesSection, {
+      ...defaultState.trackFiles
     });
   }
 

--- a/frontend/src/Store/Actions/trackActions.js
+++ b/frontend/src/Store/Actions/trackActions.js
@@ -19,7 +19,7 @@ export const defaultState = {
   isPopulated: false,
   error: null,
   sortKey: 'mediumNumber',
-  sortDirection: sortDirections.DESCENDING,
+  sortDirection: sortDirections.ASCENDING,
   secondarySortKey: 'absoluteTrackNumber',
   secondarySortDirection: sortDirections.ASCENDING,
   items: [],

--- a/src/Lidarr.Api.V1/TrackFiles/TrackFileModule.cs
+++ b/src/Lidarr.Api.V1/TrackFiles/TrackFileModule.cs
@@ -78,11 +78,23 @@ namespace Lidarr.Api.V1.TrackFiles
 
             if (albumIdQuery.HasValue)
             {
-                int albumId = Convert.ToInt32(albumIdQuery.Value);
-                var album = _albumService.GetAlbum(albumId);
-                var albumArtist = _artistService.GetArtist(album.ArtistId);
+                Console.WriteLine(albumIdQuery.Value);
 
-                return _mediaFileService.GetFilesByAlbum(album.Id).ConvertAll(f => f.ToResource(albumArtist, _upgradableSpecification));
+                string albumIdValue = albumIdQuery.Value.ToString();
+
+                var albumIds = albumIdValue.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(e => Convert.ToInt32(e))
+                    .ToList();
+
+                var result = new List<TrackFileResource>();
+                foreach (var albumId in albumIds)
+                {
+                    var album = _albumService.GetAlbum(albumId);
+                    var albumArtist = _artistService.GetArtist(album.ArtistId);
+                    result.AddRange(_mediaFileService.GetFilesByAlbum(album.Id).ConvertAll(f => f.ToResource(albumArtist, _upgradableSpecification)));
+                }
+                
+                return result;
             }
 
             else

--- a/src/NzbDrone.Core.Test/MediaFiles/TrackImport/ImportDecisionMakerFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/TrackImport/ImportDecisionMakerFixture.cs
@@ -145,7 +145,7 @@ namespace NzbDrone.Core.Test.MediaFiles.TrackImport
             GivenAugmentationSuccess();
             GivenSpecifications(_albumpass1, _albumpass2, _albumpass3, _albumfail1, _albumfail2, _albumfail3);
 
-            Subject.GetImportDecisions(_audioFiles, new Artist(), null, downloadClientItem, null, false, false, false);
+            Subject.GetImportDecisions(_audioFiles, new Artist(), null, null, downloadClientItem, null, false, false, false);
 
             _albumfail1.Verify(c => c.IsSatisfiedBy(It.IsAny<LocalAlbumRelease>()), Times.Once());
             _albumfail2.Verify(c => c.IsSatisfiedBy(It.IsAny<LocalAlbumRelease>()), Times.Once());
@@ -162,7 +162,7 @@ namespace NzbDrone.Core.Test.MediaFiles.TrackImport
             GivenAugmentationSuccess();
             GivenSpecifications(_pass1, _pass2, _pass3, _fail1, _fail2, _fail3);
 
-            Subject.GetImportDecisions(_audioFiles, new Artist(), null, downloadClientItem, null, false, false, false);
+            Subject.GetImportDecisions(_audioFiles, new Artist(), null, null, downloadClientItem, null, false, false, false);
 
             _fail1.Verify(c => c.IsSatisfiedBy(It.IsAny<LocalTrack>()), Times.Once());
             _fail2.Verify(c => c.IsSatisfiedBy(It.IsAny<LocalTrack>()), Times.Once());
@@ -180,7 +180,7 @@ namespace NzbDrone.Core.Test.MediaFiles.TrackImport
             GivenSpecifications(_albumpass1, _albumpass2, _albumpass3, _albumfail1, _albumfail2, _albumfail3);
             GivenSpecifications(_pass1, _pass2, _pass3, _fail1, _fail2, _fail3);
 
-            Subject.GetImportDecisions(_audioFiles, new Artist(), null, downloadClientItem, null, false, false, false);
+            Subject.GetImportDecisions(_audioFiles, new Artist(), null, null, downloadClientItem, null, false, false, false);
 
             _fail1.Verify(c => c.IsSatisfiedBy(It.IsAny<LocalTrack>()), Times.Never());
             _fail2.Verify(c => c.IsSatisfiedBy(It.IsAny<LocalTrack>()), Times.Never());

--- a/src/NzbDrone.Core/MediaFiles/TrackImport/Identification/IdentificationService.cs
+++ b/src/NzbDrone.Core/MediaFiles/TrackImport/Identification/IdentificationService.cs
@@ -225,16 +225,17 @@ namespace NzbDrone.Core.MediaFiles.TrackImport.Identification
 
             // if we have a release ID, use that
             var releaseIds = localAlbumRelease.LocalTracks.Select(x => x.FileTrackInfo.ReleaseMBId).Distinct().ToList();
-            if (releaseIds.Count == 1 && releaseIds[0].IsNotNullOrWhiteSpace())
-            {
-                _logger.Debug("Selecting release from consensus ForeignReleaseId [{0}]", releaseIds[0]);
-                return _releaseService.GetReleasesByForeignReleaseId(releaseIds);
-            }
 
+            // if release is set (via manual import) that overrides everything
             if (release != null)
             {
                 _logger.Debug("Release {0} [{1} tracks] was forced", release, release.TrackCount);
-                candidateReleases = new List<AlbumRelease> { release };
+                return new List<AlbumRelease> { release };
+            }
+            else if (releaseIds.Count == 1 && releaseIds[0].IsNotNullOrWhiteSpace())
+            {
+                _logger.Debug("Selecting release from consensus ForeignReleaseId [{0}]", releaseIds[0]);
+                return _releaseService.GetReleasesByForeignReleaseId(releaseIds);
             }
             else if (album != null)
             {

--- a/src/NzbDrone.Core/MediaFiles/TrackImport/ImportDecisionMaker.cs
+++ b/src/NzbDrone.Core/MediaFiles/TrackImport/ImportDecisionMaker.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.MediaFiles.TrackImport
     {
         List<ImportDecision<LocalTrack>> GetImportDecisions(List<string> musicFiles, Artist artist);
         List<ImportDecision<LocalTrack>> GetImportDecisions(List<string> musicFiles, Artist artist, ParsedTrackInfo folderInfo);
-        List<ImportDecision<LocalTrack>> GetImportDecisions(List<string> musicFiles, Artist artist, Album album, DownloadClientItem downloadClientItem, ParsedTrackInfo folderInfo, bool filterExistingFiles, bool newDownload, bool singleRelease);
+        List<ImportDecision<LocalTrack>> GetImportDecisions(List<string> musicFiles, Artist artist, Album album, AlbumRelease albumRelease, DownloadClientItem downloadClientItem, ParsedTrackInfo folderInfo, bool filterExistingFiles, bool newDownload, bool singleRelease);
     }
 
     public class ImportDecisionMaker : IMakeImportDecision
@@ -59,15 +59,15 @@ namespace NzbDrone.Core.MediaFiles.TrackImport
 
         public List<ImportDecision<LocalTrack>> GetImportDecisions(List<string> musicFiles, Artist artist)
         {
-            return GetImportDecisions(musicFiles, artist, null, null, null, false, false, false);
+            return GetImportDecisions(musicFiles, artist, null, null, null, null, false, false, false);
         }
 
         public List<ImportDecision<LocalTrack>> GetImportDecisions(List<string> musicFiles, Artist artist, ParsedTrackInfo folderInfo)
         {
-            return GetImportDecisions(musicFiles, artist, null, null, folderInfo, false, true, false);
+            return GetImportDecisions(musicFiles, artist, null, null, null, folderInfo, false, true, false);
         }
 
-        public List<ImportDecision<LocalTrack>> GetImportDecisions(List<string> musicFiles, Artist artist, Album album, DownloadClientItem downloadClientItem, ParsedTrackInfo folderInfo, bool filterExistingFiles, bool newDownload, bool singleRelease)
+        public List<ImportDecision<LocalTrack>> GetImportDecisions(List<string> musicFiles, Artist artist, Album album, AlbumRelease albumRelease, DownloadClientItem downloadClientItem, ParsedTrackInfo folderInfo, bool filterExistingFiles, bool newDownload, bool singleRelease)
         {
             var watch = new System.Diagnostics.Stopwatch();
             watch.Start();
@@ -118,7 +118,7 @@ namespace NzbDrone.Core.MediaFiles.TrackImport
 
             _logger.Debug($"Tags parsed for {files.Count} files in {watch.ElapsedMilliseconds}ms");
 
-            var releases = _identificationService.Identify(localTracks, artist, album, null, newDownload, singleRelease);
+            var releases = _identificationService.Identify(localTracks, artist, album, albumRelease, newDownload, singleRelease);
 
             foreach (var release in releases)
             {

--- a/src/NzbDrone.Core/MediaFiles/TrackImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/TrackImport/Manual/ManualImportService.cs
@@ -101,7 +101,7 @@ namespace NzbDrone.Core.MediaFiles.TrackImport.Manual
                     return new List<ManualImportItem>();
                 }
 
-                var decision = _importDecisionMaker.GetImportDecisions(new List<string> { path }, null, null, null, null, false, true, false);
+                var decision = _importDecisionMaker.GetImportDecisions(new List<string> { path }, null, null, null, null, null, false, true, false);
                 var result = MapItem(decision.First(), Path.GetDirectoryName(path), downloadId);
                 _cache.Set(result.Id.ToString(), result);
 
@@ -130,7 +130,7 @@ namespace NzbDrone.Core.MediaFiles.TrackImport.Manual
 
             var folderInfo = Parser.Parser.ParseMusicTitle(directoryInfo.Name);
             var artistFiles = _diskScanService.GetAudioFiles(folder).ToList();
-            var decisions = _importDecisionMaker.GetImportDecisions(artistFiles, artist, null, null, folderInfo, filterExistingFiles, true, false);
+            var decisions = _importDecisionMaker.GetImportDecisions(artistFiles, artist, null, null, null, folderInfo, filterExistingFiles, true, false);
 
             return decisions.Select(decision => MapItem(decision, folder, downloadId)).ToList();
         }
@@ -143,7 +143,7 @@ namespace NzbDrone.Core.MediaFiles.TrackImport.Manual
             {
                 // generate dummy decisions that don't match the release
                 _logger.Debug("UpdateItems, group key: {0}", group.Key);
-                var decisions = _importDecisionMaker.GetImportDecisions(group.Select(x => x.Path).ToList(), group.First().Artist, group.First().Album, null, null, false, true, true);
+                var decisions = _importDecisionMaker.GetImportDecisions(group.Select(x => x.Path).ToList(), group.First().Artist, group.First().Album, group.First().Release, null, null, false, true, true);
 
                 foreach (var decision in decisions)
                 {


### PR DESCRIPTION
Also add a confirmation dialog if import would result in deleting files

#### Database Migration
NO

#### Description
Add ability to switch album release from the manual import dialog.  Enforces a single album release per album (though it is quite hard to get it into such a state given the UI setup).

Also add a confirmation dialog if the manual import would result in files on disk being deleted (i.e. switching release when the existing release already has files.

#### Issues Fixed or Closed by this PR

* Fixes #347 
