### PR TITLE
Fixed: Filter TinyIoC.TinyIoCResolutionException from Sentry

### DIFF
--- a/src/NzbDrone.Common/Instrumentation/Sentry/SentryTarget.cs
+++ b/src/NzbDrone.Common/Instrumentation/Sentry/SentryTarget.cs
@@ -38,7 +38,9 @@ namespace NzbDrone.Common.Instrumentation.Sentry
             // UnauthorizedAccessExceptions will just be user configuration issues
             "UnauthorizedAccessException",
             // Filter out people stuck in boot loops
-            "CorruptDatabaseException"
+            "CorruptDatabaseException",
+            // This also filters some people in boot loops
+            "TinyIoC.TinyIoCResolutionException"
         };
 
         private static readonly List<string> FilteredExceptionMessages = new List<string> {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Filter another type of event from sentry that can occur when a user has incorrect permissions and creates a bootloop.
