### PR TITLE
Don't try to match a null codec name

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
@@ -284,6 +284,12 @@ namespace NzbDrone.Core.Test.ParserTests
             QualityParser.ParseQuality(title, null, 0).QualityDetectionSource.Should().Be(QualityDetectionSource.Extension);
         }
 
+        [Test]
+        public void should_parse_null_quality_description_as_unknown()
+        {
+            QualityParser.ParseCodec(null, null).Should().Be(Codec.Unknown);
+        }
+
         private void ParseAndVerifyQuality(string name, string desc, int bitrate, Quality quality, int sampleSize = 0)
         {
             var result = QualityParser.ParseQuality(name, desc, bitrate, sampleSize);

--- a/src/NzbDrone.Core/Parser/QualityParser.cs
+++ b/src/NzbDrone.Core/Parser/QualityParser.cs
@@ -154,6 +154,11 @@ namespace NzbDrone.Core.Parser
 
         public static Codec ParseCodec(string name, string origName)
         {
+            if (name.IsNullOrWhiteSpace())
+            {
+                return Codec.Unknown;
+            }
+
             var match = CodecRegex.Match(name);
 
             if (!match.Success) { return Codec.Unknown; }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixes #773 

#### Todos
- [x] Tests

