### PR TITLE
Fixed: Actually filter TinyIoC errors from sentry and add tests

### DIFF
--- a/src/NzbDrone.Common.Test/InstrumentationTests/SentryTargetFixture.cs
+++ b/src/NzbDrone.Common.Test/InstrumentationTests/SentryTargetFixture.cs
@@ -1,0 +1,87 @@
+﻿using NUnit.Framework;
+using NzbDrone.Common.Instrumentation;
+using FluentAssertions;
+using NzbDrone.Common.Instrumentation.Sentry;
+using System;
+using NLog;
+using NzbDrone.Test.Common;
+using System.Globalization;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NzbDrone.Common.Test.InstrumentationTests
+{
+    [TestFixture]
+    public class SentryTargetFixture : TestBase
+    {
+        private SentryTarget Subject;
+
+        private static LogLevel[] AllLevels = LogLevel.AllLevels.ToArray();
+        private static LogLevel[] SentryLevels = LogLevel.AllLevels.Where(x => x >= LogLevel.Error).ToArray();
+        private static LogLevel[] OtherLevels = AllLevels.Except(SentryLevels).ToArray();
+
+        private static Exception[] FilteredExceptions = new Exception[] {
+            new UnauthorizedAccessException(),
+            new TinyIoC.TinyIoCResolutionException(typeof(string))
+        };
+
+        [SetUp]
+        public void Setup()
+        {
+            Subject = new SentryTarget("https://aaaaaaaaaaaaaaaaaaaaaaaaaa@sentry.io/111111");
+        }
+
+        private LogEventInfo GivenLogEvent(LogLevel level, Exception ex, string message)
+        {
+            return LogEventInfo.Create(level, "SentryTest", ex, CultureInfo.InvariantCulture, message);
+        }
+
+        [Test, TestCaseSource("AllLevels")]
+        public void log_without_error_is_not_sentry_event(LogLevel level)
+        {
+            Subject.IsSentryMessage(GivenLogEvent(level, null, "test")).Should().BeFalse();
+        }
+
+        [Test, TestCaseSource("SentryLevels")]
+        public void error_or_worse_with_exception_is_sentry_event(LogLevel level)
+        {
+            Subject.IsSentryMessage(GivenLogEvent(level, new Exception(), "test")).Should().BeTrue();
+        }
+
+        [Test, TestCaseSource("OtherLevels")]
+        public void less_than_error_with_exception_is_not_sentry_event(LogLevel level)
+        {
+            Subject.IsSentryMessage(GivenLogEvent(level, new Exception(), "test")).Should().BeFalse();
+        }
+
+        [Test, TestCaseSource("FilteredExceptions")]
+        public void should_filter_event_for_filtered_exception_types(Exception ex)
+        {
+            var log = GivenLogEvent(LogLevel.Error, ex, "test");
+            Subject.IsSentryMessage(log).Should().BeFalse();
+        }
+
+        [Test, TestCaseSource("FilteredExceptions")]
+        public void should_not_filter_event_for_filtered_exception_types_if_filtering_disabled(Exception ex)
+        {
+            Subject.FilterEvents = false;
+            var log = GivenLogEvent(LogLevel.Error, ex, "test");
+            Subject.IsSentryMessage(log).Should().BeTrue();
+        }
+
+        [Test, TestCaseSource(typeof(SentryTarget), "FilteredExceptionMessages")]
+        public void should_filter_event_for_filtered_exception_messages(string message)
+        {
+            var log = GivenLogEvent(LogLevel.Error, new Exception("aaaaaaa" + message + "bbbbbbb"), "test");
+            Subject.IsSentryMessage(log).Should().BeFalse();
+        }
+
+        [TestCase("A message that isn't filtered")]
+        [TestCase("Error")]
+        public void should_not_filter_event_for_exception_messages_that_are_not_filtered(string message)
+        {
+            var log = GivenLogEvent(LogLevel.Error, new Exception(message), "test");
+            Subject.IsSentryMessage(log).Should().BeTrue();
+        }
+    }
+}

--- a/src/NzbDrone.Common.Test/NzbDrone.Common.Test.csproj
+++ b/src/NzbDrone.Common.Test/NzbDrone.Common.Test.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Http\HttpUriFixture.cs" />
     <Compile Include="Http\UserAgentBuilderFixture.cs" />
     <Compile Include="InstrumentationTests\CleanseLogMessageFixture.cs" />
+    <Compile Include="InstrumentationTests\SentryTargetFixture.cs" />
     <Compile Include="LevenshteinDistanceFixture.cs" />
     <Compile Include="OsPathFixture.cs" />
     <Compile Include="PathExtensionFixture.cs" />

--- a/src/NzbDrone.Common/Instrumentation/Sentry/SentryTarget.cs
+++ b/src/NzbDrone.Common/Instrumentation/Sentry/SentryTarget.cs
@@ -40,10 +40,10 @@ namespace NzbDrone.Common.Instrumentation.Sentry
             // Filter out people stuck in boot loops
             "CorruptDatabaseException",
             // This also filters some people in boot loops
-            "TinyIoC.TinyIoCResolutionException"
+            "TinyIoCResolutionException"
         };
 
-        private static readonly List<string> FilteredExceptionMessages = new List<string> {
+        public static readonly List<string> FilteredExceptionMessages = new List<string> {
             // Swallow the many, many exceptions flowing through from Jackett
             "Jackett.Common.IndexerException",
             // Fix openflixr being stupid with permissions
@@ -115,6 +115,11 @@ namespace NzbDrone.Common.Instrumentation.Sentry
                                      });
             
             _debounce = new SentryDebounce();
+
+            // initialize to true and reconfigure later
+            // Otherwise it will default to false and any errors occuring
+            // before config file gets read will not be filtered
+            FilterEvents = true;
         }
 
         private void OnError(Exception ex)
@@ -168,7 +173,7 @@ namespace NzbDrone.Common.Instrumentation.Sentry
             return fingerPrint;
         }
 
-        private bool IsSentryMessage(LogEventInfo logEvent)
+        public bool IsSentryMessage(LogEventInfo logEvent)
         {
             if (logEvent.Properties.ContainsKey("Sentry"))
             {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- Fixes 6548f4b1b7bc1bd094f8e3d5a52c7f46b2cc5ff4 (need only class name, not the full name)
- Add tests for `IsSentryMessage`
- Turn on filtering on initialisation to make sure any events thrown before re-configuring logging are filtered.

#### Todos
- [x] Tests
