### PR TITLE
Remove rogue . from transmission output directory

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
@@ -120,7 +120,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
             
             if (Settings.MusicCategory.IsNotNullOrWhiteSpace())
             {
-                destDir = string.Format("{0}/.{1}", destDir, Settings.MusicCategory);
+                destDir = string.Format("{0}/{1}", destDir, Settings.MusicCategory);
             }
 
             return new DownloadClientInfo


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixes issue with health check reported on discord.  Was adding a bonus `.` into the path.
