### PR TITLE
Add options to expand album types by default

### DIFF
--- a/frontend/src/Artist/Details/ArtistDetailsSeason.js
+++ b/frontend/src/Artist/Details/ArtistDetailsSeason.js
@@ -51,12 +51,18 @@ class ArtistDetailsSeason extends Component {
     const {
       name,
       onExpandPress,
-      items
+      items,
+      uiSettings
     } = this.props;
 
     const expand = _.some(items, (item) => {
-      return isAfter(item.releaseDate) ||
-             isAfter(item.releaseDate, { days: -365 });
+      return ((item.albumType === 'Album') && uiSettings.expandAlbumByDefault) ||
+        ((item.albumType === 'Single') && uiSettings.expandSingleByDefault) ||
+        ((item.albumType === 'EP') && uiSettings.expandEPByDefault) ||
+        ((item.albumType === 'Broadcast') && uiSettings.expandBroadcastByDefault) ||
+        ((item.albumType === 'Other') && uiSettings.expandOtherByDefault) ||
+        isAfter(item.releaseDate) ||
+        isAfter(item.releaseDate, { days: -365 });
     });
 
     onExpandPress(name, expand);
@@ -199,7 +205,7 @@ class ArtistDetailsSeason extends Component {
                     </Table> :
 
                     <div className={styles.noAlbums}>
-                      No albums in this group
+                      No releases in this group
                     </div>
                 }
                 <div className={styles.collapseButtonContainer}>
@@ -243,7 +249,8 @@ ArtistDetailsSeason.propTypes = {
   onTableOptionChange: PropTypes.func.isRequired,
   onExpandPress: PropTypes.func.isRequired,
   onSortPress: PropTypes.func.isRequired,
-  onMonitorAlbumPress: PropTypes.func.isRequired
+  onMonitorAlbumPress: PropTypes.func.isRequired,
+  uiSettings: PropTypes.object.isRequired
 };
 
 export default ArtistDetailsSeason;

--- a/frontend/src/Artist/Details/ArtistDetailsSeason.js
+++ b/frontend/src/Artist/Details/ArtistDetailsSeason.js
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import isAfter from 'Utilities/Date/isAfter';
 import getToggledRange from 'Utilities/Table/getToggledRange';
 import { icons, sortDirections } from 'Helpers/Props';
 import Icon from 'Components/Icon';
@@ -55,15 +54,12 @@ class ArtistDetailsSeason extends Component {
       uiSettings
     } = this.props;
 
-    const expand = _.some(items, (item) => {
-      return ((item.albumType === 'Album') && uiSettings.expandAlbumByDefault) ||
+    const expand = _.some(items, (item) =>
+      ((item.albumType === 'Album') && uiSettings.expandAlbumByDefault) ||
         ((item.albumType === 'Single') && uiSettings.expandSingleByDefault) ||
         ((item.albumType === 'EP') && uiSettings.expandEPByDefault) ||
         ((item.albumType === 'Broadcast') && uiSettings.expandBroadcastByDefault) ||
-        ((item.albumType === 'Other') && uiSettings.expandOtherByDefault) ||
-        isAfter(item.releaseDate) ||
-        isAfter(item.releaseDate, { days: -365 });
-    });
+        ((item.albumType === 'Other') && uiSettings.expandOtherByDefault));
 
     onExpandPress(name, expand);
   }

--- a/frontend/src/Artist/Details/ArtistDetailsSeasonConnector.js
+++ b/frontend/src/Artist/Details/ArtistDetailsSeasonConnector.js
@@ -8,6 +8,7 @@ import createDimensionsSelector from 'Store/Selectors/createDimensionsSelector';
 import createArtistSelector from 'Store/Selectors/createArtistSelector';
 import createCommandsSelector from 'Store/Selectors/createCommandsSelector';
 import createClientSideCollectionSelector from 'Store/Selectors/createClientSideCollectionSelector';
+import createUISettingsSelector from 'Store/Selectors/createUISettingsSelector';
 import { toggleAlbumsMonitored, setAlbumsTableOption, setAlbumsSort } from 'Store/Actions/albumActions';
 import { executeCommand } from 'Store/Actions/commandActions';
 import ArtistDetailsSeason from './ArtistDetailsSeason';
