### PR TITLE
New: Associate same AnonToken with Sentry UI instance

### DIFF
--- a/frontend/src/Store/Middleware/createSentryMiddleware.js
+++ b/frontend/src/Store/Middleware/createSentryMiddleware.js
@@ -64,6 +64,7 @@ export default function createSentryMiddleware() {
     branch,
     version,
     release,
+    userHash,
     isProduction
   } = window.Lidarr;
 
@@ -83,6 +84,7 @@ export default function createSentryMiddleware() {
   });
 
   sentry.configureScope((scope) => {
+    scope.setUser({ username: userHash });
     scope.setTag('version', version);
     scope.setTag('production', isProduction);
   });

--- a/src/Lidarr.Http/Frontend/InitializeJsModule.cs
+++ b/src/Lidarr.Http/Frontend/InitializeJsModule.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Text;
 using Nancy;
 using Nancy.Responses;
+using NzbDrone.Common;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Core.Analytics;
 using NzbDrone.Core.Configuration;
@@ -66,6 +67,7 @@ namespace Lidarr.Http.Frontend
             builder.AppendLine($"  version: '{BuildInfo.Version.ToString()}',");
             builder.AppendLine($"  branch: '{_configFileProvider.Branch.ToLower()}',");
             builder.AppendLine($"  analytics: {_analyticsService.IsEnabled.ToString().ToLowerInvariant()},");
+            builder.AppendLine($"  userHash: '{HashUtil.AnonymousToken()}',");
             builder.AppendLine($"  urlBase: '{_urlBase}',");
             builder.AppendLine($"  isProduction: {RuntimeInfo.IsProduction.ToString().ToLowerInvariant()}");
             builder.AppendLine("};");


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Frontend errors have no associated user, this will use the same AnonToken from server side to attach to UI events

Example event:
https://sentry.io/organizations/lidarr/issues/974992887/
