### PR TITLE
Fixed: Error selecting tracks in manual import dialog

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/TrackImport/Manual/ManualImportItem.cs
+++ b/src/NzbDrone.Core/MediaFiles/TrackImport/Manual/ManualImportItem.cs
@@ -10,6 +10,11 @@ namespace NzbDrone.Core.MediaFiles.TrackImport.Manual
 {
     public class ManualImportItem : ModelBase
     {
+        public ManualImportItem()
+        {
+            Tracks = new List<Track>();
+        }
+
         public string Path { get; set; }
         public string RelativePath { get; set; }
         public string FolderName { get; set; }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Make sure `x.tracks` is defined before trying to access length.

Fixes error in track selection in manual import.

Fixes Sentry LIDARR-UI-1GC


