### PR TITLE
Set sentry environment to be develop/nightly based on config file

### DIFF
--- a/appveyor-package.sh
+++ b/appveyor-package.sh
@@ -35,7 +35,7 @@ PublishSourceMaps()
         yarn sentry-cli releases new --finalize -p lidarr -p lidarr-ui -p lidarr-update "${APPVEYOR_BUILD_VERSION}-debug"
         yarn sentry-cli releases -p lidarr-ui files "${APPVEYOR_BUILD_VERSION}-debug" upload-sourcemaps _output/UI/ --rewrite
         yarn sentry-cli releases set-commits --auto "${APPVEYOR_BUILD_VERSION}-debug"
-        yarn sentry-cli releases deploys "${APPVEYOR_BUILD_VERSION}-debug" new -e production
+        yarn sentry-cli releases deploys "${APPVEYOR_BUILD_VERSION}-debug" new -e nightly
     fi
 }
 

--- a/frontend/src/Store/Middleware/createSentryMiddleware.js
+++ b/frontend/src/Store/Middleware/createSentryMiddleware.js
@@ -76,15 +76,15 @@ export default function createSentryMiddleware() {
 
   sentry.init({
     dsn,
-    environment: isProduction ? 'production' : 'development',
+    environment: branch,
     release,
     sendDefaultPii: true,
     beforeSend: cleanseData
   });
 
   sentry.configureScope((scope) => {
-    scope.setTag('branch', branch);
     scope.setTag('version', version);
+    scope.setTag('production', isProduction);
   });
 
   return createMiddleware();

--- a/src/NzbDrone.Core/Instrumentation/ReconfigureLogging.cs
+++ b/src/NzbDrone.Core/Instrumentation/ReconfigureLogging.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using NLog;
 using NLog.Config;
 using NzbDrone.Common.Extensions;
-using NzbDrone.Common.Instrumentation.Sentry;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Configuration.Events;
 using NzbDrone.Core.Messaging.Events;
@@ -40,9 +39,6 @@ namespace NzbDrone.Core.Instrumentation
             SetMinimumLogLevel(rules, "appFileInfo", minimumLogLevel <= LogLevel.Info ? LogLevel.Info : LogLevel.Off);
             SetMinimumLogLevel(rules, "appFileDebug", minimumLogLevel <= LogLevel.Debug ? LogLevel.Debug : LogLevel.Off);
             SetMinimumLogLevel(rules, "appFileTrace", minimumLogLevel <= LogLevel.Trace ? LogLevel.Trace : LogLevel.Off);
-
-            // Sentry filtering
-            LogManager.Configuration.FindTargetByName<SentryTarget>("sentryTarget").FilterEvents = _configFileProvider.FilterSentryEvents;
 
             LogManager.ReconfigExistingLoggers();
         }

--- a/src/NzbDrone.Core/Instrumentation/ReconfigureSentry.cs
+++ b/src/NzbDrone.Core/Instrumentation/ReconfigureSentry.cs
@@ -1,0 +1,39 @@
+using NLog;
+using NzbDrone.Common.Instrumentation.Sentry;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Datastore;
+using NzbDrone.Core.Lifecycle;
+using NzbDrone.Core.Messaging.Events;
+
+namespace NzbDrone.Core.Instrumentation
+{
+    public class ReconfigureSentry : IHandleAsync<ApplicationStartedEvent>
+    {
+        private readonly IConfigFileProvider _configFileProvider;
+        private readonly IMainDatabase _database;
+
+        public ReconfigureSentry(IConfigFileProvider configFileProvider,
+                                  IMainDatabase database)
+        {
+            _configFileProvider = configFileProvider;
+            _database = database;
+        }
+
+        public void Reconfigure()
+        {
+            // Extended sentry config
+            var sentry = LogManager.Configuration.FindTargetByName<SentryTarget>("sentryTarget");
+            sentry.FilterEvents = _configFileProvider.FilterSentryEvents;
+            sentry.UpdateBranch = _configFileProvider.Branch;
+            sentry.DatabaseVersion = _database.Version;
+            sentry.DatabaseMigration = _database.Migration;
+
+            LogManager.ReconfigExistingLoggers();
+        }
+
+        public void HandleAsync(ApplicationStartedEvent message)
+        {
+            Reconfigure();
+        }
+    }
+}

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -705,6 +705,7 @@
     <Compile Include="Instrumentation\LogRepository.cs" />
     <Compile Include="Instrumentation\LogService.cs" />
     <Compile Include="Instrumentation\ReconfigureLogging.cs" />
+    <Compile Include="Instrumentation\ReconfigureSentry.cs" />
     <Compile Include="Instrumentation\SlowRunningAsyncTargetWrapper.cs" />
     <Compile Include="Jobs\ScheduledTaskRepository.cs" />
     <Compile Include="Jobs\ScheduledTask.cs" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Set sentry environment to be the release update branch (i.e. nightly/develop/master).  Also add details of sqlite version and database migration to sentry events.

I think this would make commit tracking sensible as releases are intermittently pushed to develop.  It would also make it easy to view all events from nightly across nightly versions in the Sentry GUI.

The current setting of `Environment` as `production`/`development` is redundant because we have a separate `dsn` for the standard and development sentry projects, so `production` events always end up in `lidarr` and `development` events always end up in `lidarr-development` regardless of the value of `Environment`

After this change, we will still have all `development` events in `lidarr-development` (due to the different dsn).  But in `lidarr`, events will be correctly assigned to the nightly/develop/master environments.

The separate ReconfigureSentry class is required because ReconfigureLogging happens before the database has been resolved, so you can't access IMainDatabase there.

#### TODO
- [x]  Make a similar change for the frontend sentry environment
