### PR TITLE
Fixed: MediaFileRepository was ignoring AlbumRelease monitored flag

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/MediaFileRepository.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileRepository.cs
@@ -34,7 +34,7 @@ namespace NzbDrone.Core.MediaFiles
         public List<TrackFile> GetFilesByArtist(int artistId)
         {
             return Query
-                .Join<Album, AlbumRelease>(JoinType.Inner, a => a.AlbumReleases, (a, r) => a.Id == r.AlbumId)
+                .Join<Track, AlbumRelease>(JoinType.Inner, t => t.AlbumRelease, (t, r) => t.AlbumReleaseId == r.Id)
                 .Where<AlbumRelease>(r => r.Monitored == true)
                 .AndWhere(t => t.Artist.Value.Id == artistId)
                 .ToList();
@@ -58,10 +58,9 @@ namespace NzbDrone.Core.MediaFiles
         public List<TrackFile> GetFilesWithRelativePath(int artistId, string relativePath)
         {
             return Query
-                .Join<Album, AlbumRelease>(JoinType.Inner, a => a.AlbumReleases, (a, r) => a.Id == r.AlbumId)
+                .Join<Track, AlbumRelease>(JoinType.Inner, t => t.AlbumRelease, (t, r) => t.AlbumReleaseId == r.Id)
                 .Where<AlbumRelease>(r => r.Monitored == true)
-                .AndWhere(t => t.Artist.Value.Id == artistId)
-                .AndWhere(t => t.RelativePath == relativePath)
+                .AndWhere(t => t.Artist.Value.Id == artistId && t.RelativePath == relativePath)
                 .ToList();
         }
     }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
`GetFilesByArtist` and `GetFilesWithRelativePath` were ignoring the `Monitored` flag.  This means that e.g. a file is filtered by `FilterExistingFiles` even if it is mapped against a release that is not currently monitored and so is not visible in the UI.

This was introduced in #592.

#### Todos
- [x] Tests
