### PR TITLE
Fixed: Don't throw error on Docker Update Attempt

### DIFF
--- a/src/NzbDrone.Core.Test/UpdateTests/UpdateServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/UpdateTests/UpdateServiceFixture.cs
@@ -91,10 +91,11 @@ namespace NzbDrone.Core.Test.UpdateTests
         public void should_not_update_if_inside_docker()
         {
             Mocker.GetMock<IOsInfo>().Setup(x => x.IsDocker).Returns(true);
-            
-            Subject.Invoking(x => x.Execute(new ApplicationUpdateCommand()))
-                .ShouldThrow<CommandFailedException>()
-                .WithMessage("Updating is disabled inside a docker container.  Please update the container image.");
+
+            Subject.Execute(new ApplicationUpdateCommand());
+
+            Mocker.GetMock<IProcessProvider>()
+                .Verify(c => c.Start(It.IsAny<string>(), It.Is<string>(s => s.StartsWith("12")), null, null, null), Times.Never());
         }
 
         [Test]

--- a/src/NzbDrone.Core/Update/InstallUpdateService.cs
+++ b/src/NzbDrone.Core/Update/InstallUpdateService.cs
@@ -209,7 +209,8 @@ namespace NzbDrone.Core.Update
 
             if (_osInfo.IsDocker)
             {
-                throw new CommandFailedException("Updating is disabled inside a docker container.  Please update the container image.");
+                _logger.ProgressDebug("Updating is disabled inside a docker container.  Please update the container image.");
+                return;
             }
 
             if (OsInfo.IsNotWindows && !_configFileProvider.UpdateAutomatically && message.Trigger != CommandTrigger.Manual)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Don't throw errors if docker update attempt is stopped

#### Todos
- [x] Tests
