### PR TITLE
Fixed: Nullref due to InfoHash on AlreadyImportedSpec

### DIFF
--- a/src/NzbDrone.Core.Test/DecisionEngineTests/AlreadyImportedSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/AlreadyImportedSpecificationFixture.cs
@@ -154,6 +154,36 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         }
 
         [Test]
+        public void should_be_accepted_if_release_torrent_hash_is_null()
+        {
+            var downloadId = Guid.NewGuid().ToString().ToUpper();
+
+            GivenHistoryItem(downloadId, TITLE, _mp3, HistoryEventType.Grabbed);
+            GivenHistoryItem(downloadId, TITLE, _flac, HistoryEventType.DownloadImported);
+
+            _remoteAlbum.Release = Builder<TorrentInfo>.CreateNew()
+                                                         .With(t => t.DownloadProtocol = DownloadProtocol.Torrent)
+                                                         .With(t => t.InfoHash = null)
+                                                         .Build();
+
+            Subject.IsSatisfiedBy(_remoteAlbum, null).Accepted.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_be_accepted_if_release_torrent_hash_is_null_and_downloadId_is_null()
+        {
+            GivenHistoryItem(null, TITLE, _mp3, HistoryEventType.Grabbed);
+            GivenHistoryItem(null, TITLE, _flac, HistoryEventType.DownloadImported);
+
+            _remoteAlbum.Release = Builder<TorrentInfo>.CreateNew()
+                                                         .With(t => t.DownloadProtocol = DownloadProtocol.Torrent)
+                                                         .With(t => t.InfoHash = null)
+                                                         .Build();
+
+            Subject.IsSatisfiedBy(_remoteAlbum, null).Accepted.Should().BeTrue();
+        }
+
+        [Test]
         public void should_be_rejected_if_release_title_matches_grabbed_event_source_title()
         {
             var downloadId = Guid.NewGuid().ToString().ToUpper();

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/AlreadyImportedSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/AlreadyImportedSpecification.cs
@@ -77,13 +77,13 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                     continue;
                 }
 
-                var release = subject.Release;
+                var release = subject.Release;                
 
                 if (release.DownloadProtocol == DownloadProtocol.Torrent)
                 {
                     var torrentInfo = release as TorrentInfo;
 
-                    if (torrentInfo != null && torrentInfo.InfoHash.ToUpper() == lastGrabbed.DownloadId)
+                    if (torrentInfo?.InfoHash != null && torrentInfo.InfoHash.ToUpper() == lastGrabbed.DownloadId)
                     {
                         _logger.Debug("Has same torrent hash as a grabbed and imported release");
                         return Decision.Reject("Has same torrent hash as a grabbed and imported release");


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Check for null infoHash and prevent error if so

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR
Fixes #741 
Fixes LIDARR-1Y5
* 
