### PR TITLE
Fixed: Don't process tracked download if RemoteAlbum is null

### DIFF
--- a/src/NzbDrone.Core/Download/CompletedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/CompletedDownloadService.cs
@@ -50,7 +50,8 @@ namespace NzbDrone.Core.Download
 
         public void Process(TrackedDownload trackedDownload, bool ignoreWarnings = false)
         {
-            if (trackedDownload.DownloadItem.Status != DownloadItemStatus.Completed)
+            if (trackedDownload.DownloadItem.Status != DownloadItemStatus.Completed ||
+                trackedDownload.RemoteAlbum == null)
             {
                 return;
             }
@@ -80,7 +81,7 @@ namespace NzbDrone.Core.Download
                     return;
                 }
 
-                var artist = trackedDownload.RemoteAlbum?.Artist;
+                var artist = trackedDownload.RemoteAlbum.Artist;
 
                 if (artist == null)
                 {

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
@@ -156,6 +156,7 @@ namespace NzbDrone.Core.Download.TrackedDownloads
                 if (trackedDownload.RemoteAlbum == null)
                 {
                     _logger.Trace("No Album found for download '{0}'", trackedDownload.DownloadItem.Title);
+                    trackedDownload.Warn("No Album found for download '{0}'", trackedDownload.DownloadItem.Title);
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Prevent tracked downloads from being processed if `RemoteAlbum` is null.  Corrects the fix from 15425a45a

#### Todos
- [x] Tests (already exist)

#### Issues Fixed or Closed by this PR

* Fixes LIDARR-1V4
