### PR TITLE
Fix: Don't use scene name for tracks when track naming disabled

### DIFF
--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
@@ -303,6 +303,17 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
             Subject.BuildTrackFileName(new List<Track> { _track1 }, _artist, _album, _trackFile)
                    .Should().Be(Path.GetFileNameWithoutExtension(_trackFile.RelativePath));
         }
+        
+        [Test]
+        public void use_file_name_when_sceneName_is_not_null()
+        {
+            _namingConfig.RenameTracks = false;
+            _trackFile.RelativePath = "Linkin Park - 06 - Test";
+            _trackFile.SceneName = "SceneName";
+
+            Subject.BuildTrackFileName(new List<Track> { _track1 }, _artist, _album, _trackFile)
+                   .Should().Be(Path.GetFileNameWithoutExtension(_trackFile.RelativePath));
+        }
 
         [Test]
         public void use_path_when_sceneName_and_relative_path_are_null()
@@ -314,7 +325,6 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
             Subject.BuildTrackFileName(new List<Track> { _track1 }, _artist, _album, _trackFile)
                    .Should().Be(Path.GetFileNameWithoutExtension(_trackFile.Path));
         }
-
 
         [Test]
         public void should_not_clean_track_title_if_there_is_only_one()

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -93,7 +93,7 @@ namespace NzbDrone.Core.Organizer
 
             if (!namingConfig.RenameTracks)
             {
-                return GetOriginalTitle(trackFile);
+                return GetOriginalFileName(trackFile);
             }
 
             if (namingConfig.StandardTrackFormat.IsNullOrWhiteSpace())


### PR DESCRIPTION
#### Database Migration
NO

#### Description
After #580 when track naming is disabled it attempts to use the newly set `SceneName`.  But this is the same for each track, so only a single track will import and the rest fails.

This change forces `FileNameBulider` to always use the original file name, not the `SceneName`, when track naming is disabled
