### PR TITLE
Fixed: Album Lookup API

### DIFF
--- a/frontend/src/Album/Details/AlbumDetailsPageConnector.js
+++ b/frontend/src/Album/Details/AlbumDetailsPageConnector.js
@@ -55,7 +55,10 @@ class AlbumDetailsPageConnector extends Component {
   populate = () => {
     const foreignAlbumId = this.props.foreignAlbumId;
     this.setState({ hasMounted: true });
-    this.props.fetchAlbums({ foreignAlbumId });
+    this.props.fetchAlbums({
+      foreignAlbumId,
+      includeAllArtistAlbums: true
+    });
   }
 
   unpopulate = () => {

--- a/src/Lidarr.Api.V1/Albums/AlbumLookupModule.cs
+++ b/src/Lidarr.Api.V1/Albums/AlbumLookupModule.cs
@@ -20,13 +20,11 @@ namespace Lidarr.Api.V1.Albums
             Get["/"] = x => Search();
         }
 
-
         private Response Search()
         {
             var searchResults = _searchProxy.SearchForNewAlbum((string)Request.Query.term, null);
-            return MapToResource(searchResults).AsResponse();
+            return MapToResource(searchResults).ToList().AsResponse();
         }
-
 
         private static IEnumerable<AlbumResource> MapToResource(IEnumerable<NzbDrone.Core.Music.Album> albums)
         {

--- a/src/Lidarr.Api.V1/Albums/AlbumModule.cs
+++ b/src/Lidarr.Api.V1/Albums/AlbumModule.cs
@@ -42,6 +42,7 @@ namespace Lidarr.Api.V1.Albums
             var artistIdQuery = Request.Query.ArtistId;
             var albumIdsQuery = Request.Query.AlbumIds;
             var foreignIdQuery = Request.Query.ForeignAlbumId;
+            var includeAllArtistAlbumsQuery = Request.Query.IncludeAllArtistAlbums;
 
             if (!Request.Query.ArtistId.HasValue && !albumIdsQuery.HasValue && !foreignIdQuery.HasValue)
             {
@@ -57,9 +58,18 @@ namespace Lidarr.Api.V1.Albums
 
             if (foreignIdQuery.HasValue)
             {
-                int artistId = _albumService.FindById(foreignIdQuery.Value).ArtistId;
+                string foreignAlbumId = foreignIdQuery.Value.ToString();
 
-                return MapToResource(_albumService.GetAlbumsByArtist(artistId), false);
+                var album = _albumService.FindById(foreignAlbumId);
+
+                if (includeAllArtistAlbumsQuery.HasValue && Convert.ToBoolean(includeAllArtistAlbumsQuery.Value))
+                {
+                    return MapToResource(_albumService.GetAlbumsByArtist(album.ArtistId), false);
+                }
+                else
+                {
+                    return MapToResource(new List<Album> { album }, false);
+                }
             }
 
             string albumIdsValue = albumIdsQuery.Value.ToString();

--- a/src/Lidarr.Api.V1/Artist/ArtistLookupModule.cs
+++ b/src/Lidarr.Api.V1/Artist/ArtistLookupModule.cs
@@ -19,13 +19,11 @@ namespace Lidarr.Api.V1.Artist
             Get["/"] = x => Search();
         }
 
-
         private Response Search()
         {
             var searchResults = _searchProxy.SearchForNewArtist((string)Request.Query.term);
-            return MapToResource(searchResults).AsResponse();
+            return MapToResource(searchResults).ToList().AsResponse();
         }
-
 
         private static IEnumerable<ArtistResource> MapToResource(IEnumerable<NzbDrone.Core.Music.Artist> artist)
         {

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -225,7 +225,13 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
 
                         if (existingAlbum == null)
                         {
-                            return new List<Album> { GetAlbumInfo(searchGuid.ToString()).Item2 };
+                            var data = GetAlbumInfo(searchGuid.ToString());
+                            var album = data.Item2;
+                            album.Artist = _artistService.FindById(data.Item1) ?? new Artist {
+                                Metadata = data.Item3.Single(x => x.ForeignArtistId == data.Item1)
+                            };
+
+                            return new List<Album> { album };
                         }
 
                         existingAlbum.Artist = _artistService.GetArtist(existingAlbum.ArtistId);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
 - Make the Album/Artists lookup endpoints show an error if they fail instead of silently responding `500`
 - Reinstate `foreignArtistId` for album lookup on a specific album (i.e. queried with foreign ID)

#### TODOS
 - [x] Should we fix #731 or is that deliberate?

#### Issues Fixed or Closed by this PR

* Fixes #733 
* Fixes #731