@@ -19,7 +20,8 @@ function createMapStateToProps() {
     createArtistSelector(),
     createCommandsSelector(),
     createDimensionsSelector(),
-    (label, albums, artist, commands, dimensions) => {
+    createUISettingsSelector(),
+    (label, albums, artist, commands, dimensions, uiSettings) => {
 
       const albumsInGroup = _.filter(albums.items, { albumType: label });
 
@@ -37,7 +39,8 @@ function createMapStateToProps() {
         sortKey: albums.sortKey,
         sortDirection: albums.sortDirection,
         artistMonitored: artist.monitored,
-        isSmallScreen: dimensions.isSmallScreen
+        isSmallScreen: dimensions.isSmallScreen,
+        uiSettings
       };
     }
   );

--- a/frontend/src/Settings/UI/UISettings.css
+++ b/frontend/src/Settings/UI/UISettings.css
@@ -1,0 +1,3 @@
+.columnGroup {
+  flex-direction: column;
+}

--- a/frontend/src/Settings/UI/UISettings.js
+++ b/frontend/src/Settings/UI/UISettings.js
@@ -10,6 +10,7 @@ import Form from 'Components/Form/Form';
 import FormGroup from 'Components/Form/FormGroup';
 import FormLabel from 'Components/Form/FormLabel';
 import FormInputGroup from 'Components/Form/FormInputGroup';
+import styles from './UISettings.css';
 
 export const firstDayOfWeekOptions = [
   { key: 0, value: 'Sunday' },
@@ -175,47 +176,48 @@ class UISettings extends Component {
                   </FormGroup>
 
                   <FormGroup>
-                    <FormLabel>Expand Items by Default </FormLabel>
-                    <FormInputGroup
-                      type={inputTypes.CHECK}
-                      name="expandAlbumByDefault"
-                      helpText="Expand Albums"
-                      onChange={onInputChange}
-                      {...settings.expandAlbumByDefault}
-                    />
+                    <FormLabel>Expand Items by Default</FormLabel>
+                    <div className={styles.columnGroup}>
+                      <FormInputGroup
+                        type={inputTypes.CHECK}
+                        name="expandAlbumByDefault"
+                        helpText="Albums"
+                        onChange={onInputChange}
+                        {...settings.expandAlbumByDefault}
+                      />
 
-                    <FormInputGroup
-                      type={inputTypes.CHECK}
-                      name="expandEPByDefault"
-                      helpText="Expand EPs"
-                      onChange={onInputChange}
-                      {...settings.expandEPByDefault}
-                    />
+                      <FormInputGroup
+                        type={inputTypes.CHECK}
+                        name="expandEPByDefault"
+                        helpText="EPs"
+                        onChange={onInputChange}
+                        {...settings.expandEPByDefault}
+                      />
 
-                    <FormInputGroup
-                      type={inputTypes.CHECK}
-                      name="expandSingleByDefault"
-                      helpText="Expand Singles"
-                      onChange={onInputChange}
-                      {...settings.expandSingleByDefault}
-                    />
+                      <FormInputGroup
+                        type={inputTypes.CHECK}
+                        name="expandSingleByDefault"
+                        helpText="Singles"
+                        onChange={onInputChange}
+                        {...settings.expandSingleByDefault}
+                      />
 
-                    <FormInputGroup
-                      type={inputTypes.CHECK}
-                      name="expandBroadcastByDefault"
-                      helpText="Expand Broadcast items"
-                      onChange={onInputChange}
-                      {...settings.expandBroadcastByDefault}
-                    />
+                      <FormInputGroup
+                        type={inputTypes.CHECK}
+                        name="expandBroadcastByDefault"
+                        helpText="Broadcast"
+                        onChange={onInputChange}
+                        {...settings.expandBroadcastByDefault}
+                      />
 
-                    <FormInputGroup
-                      type={inputTypes.CHECK}
-                      name="expandOtherByDefault"
-                      helpText="Expand Other items"
-                      onChange={onInputChange}
-                      {...settings.expandOtherByDefault}
-                    />
-
+                      <FormInputGroup
+                        type={inputTypes.CHECK}
+                        name="expandOtherByDefault"
+                        helpText="Other"
+                        onChange={onInputChange}
+                        {...settings.expandOtherByDefault}
+                      />
+                    </div>
                   </FormGroup>
                 </FieldSet>
               </Form>

--- a/frontend/src/Settings/UI/UISettings.js
+++ b/frontend/src/Settings/UI/UISettings.js
@@ -173,6 +173,50 @@ class UISettings extends Component {
                       {...settings.enableColorImpairedMode}
                     />
                   </FormGroup>
+
+                  <FormGroup>
+                    <FormLabel>Expand Items by Default </FormLabel>
+                    <FormInputGroup
+                      type={inputTypes.CHECK}
+                      name="expandAlbumByDefault"
+                      helpText="Expand Albums"
+                      onChange={onInputChange}
+                      {...settings.expandAlbumByDefault}
+                    />
+
+                    <FormInputGroup
+                      type={inputTypes.CHECK}
+                      name="expandEPByDefault"
+                      helpText="Expand EPs"
+                      onChange={onInputChange}
+                      {...settings.expandEPByDefault}
+                    />
+
+                    <FormInputGroup
+                      type={inputTypes.CHECK}
+                      name="expandSingleByDefault"
+                      helpText="Expand Singles"
+                      onChange={onInputChange}
+                      {...settings.expandSingleByDefault}
+                    />
+
+                    <FormInputGroup
+                      type={inputTypes.CHECK}
+                      name="expandBroadcastByDefault"
+                      helpText="Expand Broadcast items"
+                      onChange={onInputChange}
+                      {...settings.expandBroadcastByDefault}
+                    />
+
+                    <FormInputGroup
+                      type={inputTypes.CHECK}
+                      name="expandOtherByDefault"
+                      helpText="Expand Other items"
+                      onChange={onInputChange}
+                      {...settings.expandOtherByDefault}
+                    />
+
+                  </FormGroup>
                 </FieldSet>
               </Form>
           }

--- a/src/Lidarr.Api.V1/Config/UiConfigResource.cs
+++ b/src/Lidarr.Api.V1/Config/UiConfigResource.cs
@@ -16,6 +16,12 @@ namespace Lidarr.Api.V1.Config
         public bool ShowRelativeDates { get; set; }
 
         public bool EnableColorImpairedMode { get; set; }
+
+        public bool ExpandAlbumByDefault { get; set; }
+        public bool ExpandSingleByDefault { get; set; }
+        public bool ExpandEPByDefault { get; set; }
+        public bool ExpandBroadcastByDefault { get; set; }
+        public bool ExpandOtherByDefault { get; set; }
     }
 
     public static class UiConfigResourceMapper
@@ -33,6 +39,12 @@ namespace Lidarr.Api.V1.Config
                 ShowRelativeDates = model.ShowRelativeDates,
 
                 EnableColorImpairedMode = model.EnableColorImpairedMode,
+
+                ExpandAlbumByDefault = model.ExpandAlbumByDefault,
+                ExpandSingleByDefault = model.ExpandSingleByDefault,
+                ExpandEPByDefault = model.ExpandEPByDefault,
+                ExpandBroadcastByDefault = model.ExpandBroadcastByDefault,
+                ExpandOtherByDefault = model.ExpandOtherByDefault
             };
         }
     }

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -314,6 +314,41 @@ namespace NzbDrone.Core.Configuration
             set { SetValue("EnableColorImpairedMode", value); }
         }
 
