### PR TITLE
Fixed: Migration 23 doesn't set Track.ArtistMetadataId

### DIFF
--- a/src/NzbDrone.Core.Test/Datastore/Migration/023_add_release_groups_etcFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/Migration/023_add_release_groups_etcFixture.cs
@@ -95,8 +95,12 @@ namespace NzbDrone.Core.Test.Datastore.Migration
                                          "JOIN AlbumReleases ON Tracks.AlbumReleaseId = AlbumReleases.Id " +
                                          "JOIN Albums ON AlbumReleases.AlbumId = Albums.Id " +
                                          "WHERE Albums.Id = " + albumId).ToList();
+
+            var album = db.Query<Album>("SELECT * FROM Albums WHERE Albums.Id = " + albumId).ToList().Single();
+
             tracks.Count.Should().Be(expectedCount);
             tracks.First().AlbumReleaseId.Should().Be(albumReleaseId);
+            tracks.All(t => t.ArtistMetadataId == album.ArtistMetadataId).Should().BeTrue();
         }
         
         [Test]

--- a/src/NzbDrone.Core/Datastore/Migration/023_add_release_groups_etc.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/023_add_release_groups_etc.cs
@@ -88,6 +88,13 @@ namespace NzbDrone.Core.Datastore.Migration
                                                 JOIN Albums ON AlbumReleases.AlbumId = Albums.Id
                                                 WHERE Albums.Id = Tracks.AlbumId)");
 
+            // Set metadata ID
+            Execute.Sql(@"UPDATE Tracks
+                          SET ArtistMetadataId = (SELECT ArtistMetadata.Id 
+                                                  FROM ArtistMetadata 
+                                                  JOIN Albums ON ArtistMetadata.Id = Albums.ArtistMetadataId
+                                                  WHERE Tracks.AlbumId = Albums.Id)");
+
             // CLEAR OUT OLD COLUMNS
 
             // Remove the columns in Artists now in ArtistMetadata


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Ensure Migration 23 sets Track.ArtistMetadataId from Album

#### Todos
- [x] Tests

