### PR TITLE
Add: option to skip automatic redownload when removing from queue

### DIFF
--- a/frontend/src/Activity/Queue/Queue.js
+++ b/frontend/src/Activity/Queue/Queue.js
@@ -107,8 +107,8 @@ class Queue extends Component {
     this.setState({ isConfirmRemoveModalOpen: true });
   }
 
-  onRemoveSelectedConfirmed = (blacklist) => {
-    this.props.onRemoveSelectedPress(this.getSelectedIds(), blacklist);
+  onRemoveSelectedConfirmed = (blacklist, skipredownload) => {
+    this.props.onRemoveSelectedPress(this.getSelectedIds(), blacklist, skipredownload);
     this.setState({ isConfirmRemoveModalOpen: false });
   }
 

--- a/frontend/src/Activity/Queue/QueueConnector.js
+++ b/frontend/src/Activity/Queue/QueueConnector.js
@@ -137,8 +137,8 @@ class QueueConnector extends Component {
     this.props.grabQueueItems({ ids });
   }
 
-  onRemoveSelectedPress = (ids, blacklist) => {
-    this.props.removeQueueItems({ ids, blacklist });
+  onRemoveSelectedPress = (ids, blacklist, skipredownload) => {
+    this.props.removeQueueItems({ ids, blacklist, skipredownload });
   }
 
   //

--- a/frontend/src/Activity/Queue/QueueRow.js
+++ b/frontend/src/Activity/Queue/QueueRow.js
@@ -42,8 +42,8 @@ class QueueRow extends Component {
     this.setState({ isRemoveQueueItemModalOpen: true });
   }
 
-  onRemoveQueueItemModalConfirmed = (blacklist) => {
-    this.props.onRemoveQueueItemPress(blacklist);
+  onRemoveQueueItemModalConfirmed = (blacklist, skipredownload) => {
+    this.props.onRemoveQueueItemPress(blacklist, skipredownload);
     this.setState({ isRemoveQueueItemModalOpen: false });
   }
 

--- a/frontend/src/Activity/Queue/QueueRowConnector.js
+++ b/frontend/src/Activity/Queue/QueueRowConnector.js
@@ -43,8 +43,8 @@ class QueueRowConnector extends Component {
     this.props.grabQueueItem({ id: this.props.id });
   }
 
-  onRemoveQueueItemPress = (blacklist) => {
-    this.props.removeQueueItem({ id: this.props.id, blacklist });
+  onRemoveQueueItemPress = (blacklist, skipredownload) => {
+    this.props.removeQueueItem({ id: this.props.id, blacklist, skipredownload });
   }
 
   //

--- a/frontend/src/Activity/Queue/RemoveQueueItemModal.js
+++ b/frontend/src/Activity/Queue/RemoveQueueItemModal.js
@@ -21,7 +21,8 @@ class RemoveQueueItemModal extends Component {
     super(props, context);
 
     this.state = {
-      blacklist: false
+      blacklist: false,
+      skipredownload: false
     };
   }
 
@@ -32,15 +33,24 @@ class RemoveQueueItemModal extends Component {
     this.setState({ blacklist: value });
   }
 
+  onSkipReDownloadChange = ({ value }) => {
+    this.setState({ skipredownload: value });
+  }
+
   onRemoveQueueItemConfirmed = () => {
     const blacklist = this.state.blacklist;
+    const skipredownload = this.state.skipredownload;
 
-    this.setState({ blacklist: false });
-    this.props.onRemovePress(blacklist);
+    this.setState({
+      blacklist: false,
+      skipredownload: false });
+    this.props.onRemovePress(blacklist, skipredownload);
   }
 
   onModalClose = () => {
-    this.setState({ blacklist: false });
+    this.setState({
+      blacklist: false,
+      skipredownload: false });
     this.props.onModalClose();
   }
 
@@ -54,6 +64,7 @@ class RemoveQueueItemModal extends Component {
     } = this.props;
 
     const blacklist = this.state.blacklist;
+    const skipredownload = this.state.skipredownload;
 
     return (
       <Modal
@@ -79,8 +90,19 @@ class RemoveQueueItemModal extends Component {
                 type={inputTypes.CHECK}
                 name="blacklist"
                 value={blacklist}
-                helpText="Prevents Lidarr from automatically grabbing these files again"
+                helpText="Prevents Lidarr from automatically grabbing this release again"
                 onChange={this.onBlacklistChange}
+              />
+            </FormGroup>
+
+            <FormGroup>
+              <FormLabel>Skip Redownload</FormLabel>
+              <FormInputGroup
+                type={inputTypes.CHECK}
+                name="skipredownload"
+                value={skipredownload}
+                helpText="Prevents Lidarr from trying download an alternative release for this item"
+                onChange={this.onSkipReDownloadChange}
               />
             </FormGroup>
 

--- a/frontend/src/Activity/Queue/RemoveQueueItemModal.js
+++ b/frontend/src/Activity/Queue/RemoveQueueItemModal.js
@@ -97,16 +97,19 @@ class RemoveQueueItemModal extends Component {
               />
             </FormGroup>
 
-            <FormGroup>
-              <FormLabel>Skip Redownload</FormLabel>
-              <FormInputGroup
-                type={inputTypes.CHECK}
-                name="skipredownload"
-                value={skipredownload}
-                helpText="Prevents Lidarr from trying download an alternative release for this item"
-                onChange={this.onSkipReDownloadChange}
-              />
-            </FormGroup>
+            {
+              blacklist &&
+                <FormGroup>
+                  <FormLabel>Skip Redownload</FormLabel>
+                  <FormInputGroup
+                    type={inputTypes.CHECK}
+                    name="skipredownload"
+                    value={skipredownload}
+                    helpText="Prevents Lidarr from trying download an alternative release for this item"
+                    onChange={this.onSkipReDownloadChange}
+                  />
+                </FormGroup>
+            }
 
           </ModalBody>
 

--- a/frontend/src/Activity/Queue/RemoveQueueItemModal.js
+++ b/frontend/src/Activity/Queue/RemoveQueueItemModal.js
@@ -43,14 +43,16 @@ class RemoveQueueItemModal extends Component {
 
     this.setState({
       blacklist: false,
-      skipredownload: false });
+      skipredownload: false
+    });
     this.props.onRemovePress(blacklist, skipredownload);
   }
 
   onModalClose = () => {
     this.setState({
       blacklist: false,
-      skipredownload: false });
+      skipredownload: false
+    });
     this.props.onModalClose();
   }
 

--- a/frontend/src/Activity/Queue/RemoveQueueItemsModal.js
+++ b/frontend/src/Activity/Queue/RemoveQueueItemsModal.js
@@ -21,7 +21,8 @@ class RemoveQueueItemsModal extends Component {
     super(props, context);
 
     this.state = {
-      blacklist: false
+      blacklist: false,
+      skipredownload: false
     };
   }
 
@@ -32,15 +33,24 @@ class RemoveQueueItemsModal extends Component {
     this.setState({ blacklist: value });
   }
 
+  onSkipReDownloadChange = ({ value }) => {
+    this.setState({ skipredownload: value });
+  }
+
   onRemoveQueueItemConfirmed = () => {
     const blacklist = this.state.blacklist;
+    const skipredownload = this.state.skipredownload;
 
-    this.setState({ blacklist: false });
-    this.props.onRemovePress(blacklist);
+    this.setState({
+      blacklist: false,
+      skipredownload: false });
+    this.props.onRemovePress(blacklist, skipredownload);
   }
 
   onModalClose = () => {
-    this.setState({ blacklist: false });
+    this.setState({
+      blacklist: false,
+      skipredownload: false });
     this.props.onModalClose();
   }
 
@@ -54,6 +64,7 @@ class RemoveQueueItemsModal extends Component {
     } = this.props;
 
     const blacklist = this.state.blacklist;
+    const skipredownload = this.state.skipredownload;
 
     return (
       <Modal
@@ -79,8 +90,19 @@ class RemoveQueueItemsModal extends Component {
                 type={inputTypes.CHECK}
                 name="blacklist"
                 value={blacklist}
-                helpText="Prevents Lidarr from automatically grabbing this release again"
+                helpText="Prevents Lidarr from automatically grabbing these files again"
                 onChange={this.onBlacklistChange}
+              />
+            </FormGroup>
+
+            <FormGroup>
+              <FormLabel>Skip Redownload</FormLabel>
+              <FormInputGroup
+                type={inputTypes.CHECK}
+                name="skipredownload"
+                value={skipredownload}
+                helpText="Prevents Lidarr from trying download alternative releases for the removed items"
+                onChange={this.onSkipReDownloadChange}
               />
             </FormGroup>
 

--- a/frontend/src/Activity/Queue/RemoveQueueItemsModal.js
+++ b/frontend/src/Activity/Queue/RemoveQueueItemsModal.js
@@ -97,16 +97,19 @@ class RemoveQueueItemsModal extends Component {
               />
             </FormGroup>
 
-            <FormGroup>
-              <FormLabel>Skip Redownload</FormLabel>
-              <FormInputGroup
-                type={inputTypes.CHECK}
-                name="skipredownload"
-                value={skipredownload}
-                helpText="Prevents Lidarr from trying download alternative releases for the removed items"
-                onChange={this.onSkipReDownloadChange}
-              />
-            </FormGroup>
+            {
+              blacklist &&
+              <FormGroup>
+                <FormLabel>Skip Redownload</FormLabel>
+                <FormInputGroup
+                  type={inputTypes.CHECK}
+                  name="skipredownload"
+                  value={skipredownload}
+                  helpText="Prevents Lidarr from trying download alternative releases for the removed items"
+                  onChange={this.onSkipReDownloadChange}
+                />
+              </FormGroup>
+            }
 
           </ModalBody>
 

--- a/frontend/src/Activity/Queue/RemoveQueueItemsModal.js
+++ b/frontend/src/Activity/Queue/RemoveQueueItemsModal.js
@@ -43,14 +43,16 @@ class RemoveQueueItemsModal extends Component {
 
     this.setState({
       blacklist: false,
-      skipredownload: false });
+      skipredownload: false
+    });
     this.props.onRemovePress(blacklist, skipredownload);
   }
 
   onModalClose = () => {
     this.setState({
       blacklist: false,
-      skipredownload: false });
+      skipredownload: false
+    });
     this.props.onModalClose();
   }
 

--- a/frontend/src/Store/Actions/queueActions.js
+++ b/frontend/src/Store/Actions/queueActions.js
@@ -351,13 +351,14 @@ export const actionHandlers = handleThunks({
   [REMOVE_QUEUE_ITEM]: function(getState, payload, dispatch) {
     const {
       id,
-      blacklist
+      blacklist,
+      skipredownload
     } = payload;
 
     dispatch(updateItem({ section: paged, id, isRemoving: true }));
 
     const promise = createAjaxRequest({
-      url: `/queue/${id}?blacklist=${blacklist}`,
+      url: `/queue/${id}?blacklist=${blacklist}&skipredownload=${skipredownload}`,
       method: 'DELETE'
     }).request;
 
@@ -373,7 +374,8 @@ export const actionHandlers = handleThunks({
   [REMOVE_QUEUE_ITEMS]: function(getState, payload, dispatch) {
     const {
       ids,
-      blacklist
+      blacklist,
+      skipredownload
     } = payload;
 
     dispatch(batchActions([
@@ -389,7 +391,7 @@ export const actionHandlers = handleThunks({
     ]));
 
     const promise = createAjaxRequest({
-      url: `/queue/bulk?blacklist=${blacklist}`,
+      url: `/queue/bulk?blacklist=${blacklist}&skipredownload=${skipredownload}`,
       method: 'DELETE',
       dataType: 'json',
       data: JSON.stringify({ ids })

--- a/src/Lidarr.Api.V1/Queue/QueueActionModule.cs
+++ b/src/Lidarr.Api.V1/Queue/QueueActionModule.cs
@@ -77,8 +77,9 @@ namespace Lidarr.Api.V1.Queue
         private Response Remove(int id)
         {
             var blacklist = Request.GetBooleanQueryParameter("blacklist");
+            var skipReDownload = Request.GetBooleanQueryParameter("skipredownload");
 
-            var trackedDownload = Remove(id, blacklist);
+            var trackedDownload = Remove(id, blacklist, skipReDownload);
 
             if (trackedDownload != null)
             {
@@ -91,13 +92,14 @@ namespace Lidarr.Api.V1.Queue
         private Response Remove()
         {
             var blacklist = Request.GetBooleanQueryParameter("blacklist");
+            var skipReDownload = Request.GetBooleanQueryParameter("skipredownload");
 
             var resource = Request.Body.FromJson<QueueBulkResource>();
             var trackedDownloadIds = new List<string>();
 
             foreach (var id in resource.Ids)
             {
-                var trackedDownload = Remove(id, blacklist);
+                var trackedDownload = Remove(id, blacklist, skipReDownload);
 
                 if (trackedDownload != null)
                 {
@@ -110,7 +112,7 @@ namespace Lidarr.Api.V1.Queue
             return new object().AsResponse();
         }
 
-        private TrackedDownload Remove(int id, bool blacklist)
+        private TrackedDownload Remove(int id, bool blacklist, bool skipReDownload)
         {
             var pendingRelease = _pendingReleaseService.FindPendingQueueItem(id);
 
@@ -139,7 +141,7 @@ namespace Lidarr.Api.V1.Queue
 
             if (blacklist)
             {
-                _failedDownloadService.MarkAsFailed(trackedDownload.DownloadItem.DownloadId);
+                _failedDownloadService.MarkAsFailed(trackedDownload.DownloadItem.DownloadId, skipReDownload);
             }
 
             return trackedDownload;

--- a/src/NzbDrone.Core.Test/Download/RedownloadFailedDownloadServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/RedownloadFailedDownloadServiceFixture.cs
@@ -1,0 +1,128 @@
+using NUnit.Framework;
+using NzbDrone.Core.Download;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Messaging.Commands;
+using Moq;
+using System.Collections.Generic;
+using NzbDrone.Core.Music;
+using FizzWare.NBuilder;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.IndexerSearch;
+
+namespace NzbDrone.Core.Test.Download
+{
+    [TestFixture]
+    public class RedownloadFailedDownloadServiceFixture : CoreTest<RedownloadFailedDownloadService>
+    {
+        [SetUp]
+        public void Setup()
+        {
+            Mocker.GetMock<IConfigService>()
+                .Setup(x => x.AutoRedownloadFailed)
+                .Returns(true);
+
+            Mocker.GetMock<IAlbumService>()
+                .Setup(x => x.GetAlbumsByArtist(It.IsAny<int>()))
+                .Returns(Builder<Album>.CreateListOfSize(3).Build() as List<Album>);
+        }
+
+        [Test]
+        public void should_skip_redownload_if_event_has_skipredownload_set()
+        {
+            var failedEvent = new DownloadFailedEvent {
+                ArtistId = 1,
+                AlbumIds = new List<int> { 1 },
+                SkipReDownload = true
+            };
+
+            Subject.HandleAsync(failedEvent);
+
+            Mocker.GetMock<IManageCommandQueue>()
+                .Verify(x => x.Push(It.IsAny<Command>(), It.IsAny<CommandPriority>(), It.IsAny<CommandTrigger>()),
+                        Times.Never());
+        }
+
+        [Test]
+        public void should_skip_redownload_if_redownload_failed_disabled()
+        {
+            var failedEvent = new DownloadFailedEvent {
+                ArtistId = 1,
+                AlbumIds = new List<int> { 1 }
+            };
+
+            Mocker.GetMock<IConfigService>()
+                .Setup(x => x.AutoRedownloadFailed)
+                .Returns(false);
+
+            Subject.HandleAsync(failedEvent);
+
+            Mocker.GetMock<IManageCommandQueue>()
+                .Verify(x => x.Push(It.IsAny<Command>(), It.IsAny<CommandPriority>(), It.IsAny<CommandTrigger>()),
+                        Times.Never());
+        }
+
+        [Test]
+        public void should_redownload_album_on_failure()
+        {
+            var failedEvent = new DownloadFailedEvent {
+                ArtistId = 1,
+                AlbumIds = new List<int> { 2 }
+            };
+
+            Subject.HandleAsync(failedEvent);
+
+            Mocker.GetMock<IManageCommandQueue>()
+                .Verify(x => x.Push(It.Is<AlbumSearchCommand>(c => c.AlbumIds.Count == 1 &&
+                                                              c.AlbumIds[0] == 2),
+                                    It.IsAny<CommandPriority>(), It.IsAny<CommandTrigger>()),
+                        Times.Once());
+
+            Mocker.GetMock<IManageCommandQueue>()
+                .Verify(x => x.Push(It.IsAny<ArtistSearchCommand>(), It.IsAny<CommandPriority>(), It.IsAny<CommandTrigger>()),
+                        Times.Never());
+        }
+
+        [Test]
+        public void should_redownload_multiple_albums_on_failure()
+        {
+            var failedEvent = new DownloadFailedEvent {
+                ArtistId = 1,
+                AlbumIds = new List<int> { 2, 3 }
+            };
+
+            Subject.HandleAsync(failedEvent);
+
+            Mocker.GetMock<IManageCommandQueue>()
+                .Verify(x => x.Push(It.Is<AlbumSearchCommand>(c => c.AlbumIds.Count == 2 &&
+                                                              c.AlbumIds[0] == 2 &&
+                                                              c.AlbumIds[1] == 3),
+                                    It.IsAny<CommandPriority>(), It.IsAny<CommandTrigger>()),
+                        Times.Once());
+
+            Mocker.GetMock<IManageCommandQueue>()
+                .Verify(x => x.Push(It.IsAny<ArtistSearchCommand>(), It.IsAny<CommandPriority>(), It.IsAny<CommandTrigger>()),
+                        Times.Never());
+        }
+
+        [Test]
+        public void should_redownload_artist_on_failure()
+        {
+            // note that artist is set to have 3 albums in setup
+            var failedEvent = new DownloadFailedEvent {
+                ArtistId = 2,
+                AlbumIds = new List<int> { 1, 2, 3 }
+            };
+
+            Subject.HandleAsync(failedEvent);
+
+            Mocker.GetMock<IManageCommandQueue>()
+                .Verify(x => x.Push(It.Is<ArtistSearchCommand>(c => c.ArtistId == failedEvent.ArtistId),
+                                    It.IsAny<CommandPriority>(), It.IsAny<CommandTrigger>()),
+                        Times.Once());
+
+            Mocker.GetMock<IManageCommandQueue>()
+                .Verify(x => x.Push(It.IsAny<AlbumSearchCommand>(), It.IsAny<CommandPriority>(), It.IsAny<CommandTrigger>()),
+                        Times.Never());
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -139,6 +139,7 @@
     <Compile Include="Download\DownloadClientTests\VuzeTests\VuzeFixture.cs" />
     <Compile Include="Download\DownloadServiceFixture.cs" />
     <Compile Include="Download\FailedDownloadServiceFixture.cs" />
+    <Compile Include="Download\RedownloadFailedDownloadServiceFixture.cs" />
     <Compile Include="Download\NzbValidationServiceFixture.cs" />
     <Compile Include="Download\Pending\PendingReleaseServiceTests\PendingReleaseServiceFixture.cs" />
     <Compile Include="Download\Pending\PendingReleaseServiceTests\RemovePendingFixture.cs" />

--- a/src/NzbDrone.Core/Download/DownloadFailedEvent.cs
+++ b/src/NzbDrone.Core/Download/DownloadFailedEvent.cs
@@ -23,5 +23,6 @@ namespace NzbDrone.Core.Download
         public Dictionary<string, string> Data { get; set; }
         public TrackedDownload TrackedDownload { get; set; }
         public Language Language { get; set; }
+        public bool SkipReDownload { get; set; }
     }
 }

--- a/src/NzbDrone.Core/Download/RedownloadFailedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/RedownloadFailedDownloadService.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using NLog;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.IndexerSearch;
@@ -28,6 +28,12 @@ namespace NzbDrone.Core.Download
 
         public void HandleAsync(DownloadFailedEvent message)
         {
+            if (message.SkipReDownload)
+            {
+                _logger.Debug("Skip redownloading requested by user");
+                return;
+            }
+
             if (!_configService.AutoRedownloadFailed)
             {
                 _logger.Debug("Auto redownloading failed albums is disabled");


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When trying to remove a failed/not matching download from queue with blacklisting, it should be possible to skip the automatic redownload as it would try to find another release which might be unwanted.

Adds tests to #616 