### PR TITLE
Partially recover databases for users affected by bad 023 migration

### DIFF
--- a/src/NzbDrone.Core/Datastore/Migration/028_clean_artistmetadata_table.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/028_clean_artistmetadata_table.cs
@@ -1,0 +1,55 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(028)]
+    public class clean_artist_metadata_table : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            // Remove any artists linked to missing metadata
+            Execute.Sql(@"DELETE FROM Artists
+                          WHERE Id in (
+                          SELECT Artists.Id from Artists
+                          LEFT OUTER JOIN ArtistMetadata ON Artists.ArtistMetadataId = ArtistMetadata.Id
+                          WHERE ArtistMetadata.Id IS NULL)");
+
+            // Remove any albums linked to missing metadata
+            Execute.Sql(@"DELETE FROM Albums
+                          WHERE Id in (
+                          SELECT Albums.Id from Albums
+                          LEFT OUTER JOIN ArtistMetadata ON Albums.ArtistMetadataId = ArtistMetadata.Id
+                          WHERE ArtistMetadata.Id IS NULL)");
+
+            // Remove any album releases linked to albums that were deleted
+            Execute.Sql(@"DELETE FROM AlbumReleases
+                          WHERE Id in (
+                          SELECT AlbumReleases.Id from AlbumReleases
+                          LEFT OUTER JOIN Albums ON Albums.Id = AlbumReleases.AlbumId
+                          WHERE Albums.Id IS NULL)");
+
+            // Remove any tracks linked to album releases that were deleted
+            Execute.Sql(@"DELETE FROM Tracks
+                          WHERE Id in (
+                          SELECT Tracks.Id from Tracks
+                          LEFT OUTER JOIN AlbumReleases ON Tracks.AlbumReleaseId = AlbumReleases.Id
+                          WHERE AlbumReleases.Id IS NULL)");
+
+            // Remove any tracks linked to the original missing metadata
+            Execute.Sql(@"DELETE FROM Tracks
+                          WHERE Id in (
+                          SELECT Tracks.Id from Tracks
+                          LEFT OUTER JOIN ArtistMetadata ON Tracks.ArtistMetadataId = ArtistMetadata.Id
+                          WHERE ArtistMetadata.Id IS NULL)");
+
+            // Remove any trackfiles linked to the deleted tracks
+            Execute.Sql(@"DELETE FROM TrackFiles
+                          WHERE Id IN (
+                          SELECT TrackFiles.Id FROM TrackFiles
+                          LEFT OUTER JOIN Tracks
+                          ON TrackFiles.Id = Tracks.TrackFileId
+                          WHERE Tracks.Id IS NULL)");
+        }
+    }
+}

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -201,6 +201,7 @@
     <Compile Include="Datastore\Migration\024_clear_media_info.cs" />
     <Compile Include="Datastore\Migration\025_rename_release_profiles.cs" />
     <Compile Include="Datastore\Migration\026_rename_quality_profiles_add_upgrade_allowed.cs" />
+    <Compile Include="Datastore\Migration\028_clean_artistmetadata_table.cs" />
     <Compile Include="Datastore\Migration\Framework\MigrationContext.cs" />
     <Compile Include="Datastore\Migration\Framework\MigrationController.cs" />
     <Compile Include="Datastore\Migration\Framework\MigrationDbFactory.cs" />


### PR DESCRIPTION
#### Database Migration
YES

#### Description
It appears some users have broken databases because they are missing the artist metadata entries corresponding to some artists.

I believe this happened because we had an over-eager housekeeper briefly, fixed in 6723f32abb1e6faf7cba6ae32c3e3a9f6c45b581.

This does a one-off cleanup (with a migration) to remove any Artists/Albums/Tracks linked to this metadata entry, and also any AlbumReleases/Albums/Tracks/Trackfiles linked to now missing items.

In my testing this recovers the database and any the missing artists can be successfully re-imported.
