### PR TITLE
Fixed: Cache fingerprints and relax fpcalc health check

### DIFF
--- a/src/NzbDrone.Core/HealthCheck/Checks/FpcalcCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/FpcalcCheck.cs
@@ -32,7 +32,7 @@ namespace NzbDrone.Core.HealthCheck.Checks
             }
 
             var fpcalcVersion = _fingerprintingService.FpcalcVersion();
-            if (fpcalcVersion == null || fpcalcVersion < new Version("1.4.3"))
+            if (fpcalcVersion == null || fpcalcVersion < new Version("1.2.0"))
             {
                 return new HealthCheck(GetType(), HealthCheckResult.Warning, $"You have an old version of fpcalc.  Please upgrade to 1.4.3.", "#fpcalc-upgrade");
             }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Relax fpcalc health check to the version in the LSIO container, at least until they update.  Add caching to fingerprint calculation to speed up re-calculation in Manual Import.
