### PR TITLE
Fixed: ReleasePush Validation and Error on Parse

### DIFF
--- a/src/Lidarr.Api.V1/Indexers/ReleaseResource.cs
+++ b/src/Lidarr.Api.V1/Indexers/ReleaseResource.cs
@@ -54,11 +54,6 @@ namespace Lidarr.Api.V1.Indexers
         //TODO: besides a test I don't think this is used...
         public DownloadProtocol DownloadProtocol { get; set; }
 
-        //public bool IsDaily { get; set; }
-        //public bool IsAbsoluteNumbering { get; set; }
-        //public bool IsPossibleSpecialEpisode { get; set; }
-        //public bool Special { get; set; }
-
         // Sent when queuing an unknown release
 
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Actually use validation for release push, standard PostValidatiors don’t work given we are initiating the endpoint direct with Nancy instead of using our RestModule. 

Fix error and log if release doesn’t get parsed by decision maker

#### Todos
- [x] Fix validating on standard release endpoint (same issue)
- [x] Fix sending bad date fails on the bind before validation so is not caught


#### Issues Fixed or Closed by this PR

* Fixes #707 
* Fixes LIDARR-1W4
