### PR TITLE
Fixed: Disable update for docker containers

### DIFF
--- a/frontend/src/Settings/General/GeneralSettings.js
+++ b/frontend/src/Settings/General/GeneralSettings.js
@@ -98,6 +98,7 @@ class GeneralSettings extends Component {
       isResettingApiKey,
       isMono,
       isWindows,
+      isDocker,
       mode,
       onInputChange,
       onConfirmResetApiKey,
@@ -161,6 +162,7 @@ class GeneralSettings extends Component {
                   advancedSettings={advancedSettings}
                   settings={settings}
                   isMono={isMono}
+                  isDocker={isDocker}
                   onInputChange={onInputChange}
                 />
 
@@ -202,6 +204,7 @@ GeneralSettings.propTypes = {
   hasSettings: PropTypes.bool.isRequired,
   isMono: PropTypes.bool.isRequired,
   isWindows: PropTypes.bool.isRequired,
+  isDocker: PropTypes.bool.isRequired,
   mode: PropTypes.string.isRequired,
   onInputChange: PropTypes.func.isRequired,
   onConfirmResetApiKey: PropTypes.func.isRequired,

--- a/frontend/src/Settings/General/GeneralSettingsConnector.js
+++ b/frontend/src/Settings/General/GeneralSettingsConnector.js
@@ -26,6 +26,7 @@ function createMapStateToProps() {
         isResettingApiKey,
         isMono: systemStatus.isMono,
         isWindows: systemStatus.isWindows,
+        isDocker: systemStatus.isDocker,
         mode: systemStatus.mode,
         ...sectionSettings
       };

--- a/frontend/src/Settings/General/UpdateSettings.js
+++ b/frontend/src/Settings/General/UpdateSettings.js
@@ -16,6 +16,7 @@ function UpdateSettings(props) {
     advancedSettings,
     settings,
     isMono,
+    isDocker,
     onInputChange
   } = props;
 
@@ -34,6 +35,14 @@ function UpdateSettings(props) {
     { key: 'builtIn', value: 'Built-In' },
     { key: 'script', value: 'Script' }
   ];
+
+  if (isDocker) {
+    return (
+      <FieldSet legend="Updates">
+        <div>Updating is disabled inside a docker container.  Update the container image instead.</div>
+      </FieldSet>
+    );
+  }
 
   return (
     <FieldSet legend="Updates">
@@ -117,6 +126,7 @@ UpdateSettings.propTypes = {
   advancedSettings: PropTypes.bool.isRequired,
   settings: PropTypes.object.isRequired,
   isMono: PropTypes.bool.isRequired,
+  isDocker: PropTypes.bool.isRequired,
   onInputChange: PropTypes.func.isRequired
 };
 

--- a/frontend/src/System/Status/About/About.js
+++ b/frontend/src/System/Status/About/About.js
@@ -16,6 +16,7 @@ class About extends Component {
     const {
       version,
       isMonoRuntime,
+      isDocker,
       runtimeVersion,
       migrationVersion,
       appData,
@@ -39,6 +40,14 @@ class About extends Component {
               <DescriptionListItem
                 title="Mono Version"
                 data={runtimeVersion}
+              />
+          }
+
+          {
+            isDocker &&
+              <DescriptionListItem
+                title="Docker"
+                data={'True'}
               />
           }
 
@@ -83,6 +92,7 @@ About.propTypes = {
   version: PropTypes.string.isRequired,
   isMonoRuntime: PropTypes.bool.isRequired,
   runtimeVersion: PropTypes.string.isRequired,
+  isDocker: PropTypes.bool.isRequired,
   migrationVersion: PropTypes.number.isRequired,
   appData: PropTypes.string.isRequired,
   startupPath: PropTypes.string.isRequired,

--- a/frontend/src/System/Updates/Updates.js
+++ b/frontend/src/System/Updates/Updates.js
@@ -24,6 +24,7 @@ class Updates extends Component {
       error,
       items,
       isInstallingUpdate,
+      isDocker,
       shortDateFormat,
       onInstallLatestPress
     } = this.props;
@@ -48,24 +49,34 @@ class Updates extends Component {
 
           {
             hasUpdateToInstall &&
-            <div className={styles.updateAvailable}>
-              <SpinnerButton
-                className={styles.updateAvailable}
-                kind={kinds.PRIMARY}
-                isSpinning={isInstallingUpdate}
-                onPress={onInstallLatestPress}
-              >
-                Install Latest
-              </SpinnerButton>
+              <div className={styles.updateAvailable}>
+                {
+                  !isDocker &&
+                  <SpinnerButton
+                    className={styles.updateAvailable}
+                    kind={kinds.PRIMARY}
+                    isSpinning={isInstallingUpdate}
+                    onPress={onInstallLatestPress}
+                  >
+                    Install Latest
+                  </SpinnerButton>
+                }
 
-              {
-                isFetching &&
-                  <LoadingIndicator
-                    className={styles.loading}
-                    size={20}
-                  />
-              }
-            </div>
+                {
+                  isDocker &&
+                    <div className={styles.upToDateMessage}>
+                      An update is available.  Please update your Docker image and re-create the container.
+                    </div>
+                }
+
+                {
+                  isFetching &&
+                    <LoadingIndicator
+                      className={styles.loading}
+                      size={20}
+                    />
+                }
+              </div>
           }
 
           {
@@ -162,6 +173,7 @@ Updates.propTypes = {
   error: PropTypes.object,
   items: PropTypes.array.isRequired,
   isInstallingUpdate: PropTypes.bool.isRequired,
+  isDocker: PropTypes.bool.isRequired,
   shortDateFormat: PropTypes.string.isRequired,
   onInstallLatestPress: PropTypes.func.isRequired
 };

--- a/frontend/src/System/Updates/UpdatesConnector.js
+++ b/frontend/src/System/Updates/UpdatesConnector.js
@@ -6,6 +6,7 @@ import { fetchUpdates } from 'Store/Actions/systemActions';
 import { executeCommand } from 'Store/Actions/commandActions';
 import createCommandExecutingSelector from 'Store/Selectors/createCommandExecutingSelector';
 import createUISettingsSelector from 'Store/Selectors/createUISettingsSelector';
+import createSystemStatusSelector from 'Store/Selectors/createSystemStatusSelector';
 import * as commandNames from 'Commands/commandNames';
 import Updates from './Updates';
 
@@ -14,7 +15,8 @@ function createMapStateToProps() {
     (state) => state.system.updates,
     createUISettingsSelector(),
     createCommandExecutingSelector(commandNames.APPLICATION_UPDATE),
-    (updates, uiSettings, isInstallingUpdate) => {
+    createSystemStatusSelector(),
+    (updates, uiSettings, isInstallingUpdate, systemStatus) => {
       const {
         isFetching,
         isPopulated,
@@ -28,6 +30,7 @@ function createMapStateToProps() {
         error,
         items,
         isInstallingUpdate,
+        isDocker: systemStatus.isDocker,
         shortDateFormat: uiSettings.shortDateFormat
       };
     }

--- a/src/Lidarr.Api.V1/System/SystemModule.cs
+++ b/src/Lidarr.Api.V1/System/SystemModule.cs
@@ -64,6 +64,7 @@ namespace Lidarr.Api.V1.System
                 IsLinux = OsInfo.IsLinux,
                 IsOsx = OsInfo.IsOsx,
                 IsWindows = OsInfo.IsWindows,
+                IsDocker = _osInfo.IsDocker,
                 Mode = _runtimeInfo.Mode,
                 Branch = _configFileProvider.Branch,
                 Authentication = _configFileProvider.AuthenticationMethod,

--- a/src/NzbDrone.Common/EnvironmentInfo/OsInfo.cs
+++ b/src/NzbDrone.Common/EnvironmentInfo/OsInfo.cs
@@ -14,7 +14,9 @@ namespace NzbDrone.Common.EnvironmentInfo
         public static bool IsLinux => Os == Os.Linux;
         public static bool IsOsx => Os == Os.Osx;
         public static bool IsWindows => Os == Os.Windows;
-        public static bool IsDocker { get; }
+
+        // this needs to not be static so we can mock it
+        public bool IsDocker { get; }
         
         public string Version { get; }
         public string Name { get; }
@@ -45,10 +47,6 @@ namespace NzbDrone.Common.EnvironmentInfo
                         else
                         {
                             Os = Os.Linux;
-                            if (File.Exists("/proc/1/cgroup") && File.ReadAllText("/proc/1/cgroup").Contains("/docker/"))
-                            {
-                                IsDocker = true;
-                            }
                         }
                         break;
                     }
@@ -88,8 +86,14 @@ namespace NzbDrone.Common.EnvironmentInfo
                 FullName = Name;
             }
 
+            if (IsLinux && File.Exists("/proc/1/cgroup") && File.ReadAllText("/proc/1/cgroup").Contains("/docker/"))
+            {
+                IsDocker = true;
+            }
+
             Environment.SetEnvironmentVariable("OS_NAME", Name);
             Environment.SetEnvironmentVariable("OS_VERSION", Version);
+            Environment.SetEnvironmentVariable("OS_IS_DOCKER", IsDocker.ToString());
         }
     }
 
@@ -98,6 +102,8 @@ namespace NzbDrone.Common.EnvironmentInfo
         string Version { get; }
         string Name { get; }
         string FullName { get; }
+
+        bool IsDocker { get; }
     }
 
     public enum Os

--- a/src/NzbDrone.Common/Instrumentation/Sentry/SentryTarget.cs
+++ b/src/NzbDrone.Common/Instrumentation/Sentry/SentryTarget.cs
@@ -260,10 +260,12 @@ namespace NzbDrone.Common.Instrumentation.Sentry
                 // populated these values yet
                 var osName = Environment.GetEnvironmentVariable("OS_NAME");
                 var osVersion = Environment.GetEnvironmentVariable("OS_VERSION");
+                var isDocker = Environment.GetEnvironmentVariable("OS_IS_DOCKER");
                 var runTimeVersion = Environment.GetEnvironmentVariable("RUNTIME_VERSION");
 
                 sentryEvent.SetTag("os_name", osName);
                 sentryEvent.SetTag("os_version", $"{osName} {osVersion}");
+                sentryEvent.SetTag("is_docker", isDocker);
                 sentryEvent.SetTag("runtime_version", $"{PlatformInfo.PlatformName} {runTimeVersion}");
                 sentryEvent.SetTag("sqlite_version", $"{DatabaseVersion}");
                 sentryEvent.SetTag("database_migration", $"{DatabaseMigration}");

--- a/src/NzbDrone.Core.Test/HealthCheck/Checks/RemotePathMappingCheckFixture.cs
+++ b/src/NzbDrone.Core.Test/HealthCheck/Checks/RemotePathMappingCheckFixture.cs
@@ -5,6 +5,7 @@ using Moq;
 using NUnit.Framework;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnsureThat;
+using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.Download.Clients;
 using NzbDrone.Core.HealthCheck.Checks;
@@ -86,7 +87,9 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
 
         private void GivenDocker()
         {
-            //
+            Mocker.GetMock<IOsInfo>()
+                .Setup(x => x.IsDocker)
+                .Returns(true);
         }
 
         [Test]
@@ -139,9 +142,10 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
         }
 
         [Test]
-        [Explicit("Only works if running inside a docker container")]
         public void should_return_docker_path_mapping_error_if_on_docker_and_root_missing()
         {
+            GivenDocker();
+            
             Subject.Check().ShouldBeError(wikiFragment: "docker-bad-remote-path-mapping");
         }
 
@@ -215,9 +219,10 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
         }
 
         [Test]
-        [Explicit("Only works if running inside a docker container")]
         public void should_return_docker_mapping_error_on_track_import_failed_event_inside_docker_if_folder_does_not_exist()
         {
+            GivenDocker();
+            
             clientStatus.IsLocalhost = false;
             var importEvent = new TrackImportFailedEvent(null, null, true, downloadItem);
 

--- a/src/NzbDrone.Core.Test/UpdateTests/UpdateServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/UpdateTests/UpdateServiceFixture.cs
@@ -88,6 +88,16 @@ namespace NzbDrone.Core.Test.UpdateTests
         }
 
         [Test]
+        public void should_not_update_if_inside_docker()
+        {
+            Mocker.GetMock<IOsInfo>().Setup(x => x.IsDocker).Returns(true);
+            
+            Subject.Invoking(x => x.Execute(new ApplicationUpdateCommand()))
+                .ShouldThrow<CommandFailedException>()
+                .WithMessage("Updating is disabled inside a docker container.  Please update the container image.");
+        }
+
+        [Test]
         public void should_delete_sandbox_before_update_if_folder_exists()
         {
             Mocker.GetMock<IDiskProvider>().Setup(c => c.FolderExists(_sandboxFolder)).Returns(true);

--- a/src/NzbDrone.Core/HealthCheck/Checks/RemotePathMappingCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/RemotePathMappingCheck.cs
@@ -58,7 +58,7 @@ namespace NzbDrone.Core.HealthCheck.Checks
                                 {
                                     return new HealthCheck(GetType(), HealthCheckResult.Error, $"Remote download client {client.Definition.Name} places downloads in {folder.FullPath} but this is not a valid {_osInfo.Name} path.  Review your remote path mappings and download client settings.", "#bad-remote-path-mapping");
                                 }
-                                else if (OsInfo.IsDocker)
+                                else if (_osInfo.IsDocker)
                                 {
                                     return new HealthCheck(GetType(), HealthCheckResult.Error, $"You are using docker; download client {client.Definition.Name} places downloads in {folder.FullPath} but this is not a valid {_osInfo.Name} path.  Review your remote path mappings and download client settings.", "#docker-bad-remote-path-mapping");
                                 }
@@ -70,7 +70,7 @@ namespace NzbDrone.Core.HealthCheck.Checks
 
                             if (!_diskProvider.FolderExists(folder.FullPath))
                             {
-                                if (OsInfo.IsDocker)
+                                if (_osInfo.IsDocker)
                                 {
                                     return new HealthCheck(GetType(), HealthCheckResult.Error, $"You are using docker; download client {client.Definition.Name} places downloads in {folder.FullPath} but this directory does not appear to exist inside the container.  Review your remote path mappings and container volume settings.", "#docker-bad-remote-path-mapping");
                                 }
@@ -141,7 +141,7 @@ namespace NzbDrone.Core.HealthCheck.Checks
                         {
                             return new HealthCheck(GetType(), HealthCheckResult.Error, $"Remote download client {client.Definition.Name} reported files in {dlpath} but this is not a valid {_osInfo.Name} path.  Review your remote path mappings and download client settings.", "#bad-remote-path-mapping");
                         }
-                        else if (OsInfo.IsDocker)
+                        else if (_osInfo.IsDocker)
                         {
                             return new HealthCheck(GetType(), HealthCheckResult.Error, $"You are using docker; download client {client.Definition.Name} reported files in {dlpath} but this is not a valid {_osInfo.Name} path.  Review your remote path mappings and download client settings.", "#docker-bad-remote-path-mapping");
                         }
@@ -157,7 +157,7 @@ namespace NzbDrone.Core.HealthCheck.Checks
                     }
                 
                     // if it's a remote client/docker, likely missing path mappings
-                    if (OsInfo.IsDocker)
+                    if (_osInfo.IsDocker)
                     {
                         return new HealthCheck(GetType(), HealthCheckResult.Error, $"You are using docker; download client {client.Definition.Name} reported files in {dlpath} but this directory does not appear to exist inside the container.  Review your remote path mappings and container volume settings.", "#docker-bad-remote-path-mapping");
                     }

--- a/src/NzbDrone.Core/Update/InstallUpdateService.cs
+++ b/src/NzbDrone.Core/Update/InstallUpdateService.cs
@@ -32,6 +32,7 @@ namespace NzbDrone.Core.Update
         private readonly IConfigFileProvider _configFileProvider;
         private readonly IRuntimeInfo _runtimeInfo;
         private readonly IBackupService _backupService;
+        private readonly IOsInfo _osInfo;
 
 
         public InstallUpdateService(ICheckUpdateService checkUpdateService,
@@ -46,6 +47,7 @@ namespace NzbDrone.Core.Update
                                     IConfigFileProvider configFileProvider,
                                     IRuntimeInfo runtimeInfo,
                                     IBackupService backupService,
+                                    IOsInfo osInfo,
                                     Logger logger)
         {
             if (configFileProvider == null)
@@ -64,6 +66,7 @@ namespace NzbDrone.Core.Update
             _configFileProvider = configFileProvider;
             _runtimeInfo = runtimeInfo;
             _backupService = backupService;
+            _osInfo = osInfo;
             _logger = logger;
         }
 
@@ -202,6 +205,11 @@ namespace NzbDrone.Core.Update
             {
                 _logger.ProgressDebug("No update available");
                 return;
+            }
+
+            if (_osInfo.IsDocker)
+            {
+                throw new CommandFailedException("Updating is disabled inside a docker container.  Please update the container image.");
             }
 
             if (OsInfo.IsNotWindows && !_configFileProvider.UpdateAutomatically && message.Trigger != CommandTrigger.Manual)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Prevent Lidarr from updating inside a docker container.  Also note that docker is being used in the about page and sentry context.

#### Issues Fixed or Closed by this PR

* Fixes #628 
