### PR TITLE
New: AudioBitRate Naming Token

### DIFF
--- a/frontend/src/Album/Details/TrackRow.css
+++ b/frontend/src/Album/Details/TrackRow.css
@@ -19,7 +19,7 @@
 .audio {
   composes: cell from '~Components/Table/Cells/TableRowCell.css';
 
-  width: 200px;
+  width: 250px;
 }
 
 .language,

--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
@@ -90,6 +90,7 @@ const qualityTokens = [
 const mediaInfoTokens = [
   { token: '{MediaInfo AudioCodec}', example: 'FLAC' },
   { token: '{MediaInfo AudioChannels}', example: '2.0' },
+  { token: '{MediaInfo AudioBitRate}', example: '320kbps' },
   { token: '{MediaInfo AudioBitsPerSample}', example: '24bit' },
   { token: '{MediaInfo AudioSampleRate}', example: '44.1kHz' }
 ];
@@ -100,8 +101,8 @@ const otherTokens = [
 ];
 
 const originalTokens = [
-  { token: '{Original Title}', example: 'Artist.Name.S01E01.HDTV.x264-EVOLVE' },
-  { token: '{Original Filename}', example: 'artist.name.s01e01.hdtv.x264-EVOLVE' }
+  { token: '{Original Title}', example: 'Artist.Name.Album.Name.2018.FLAC-EVOLVE' },
+  { token: '{Original Filename}', example: '01 - track name' }
 ];
 
 class NamingModal extends Component {

--- a/frontend/src/TrackFile/MediaInfo.js
+++ b/frontend/src/TrackFile/MediaInfo.js
@@ -8,7 +8,8 @@ function MediaInfo(props) {
     audioChannels,
     audioCodec,
     audioBitRate,
-    videoCodec
+    audioBits,
+    audioSampleRate
   } = props;
 
   if (type === mediaInfoTypes.AUDIO) {
@@ -38,14 +39,26 @@ function MediaInfo(props) {
           !!audioBitRate &&
             audioBitRate
         }
-      </span>
-    );
-  }
 
-  if (type === mediaInfoTypes.VIDEO) {
-    return (
-      <span>
-        {videoCodec}
+        {
+          ((!!audioCodec && !!audioSampleRate) || (!!audioChannels && !!audioSampleRate) || (!!audioBitRate && !!audioSampleRate)) &&
+          ' - '
+        }
+
+        {
+          !!audioSampleRate &&
+          audioSampleRate
+        }
+
+        {
+          ((!!audioCodec && !!audioBits) || (!!audioChannels && !!audioBits) || (!!audioBitRate && !!audioBits) || (!!audioSampleRate && !!audioBits)) &&
+          ' - '
+        }
+
+        {
+          !!audioBits &&
+          audioBits
+        }
       </span>
     );
   }
@@ -58,7 +71,8 @@ MediaInfo.propTypes = {
   audioChannels: PropTypes.number,
   audioCodec: PropTypes.string,
   audioBitRate: PropTypes.string,
-  videoCodec: PropTypes.string
+  audioBits: PropTypes.string,
+  audioSampleRate: PropTypes.string
 };
 
 export default MediaInfo;

--- a/src/Lidarr.Api.V1/TrackFiles/MediaInfoResource.cs
+++ b/src/Lidarr.Api.V1/TrackFiles/MediaInfoResource.cs
@@ -9,6 +9,8 @@ namespace Lidarr.Api.V1.TrackFiles
         public decimal AudioChannels { get; set; }
         public string AudioBitRate { get; set; }
         public string AudioCodec { get; set; }
+        public string AudioBits { get; set; }
+        public string AudioSampleRate { get; set; }
     }
 
     public static class MediaInfoResourceMapper
@@ -24,7 +26,9 @@ namespace Lidarr.Api.V1.TrackFiles
                    {
                        AudioChannels = MediaInfoFormatter.FormatAudioChannels(model),
                        AudioCodec = MediaInfoFormatter.FormatAudioCodec(model),
-                       AudioBitRate = MediaInfoFormatter.FormatAudioBitrate(model)
+                       AudioBitRate = MediaInfoFormatter.FormatAudioBitrate(model),
+                       AudioBits = MediaInfoFormatter.FormatAudioBitsPerSample(model),
+                       AudioSampleRate = MediaInfoFormatter.FormatAudioSampleRate(model)
                     };
         }
     }

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
@@ -375,7 +375,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
             _namingConfig.StandardTrackFormat = "{MediaInfo AudioSampleRate}";
 
             Subject.BuildTrackFileName(new List<Track> { _track1 }, _artist, _album, _trackFile)
-                   .Should().Be("44kHz");
+                   .Should().Be("44.1kHz");
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
@@ -69,7 +69,16 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
                             .With(e => e.MediumNumber = _medium.Number)
                             .Build();
 
