### PR TITLE
New: Housekeeper to tidy up albums with multiple monitored releases

### DIFF
--- a/src/NzbDrone.Core.Test/Housekeeping/Housekeepers/FixMultipleAlbumReleasesMonitoredFixture.cs
+++ b/src/NzbDrone.Core.Test/Housekeeping/Housekeepers/FixMultipleAlbumReleasesMonitoredFixture.cs
@@ -1,0 +1,106 @@
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Housekeeping.Housekeepers;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Music;
+using System.Linq;
+using NzbDrone.Test.Common;
+using Moq;
+
+namespace NzbDrone.Core.Test.Housekeeping.Housekeepers
+{
+    [TestFixture]
+    public class FixMultipleAlbumReleasesMonitoredFixture : DbTest<FixMultipleAlbumReleasesMonitored, AlbumRelease>
+    {
+        private ReleaseRepository _releaseRepo;
+        
+        [SetUp]
+        public void Setup()
+        {
+            _releaseRepo = Mocker.Resolve<ReleaseRepository>();
+
+            // do it like this so we can verify no call to SetMonitored
+            // in the case where one release is monitored
+            Mocker.GetMock<IReleaseRepository>()
+                .Setup(x => x.FindByAlbum(It.IsAny<int>()))
+                .Returns((int id) => _releaseRepo.FindByAlbum(id));
+            
+            Mocker.GetMock<IReleaseRepository>()
+                .Setup(x => x.SetMonitored(It.IsAny<AlbumRelease>()))
+                .Returns((AlbumRelease a) => _releaseRepo.SetMonitored(a));
+        }
+        
+        [Test]
+        public void should_unmonitor_some_if_too_many_monitored()
+        {
+            var releases = Builder<AlbumRelease>
+                .CreateListOfSize(10)
+                .All()
+                .With(x => x.Id = 0)
+                .With(x => x.Monitored = false)
+                .With(x => x.AlbumId = 1)
+                .Random(3)
+                .With(x => x.Monitored = true)
+                .BuildList();
+            
+            _releaseRepo.InsertMany(releases);
+            
+            _releaseRepo.All().Count(x => x.Monitored).Should().Be(3);
+        
+            Subject.Clean();
+            
+            _releaseRepo.All().Count(x => x.Monitored).Should().Be(1);
+            
+            // Count sentry and standard
+            ExceptionVerification.ExpectedWarns(2);
+        }
+        
+        [Test]
+        public void should_monitor_one_if_none_monitored()
+        {
+            var releases = Builder<AlbumRelease>
+                .CreateListOfSize(10)
+                .All()
+                .With(x => x.Id = 0)
+                .With(x => x.Monitored = false)
+                .With(x => x.AlbumId = 1)
+                .BuildList();
+            
+            _releaseRepo.InsertMany(releases);
+            
+            _releaseRepo.All().Count(x => x.Monitored).Should().Be(0);
+        
+            Subject.Clean();
+            
+            _releaseRepo.All().Count(x => x.Monitored).Should().Be(1);
+
+            // Count sentry and standard
+            ExceptionVerification.ExpectedWarns(2);
+        }
+
+        [Test]
+        public void no_change_if_one_monitored()
+        {
+            var releases = Builder<AlbumRelease>
+                .CreateListOfSize(10)
+                .All()
+                .With(x => x.Id = 0)
+                .With(x => x.Monitored = false)
+                .With(x => x.AlbumId = 1)
+                .Random(1)
+                .With(x => x.Monitored = true)
+                .BuildList();
+
+            _releaseRepo.InsertMany(releases);
+
+            _releaseRepo.All().Count(x => x.Monitored).Should().Be(1);
+
+            Subject.Clean();
+
+            _releaseRepo.All().Count(x => x.Monitored).Should().Be(1);
+            
+            Mocker.GetMock<IReleaseRepository>().Verify(x => x.SetMonitored(It.IsAny<AlbumRelease>()), Times.Never());
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -240,6 +240,7 @@
     <Compile Include="Housekeeping\Housekeepers\CleanupOrphanedMetadataFilesFixture.cs" />
     <Compile Include="Housekeeping\Housekeepers\CleanupUnusedTagsFixture.cs" />
     <Compile Include="Housekeeping\Housekeepers\CleanupOrphanedPendingReleasesFixture.cs" />
+    <Compile Include="Housekeeping\Housekeepers\FixMultipleAlbumReleasesMonitoredFixture.cs" />
     <Compile Include="Housekeeping\Housekeepers\FixFutureDownloadClientStatusTimesFixture.cs" />
     <Compile Include="Housekeeping\Housekeepers\FixFutureImportListStatusTimesFixture.cs" />
     <Compile Include="Housekeeping\Housekeepers\FixFutureIndexerStatusTimesFixture.cs" />

--- a/src/NzbDrone.Core/Housekeeping/Housekeepers/FixMultipleAlbumReleasesMonitored.cs
+++ b/src/NzbDrone.Core/Housekeeping/Housekeepers/FixMultipleAlbumReleasesMonitored.cs
@@ -1,0 +1,55 @@
+using System.Linq;
+using NLog;
+using NLog.Fluent;
+using NzbDrone.Common.Instrumentation.Extensions;
+using NzbDrone.Core.Datastore;
+using NzbDrone.Core.Music;
+
+namespace NzbDrone.Core.Housekeeping.Housekeepers
+{
+    public class FixMultipleAlbumReleasesMonitored : IHousekeepingTask
+    {
+        private readonly IMainDatabase _database;
+        private readonly IReleaseRepository _releaseRepository;
+        private readonly Logger _logger;
+
+        public FixMultipleAlbumReleasesMonitored(IMainDatabase database,
+                                                 IReleaseRepository releaseRepository,
+                                                 Logger logger)
+        {
+            _database = database;
+            _releaseRepository = releaseRepository;
+            _logger = logger;
+        }
+
+        public void Clean()
+        {
+            var mapper = _database.GetDataMapper();
+
+            var albumIds = mapper.ExecuteReader(@"SELECT AlbumId
+                                                  FROM (
+                                                    SELECT AlbumId, Sum(Monitored)
+                                                    FROM AlbumReleases
+                                                    GROUP BY AlbumId
+                                                    HAVING Sum(Monitored) != 1
+                                                  )", reader => reader.GetInt32(0));
+
+            foreach (var albumId in albumIds)
+            {
+                var releases = _releaseRepository.FindByAlbum(albumId);
+                var monitored = releases.FirstOrDefault(x => x.Monitored) ?? releases.First();
+
+                // this will make sure that only 'monitored' is monitored and unmonitor the rest
+                _releaseRepository.SetMonitored(monitored);
+
+                // log a warning to sentry so we can work out whether this is something
+                // that is happening regularly
+                _logger.Warn()
+                    .Message("Multiple releases were monitored for {0} [{1}], correcting", monitored.Title, albumId)
+                    .WriteSentryWarn($"Multiple releases monitored")
+                    .Write();
+
+            }
+        }
+    }
+}

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -533,6 +533,7 @@
     <Compile Include="Housekeeping\Housekeepers\CleanupOrphanedPendingReleases.cs" />
     <Compile Include="Housekeeping\Housekeepers\DeleteBadMediaCovers.cs" />
     <Compile Include="Housekeeping\Housekeepers\EnsureValidLanguageProfileId.cs" />
+    <Compile Include="Housekeeping\Housekeepers\FixMultipleAlbumReleasesMonitored.cs" />
     <Compile Include="Housekeeping\Housekeepers\FixFutureDownloadClientStatusTimes.cs" />
     <Compile Include="Housekeeping\Housekeepers\FixFutureImportListStatusTimes.cs" />
     <Compile Include="Housekeeping\Housekeepers\FixFutureIndexerStatusTimes.cs" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Add a housekeeper to fix the database if an ends up not having exactly one release monitored.

It's not destructive so figure it might as well sit there and the sentry warning will give us an idea of whether we need to look again more closely.