### PR TITLE
Fixed: Sentry version mismatch

### DIFF
--- a/src/NzbDrone.Common/Instrumentation/Sentry/SentryCleanser.cs
+++ b/src/NzbDrone.Common/Instrumentation/Sentry/SentryCleanser.cs
@@ -66,15 +66,20 @@ namespace NzbDrone.Common.Instrumentation.Sentry
                 return null;
             }
 
-            var rootDir = OsInfo.IsWindows ? "\\src\\" : "/src/";
-            var index = path.IndexOf(rootDir, StringComparison.Ordinal);
-
-            if (index <= 0)
+            // the paths in the stacktrace depend on where it was compiled,
+            // not the current OS
+            var rootDirs = new [] { "\\src\\", "/src/" };
+            foreach (var rootDir in rootDirs)
             {
-                return path;
+                var index = path.IndexOf(rootDir, StringComparison.Ordinal);
+
+                if (index > 0)
+                {
+                    return path.Substring(index + rootDir.Length - 1);
+                }
             }
 
-            return path.Substring(index + rootDir.Length - 1);
+            return path;
         }
     }
 }

--- a/src/NzbDrone.Common/NzbDrone.Common.csproj
+++ b/src/NzbDrone.Common/NzbDrone.Common.csproj
@@ -57,8 +57,8 @@
     <Reference Include="Sentry, Version=1.1.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Sentry.1.1.2\lib\net461\Sentry.dll</HintPath>
     </Reference>
-    <Reference Include="Sentry.Protocol, Version=1.0.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Sentry.Protocol.1.0.4\lib\net46\Sentry.Protocol.dll</HintPath>
+    <Reference Include="Sentry.Protocol, Version=1.0.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sentry.Protocol.1.0.3\lib\net46\Sentry.Protocol.dll</HintPath>
     </Reference>
     <Reference Include="Sentry.PlatformAbstractions, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Sentry.PlatformAbstractions.1.0.0\lib\net45\Sentry.PlatformAbstractions.dll</HintPath>

--- a/src/NzbDrone.Common/packages.config
+++ b/src/NzbDrone.Common/packages.config
@@ -6,6 +6,6 @@
   <package id="NLog" version="4.5.4" targetFramework="net461" />
   <package id="Sentry" version="1.1.2" targetFramework="net461" />
   <package id="Sentry.PlatformAbstractions" version="1.0.0" targetFramework="net461" />
-  <package id="Sentry.Protocol" version="1.0.4" targetFramework="net461" />
+  <package id="Sentry.Protocol" version="1.0.3" targetFramework="net461" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fix mismatched sentry packages preventing app starting on windows.

Also fix `ShortenPath` when compiled on one OS and run on another.