### PR TITLE
Fixed: Skip albums and releases with no valid tracks

### DIFF
--- a/src/NzbDrone.Core.Test/MusicTests/AddAlbumFixture.cs
+++ b/src/NzbDrone.Core.Test/MusicTests/AddAlbumFixture.cs
@@ -90,6 +90,30 @@ namespace NzbDrone.Core.Test.MusicTests
         }
 
         [Test]
+        public void should_not_add_if_no_releases()
+        {
+            _fakeAlbum.AlbumReleases = new List<AlbumRelease>();
+            GivenValidAlbum(_fakeAlbum.ForeignAlbumId);
+
+            Subject.AddAlbum(_fakeAlbum).Should().BeNull();
+            
+            Mocker.GetMock<IAlbumService>()
+                .Verify(x => x.AddAlbum(It.IsAny<Album>()), Times.Never());
+        }
+        
+        [Test]
+        public void should_not_add_item_in_list_if_no_releases()
+        {
+            _fakeAlbum.AlbumReleases = new List<AlbumRelease>();
+            GivenValidAlbum(_fakeAlbum.ForeignAlbumId);
+
+            Subject.AddAlbums(new List<Album> { _fakeAlbum }).Should().BeEquivalentTo(new List<Album> { null });
+            
+            Mocker.GetMock<IAlbumService>()
+                .Verify(x => x.AddAlbum(It.IsAny<Album>()), Times.Never());
+        }
+
+        [Test]
         public void should_not_add_duplicate_releases()
         {
             var newAlbum = Builder<Album>.CreateNew().Build();

--- a/src/NzbDrone.Core.Test/MusicTests/RefreshAlbumServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MusicTests/RefreshAlbumServiceFixture.cs
@@ -108,6 +108,21 @@ namespace NzbDrone.Core.Test.MusicTests
         }
 
         [Test]
+        public void should_remove_album_with_no_valid_releases()
+        {
+            var album = _albums.First();
+            album.AlbumReleases = new List<AlbumRelease>();
+
+            GivenNewAlbumInfo(album);
+
+            Subject.RefreshAlbumInfo(album, false);
+            
+            Mocker.GetMock<IAlbumService>()
+                .Verify(x => x.DeleteMany(It.Is<List<Album>>(y => y.Count == 1 && y.First().ForeignAlbumId == album.ForeignAlbumId)),
+                        Times.Once());
+        }
+
+        [Test]
         public void two_equivalent_releases_should_be_equal()
         {
             var release = Builder<AlbumRelease>.CreateNew().Build();

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -319,7 +319,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
 
             if (resource.Releases != null)
             {
-                album.AlbumReleases = resource.Releases.Select(x => MapRelease(x, artistDict)).ToList();
+                album.AlbumReleases = resource.Releases.Select(x => MapRelease(x, artistDict)).Where(x => x.TrackCount > 0).ToList();
             }
 
             album.AnyReleaseOk = true;

--- a/src/NzbDrone.Core/Music/AddAlbumService.cs
+++ b/src/NzbDrone.Core/Music/AddAlbumService.cs
@@ -86,6 +86,13 @@ namespace NzbDrone.Core.Music
         private Album AddAlbum(Tuple<string, Album, List<ArtistMetadata>> skyHookData)
         {
             var newAlbum = skyHookData.Item2;
+
+            if (newAlbum.AlbumReleases.Value.Count == 0)
+            {
+                _logger.Debug($"Skipping album with no valid releases {newAlbum}");
+                return null;
+            }
+
             _logger.ProgressInfo("Adding Album {0}", newAlbum.Title);
             
             _artistMetadataRepository.UpsertMany(skyHookData.Item3);

--- a/src/NzbDrone.Core/Music/RefreshAlbumService.cs
+++ b/src/NzbDrone.Core/Music/RefreshAlbumService.cs
@@ -84,6 +84,13 @@ namespace NzbDrone.Core.Music
                 return;
             }
 
+            if (tuple.Item2.AlbumReleases.Value.Count == 0)
+            {
+                _logger.Debug($"{album} has no valid releases, removing.");
+                _albumService.DeleteMany(new List<Album> { album });
+                return;
+            }
+
             var remoteMetadata = tuple.Item3.DistinctBy(x => x.ForeignArtistId).ToList();
             var existingMetadata = _artistMetadataRepository.FindById(remoteMetadata.Select(x => x.ForeignArtistId).ToList());
             var updateMetadataList = new List<ArtistMetadata>();

--- a/src/NzbDrone.Core/Music/RefreshArtistService.cs
+++ b/src/NzbDrone.Core/Music/RefreshArtistService.cs
@@ -139,8 +139,6 @@ namespace NzbDrone.Core.Music
                 }
             }
 
-            _artistService.UpdateArtist(artist);
-            
             _logger.Debug("{0} Deleting {1}, Updating {2}, Adding {3} albums",
                           artist, existingAlbums.Count, updateAlbumsList.Count, newAlbumsList.Count);
 
@@ -157,10 +155,12 @@ namespace NzbDrone.Core.Music
 
             _refreshAlbumService.RefreshAlbumInfo(updateAlbumsList, forceAlbumRefresh, forceUpdateFileTags);
 
-            _eventAggregator.PublishEvent(new AlbumInfoRefreshedEvent(artist, newAlbumsList, updateAlbumsList));
+            // Do this last so artist only marked as refreshed if refresh of tracks / albums completed successfully
+            _artistService.UpdateArtist(artist);
 
-            _logger.Debug("Finished artist refresh for {0}", artist.Name);
+            _eventAggregator.PublishEvent(new AlbumInfoRefreshedEvent(artist, newAlbumsList, updateAlbumsList));
             _eventAggregator.PublishEvent(new ArtistUpdatedEvent(artist));
+            _logger.Debug("Finished artist refresh for {0}", artist.Name);
         }
 
         private List<Album> UpdateAlbums(Artist artist, List<Album> albumsToUpdate)


### PR DESCRIPTION
#### Database Migration
NO

Only mark artist as refreshed if track refresh successful. Also skip albums and releases with no valid tracks.