### PR TITLE
Various small fixes

### DIFF
--- a/src/NzbDrone.Common/Instrumentation/Sentry/SentryTarget.cs
+++ b/src/NzbDrone.Common/Instrumentation/Sentry/SentryTarget.cs
@@ -267,7 +267,8 @@ namespace NzbDrone.Common.Instrumentation.Sentry
 
                         if (message.IsNotNullOrWhiteSpace() && message.Length < 200)
                         {
-                            sentryFingerprint.Add(message);
+                            // Windows gives a trailing '.' for NullReferenceException but mono doesn't
+                            sentryFingerprint.Add(message.TrimEnd('.'));
                         }
                     }
                 }

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -362,6 +362,7 @@
     <Compile Include="ParserTests\NormalizeTitleFixture.cs" />
     <Compile Include="ParserTests\ParserFixture.cs" />
     <Compile Include="ParserTests\ParsingServiceTests\GetArtistFixture.cs" />
+    <Compile Include="ParserTests\ParsingServiceTests\GetAlbumsFixture.cs" />
     <Compile Include="ParserTests\PathParserFixture.cs" />
     <Compile Include="ParserTests\QualityParserFixture.cs" />
     <Compile Include="ParserTests\ReleaseGroupParserFixture.cs" />

--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/GetAlbumsFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/GetAlbumsFixture.cs
@@ -1,0 +1,38 @@
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Core.Parser;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Music;
+using FizzWare.NBuilder;
+using NzbDrone.Core.IndexerSearch.Definitions;
+using NzbDrone.Core.Parser.Model;
+using FluentAssertions;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
+{
+    [TestFixture]
+    public class GetAlbumsFixture : CoreTest<ParsingService>
+    {
+        [Test]
+        public void should_not_fail_if_search_criteria_contains_multiple_albums_with_the_same_name()
+        {
+            var artist = Builder<Artist>.CreateNew().Build();
+            var albums = Builder<Album>.CreateListOfSize(2).All().With(x => x.Title = "IdenticalTitle").Build().ToList();
+            var criteria = new AlbumSearchCriteria {
+                Artist = artist,
+                Albums = albums
+            };
+
+            var parsed = new ParsedAlbumInfo {
+                AlbumTitle = "IdenticalTitle"
+            };
+            
+            Subject.GetAlbums(parsed, artist, criteria).Should().BeEquivalentTo(new List<Album>());
+
+            Mocker.GetMock<IAlbumService>()
+                .Verify(s => s.FindByTitle(artist.ArtistMetadataId, "IdenticalTitle"), Times.Once());
+        }
+    }
+}

--- a/src/NzbDrone.Core/HealthCheck/Checks/FpcalcCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/FpcalcCheck.cs
@@ -32,7 +32,7 @@ namespace NzbDrone.Core.HealthCheck.Checks
             }
 
             var fpcalcVersion = _fingerprintingService.FpcalcVersion();
-            if (fpcalcVersion == null || fpcalcVersion < new Version("1.2.0"))
+            if (fpcalcVersion == null || fpcalcVersion < new Version("1.4.3"))
             {
                 return new HealthCheck(GetType(), HealthCheckResult.Warning, $"You have an old version of fpcalc.  Please upgrade to 1.4.3.", "#fpcalc-upgrade");
             }

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -149,7 +149,7 @@ namespace NzbDrone.Core.Parser
 
             if (searchCriteria != null)
             {
-                albumInfo = searchCriteria.Albums.SingleOrDefault(e => e.Title == albumTitle);
+                albumInfo = searchCriteria.Albums.ExclusiveOrDefault(e => e.Title == albumTitle);
             }
 
             if (albumInfo == null)

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -18,7 +18,6 @@ namespace NzbDrone.Core.Parser
         RemoteAlbum Map(ParsedAlbumInfo parsedAlbumInfo, SearchCriteriaBase searchCriteria = null);
         RemoteAlbum Map(ParsedAlbumInfo parsedAlbumInfo, int artistId, IEnumerable<int> albumIds);
         List<Album> GetAlbums(ParsedAlbumInfo parsedAlbumInfo, Artist artist, SearchCriteriaBase searchCriteria = null);
-        Album GetAlbum(Artist artist, ParsedTrackInfo parsedTrackInfo);
 
         // Music stuff here
         Album GetLocalAlbum(string filename, Artist artist);
@@ -235,51 +234,6 @@ namespace NzbDrone.Core.Parser
                 .ToList();
 
             return tracksInAlbum.Count == 1 ? _albumService.GetAlbum(tracksInAlbum.First().AlbumId) : null;
-        }
-
-        public Album GetAlbum(Artist artist, ParsedTrackInfo parsedTrackInfo)
-        {
-            Album album = null;
-
-            if (parsedTrackInfo == null)
-            {
-                return null;
-            }
-
-            if (parsedTrackInfo.ReleaseMBId.IsNotNullOrWhiteSpace())
-            {
-                album = _albumService.FindAlbumByRelease(parsedTrackInfo.ReleaseMBId);
-            }
-
-            if (album == null && parsedTrackInfo.AlbumTitle.IsNullOrWhiteSpace())
-            {
-                _logger.Debug("Album title could not be parsed for {0}", parsedTrackInfo);
-                return null;
-            }
-
-            var cleanAlbumTitle = Parser.CleanAlbumTitle(parsedTrackInfo.AlbumTitle);
-            _logger.Debug("Cleaning Album title of common matching issues. Cleaned album title is '{0}'", cleanAlbumTitle);
-
-            if (album == null)
-            {
-                album = _albumService.FindByTitle(artist.ArtistMetadataId, cleanAlbumTitle);
-            }
-
-            if (album == null)
-            {
-                _logger.Debug("Trying inexact album match for {0}", parsedTrackInfo);
-                album = _albumService.FindByTitleInexact(artist.ArtistMetadataId, cleanAlbumTitle);
-            }
-
-            if (album == null)
-            {
-                _logger.Debug("Parsed album title not found in Db for {0}", parsedTrackInfo);
-                return null;
-            }
-
-            _logger.Debug("Album {0} selected for {1}", album, parsedTrackInfo);
-
-            return album;
         }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- Remove unused function from `ParsingService` (following importer rewrite)
- Fix `NullReferenceException` in `GetAlbums`
- Make fpcalc check strict again now that the LSIO docker has updated to bionic
- Strip trailing `.` from exception messages in Sentry to try to get events to group across platforms