+        public bool ExpandAlbumByDefault
+        {
+            get { return GetValueBoolean("ExpandAlbumByDefault", false); }
+
+            set { SetValue("ExpandAlbumByDefault", value); }
+        }
+
+        public bool ExpandEPByDefault
+        {
+            get { return GetValueBoolean("ExpandEPByDefault", false); }
+
+            set { SetValue("ExpandEPByDefault", value); }
+        }
+
+        public bool ExpandSingleByDefault
+        {
+            get { return GetValueBoolean("ExpandSingleByDefault", false); }
+
+            set { SetValue("ExpandSingleByDefault", value); }
+        }
+
+        public bool ExpandBroadcastByDefault
+        {
+            get { return GetValueBoolean("ExpandBroadcastByDefault", false); }
+
+            set { SetValue("ExpandBroadcastByDefault", value); }
+        }
+
+        public bool ExpandOtherByDefault
+        {
+            get { return GetValueBoolean("ExpandOtherByDefault", false); }
+
+            set { SetValue("ExpandOtherByDefault", value); }
+        }
+
         public bool CleanupMetadataImages
         {
             get { return GetValueBoolean("CleanupMetadataImages", true); }

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -57,6 +57,12 @@ namespace NzbDrone.Core.Configuration
         string TimeFormat { get; set; }
         bool ShowRelativeDates { get; set; }
         bool EnableColorImpairedMode { get; set; }
+        
+        bool ExpandAlbumByDefault { get; set; }
+        bool ExpandSingleByDefault { get; set; }
+        bool ExpandEPByDefault { get; set; }
+        bool ExpandBroadcastByDefault { get; set; }
+        bool ExpandOtherByDefault { get; set; }
 
         //Internal
         bool CleanupMetadataImages { get; set; }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Add some checkboxes to UI settings to specify which (if any) release types should be expanded by  default.

#### Issues Fixed or Closed by this PR

* fixes #567 
