### PR TITLE
Fixed: Make artist stats update when album (un)monitored

### DIFF
--- a/src/Lidarr.Api.V1/Artist/ArtistModule.cs
+++ b/src/Lidarr.Api.V1/Artist/ArtistModule.cs
@@ -25,6 +25,7 @@ namespace Lidarr.Api.V1.Artist
 {
     public class ArtistModule : LidarrRestModuleWithSignalR<ArtistResource, NzbDrone.Core.Music.Artist>, 
                                 IHandle<AlbumImportedEvent>,
+                                IHandle<AlbumEditedEvent>,
                                 IHandle<TrackFileDeletedEvent>,
                                 IHandle<ArtistUpdatedEvent>,       
                                 IHandle<ArtistEditedEvent>,  
@@ -240,6 +241,11 @@ namespace Lidarr.Api.V1.Artist
         public void Handle(AlbumImportedEvent message)
         {
             BroadcastResourceChange(ModelAction.Updated, GetArtistResource(message.Artist));
+        }
+
+        public void Handle(AlbumEditedEvent message)
+        {
+            BroadcastResourceChange(ModelAction.Updated, GetArtistResource(message.Album.Artist.Value));
         }
 
         public void Handle(TrackFileDeletedEvent message)

--- a/src/NzbDrone.Core/Music/AlbumService.cs
+++ b/src/NzbDrone.Core/Music/AlbumService.cs
@@ -282,12 +282,21 @@ namespace NzbDrone.Core.Music
             var album = _albumRepository.Get(albumId);
             _albumRepository.SetMonitoredFlat(album, monitored);
 
+            // publish album edited event so artist stats update
+            _eventAggregator.PublishEvent(new AlbumEditedEvent(album, album));
+
             _logger.Debug("Monitored flag for Album:{0} was set to {1}", albumId, monitored);
         }
 
         public void SetMonitored(IEnumerable<int> ids, bool monitored)
         {
             _albumRepository.SetMonitored(ids, monitored);
+
+            // publish album edited event so artist stats update
+            foreach (var album in _albumRepository.Get(ids))
+            {
+                _eventAggregator.PublishEvent(new AlbumEditedEvent(album, album));
+            }
         }
 
         public List<Album> UpdateAlbums(List<Album> albums)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Make sure artist stats get invalidate when an album monitored or unmonitored and push the updated stats to the frontend.