-            _trackFile = new TrackFile { Quality = new QualityModel(Quality.MP3_256), ReleaseGroup = "LidarrTest" };
+            _trackFile = Builder<TrackFile>.CreateNew()
+                .With(e => e.Quality = new QualityModel(Quality.MP3_256))
+                .With(e => e.ReleaseGroup = "LidarrTest")
+                .With(e => e.MediaInfo = new Parser.Model.MediaInfoModel {
+                    AudioBitrate = 320,
+                    AudioBits = 16,
+                    AudioChannels = 2,
+                    AudioFormat = "Flac Audio",
+                    AudioSampleRate = 44100
+                }).Build();
             
             Mocker.GetMock<IQualityDefinitionService>()
                 .Setup(v => v.Get(Moq.It.IsAny<Quality>()))
@@ -322,6 +331,51 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
 
             Subject.BuildTrackFileName(new List<Track> { _track1 }, _artist, _album, _trackFile)
                    .Should().Be("MP3-256");
+        }
+
+        [Test]
+        public void should_replace_media_info_audio_codec()
+        {
+            _namingConfig.StandardTrackFormat = "{MediaInfo AudioCodec}";
+
+            Subject.BuildTrackFileName(new List<Track> { _track1 }, _artist, _album, _trackFile)
+                   .Should().Be("FLAC");
+        }
+
+        [Test]
+        public void should_replace_media_info_audio_bitrate()
+        {
+            _namingConfig.StandardTrackFormat = "{MediaInfo AudioBitRate}";
+
+            Subject.BuildTrackFileName(new List<Track> { _track1 }, _artist, _album, _trackFile)
+                   .Should().Be("320 kbps");
+        }
+
+        [Test]
+        public void should_replace_media_info_audio_channels()
+        {
+            _namingConfig.StandardTrackFormat = "{MediaInfo AudioChannels}";
+
+            Subject.BuildTrackFileName(new List<Track> { _track1 }, _artist, _album, _trackFile)
+                   .Should().Be("2.0");
+        }
+
+        [Test]
+        public void should_replace_media_info_bits_per_sample()
+        {
+            _namingConfig.StandardTrackFormat = "{MediaInfo AudioBitsPerSample}";
+
+            Subject.BuildTrackFileName(new List<Track> { _track1 }, _artist, _album, _trackFile)
+                   .Should().Be("16bit");
+        }
+
+        [Test]
+        public void should_replace_media_info_sample_rate()
+        {
+            _namingConfig.StandardTrackFormat = "{MediaInfo AudioSampleRate}";
+
+            Subject.BuildTrackFileName(new List<Track> { _track1 }, _artist, _album, _trackFile)
+                   .Should().Be("44kHz");
         }
 
         [Test]

--- a/src/NzbDrone.Core/MediaFiles/MediaInfoFormatter.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfoFormatter.cs
@@ -19,6 +19,11 @@ namespace NzbDrone.Core.MediaFiles
 
         public static string FormatAudioBitsPerSample(MediaInfoModel mediaInfo)
         {
+            if (mediaInfo.AudioBits == 0)
+            {
+                return string.Empty;
+            }
+
             return mediaInfo.AudioBits + "bit";
         }
 

--- a/src/NzbDrone.Core/MediaFiles/MediaInfoFormatter.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfoFormatter.cs
@@ -24,7 +24,7 @@ namespace NzbDrone.Core.MediaFiles
 
         public static string FormatAudioSampleRate(MediaInfoModel mediaInfo)
         {
-            return $"{mediaInfo.AudioSampleRate / 1000:0.#}kHz";
+            return $"{(double)mediaInfo.AudioSampleRate / 1000:0.#}kHz";
         }
 
         public static decimal FormatAudioChannels(MediaInfoModel mediaInfo)

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -341,6 +341,7 @@ namespace NzbDrone.Core.Organizer
 
             tokenHandlers["{MediaInfo AudioCodec}"] = m => audioCodec;
             tokenHandlers["{MediaInfo AudioChannels}"] = m => audioChannelsFormatted;
+            tokenHandlers["{MediaInfo AudioBitRate}"] = m => MediaInfoFormatter.FormatAudioBitrate(trackFile.MediaInfo);
             tokenHandlers["{MediaInfo AudioBitsPerSample}"] = m => MediaInfoFormatter.FormatAudioBitsPerSample(trackFile.MediaInfo);
             tokenHandlers["{MediaInfo AudioSampleRate}"] = m => MediaInfoFormatter.FormatAudioSampleRate(trackFile.MediaInfo);
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- Add naming token for AudioBitRate
- Return blank for AudioBits when = to 0
- Add tests for MediaInfo Tokens
- Show Bits and SampleRate in UI Track table

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR
#758 partial
