### PR TITLE
Fixed: Slack AlbumImportFailed notification

### DIFF
--- a/src/NzbDrone.Core/Notifications/Slack/Slack.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/Slack.cs
@@ -128,7 +128,6 @@ namespace NzbDrone.Core.Notifications.Slack
                 new Attachment
                 {
                     Fallback = message.Message,
-                    Title = message.Album.Title,
                     Text = message.Message,
                     Color = "warning"
                 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
message.Album is null at the moment
