### PR TITLE
Fixed: Map dsm shared folder to full path in status

### DIFF
--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/TorrentDownloadStationFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/TorrentDownloadStationFixture.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Download;
+using NzbDrone.Core.Download.Clients;
 using NzbDrone.Core.Download.Clients.DownloadStation;
 using NzbDrone.Core.Download.Clients.DownloadStation.Proxies;
 using NzbDrone.Core.MediaFiles.TorrentInfo;
@@ -296,6 +297,17 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
                   .Returns<OsPath, DownloadStationSettings, string>((path, setttings, serial) => _physicalPath);
         }
 
+        protected void GivenSharedFolder(string share)
+        {
+            Mocker.GetMock<ISharedFolderResolver>()
+                  .Setup(s => s.RemapToFullPath(It.IsAny<OsPath>(), It.IsAny<DownloadStationSettings>(), It.IsAny<string>()))
+                  .Throws(new DownloadClientException("There is no matching shared folder"));
+
+            Mocker.GetMock<ISharedFolderResolver>()
+                  .Setup(s => s.RemapToFullPath(It.Is<OsPath>(x => x.FullPath == share), It.IsAny<DownloadStationSettings>(), It.IsAny<string>()))
+                  .Returns<OsPath, DownloadStationSettings, string>((path, setttings, serial) => _physicalPath);
+        }
+
         protected void GivenSerialNumber()
         {
             Mocker.GetMock<ISerialNumberProvider>()
@@ -493,6 +505,41 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
 
             Mocker.GetMock<IDownloadStationTaskProxy>()
                   .Verify(v => v.AddTaskFromUrl(It.IsAny<string>(), null, _settings), Times.Never());
+        }
+
+        [Test]
+        public void GetStatus_should_map_outputpath_when_using_default()
+        {
+            GivenSerialNumber();
+            GivenSharedFolder("/somepath");
+
+            var status = Subject.GetStatus();
+
+            status.OutputRootFolders.First().Should().Be(_physicalPath);
+        }
+
+        [Test]
+        public void GetStatus_should_map_outputpath_when_using_destination()
+        {
+            GivenSerialNumber();
+            GivenTvDirectory();
+            GivenSharedFolder($"/{_musicDirectory}");
+
+            var status = Subject.GetStatus();
+
+            status.OutputRootFolders.First().Should().Be(_physicalPath);
+        }
+
+        [Test]
+        public void GetStatus_should_map_outputpath_when_using_category()
+        {
+            GivenSerialNumber();
+            GivenMusicCategory();
+            GivenSharedFolder($"/somepath/{_category}");
+
+            var status = Subject.GetStatus();
+
+            status.OutputRootFolders.First().Should().Be(_physicalPath);
         }
 
         [Test]

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
@@ -113,12 +113,15 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
         {
             try
             {
-                var path = GetDownloadDirectory();
+                var serialNumber = _serialNumberProvider.GetSerialNumber(Settings);
+                var sharedFolder = GetDownloadDirectory() ?? GetDefaultDir();
+                var outputPath = new OsPath($"/{sharedFolder.TrimStart('/')}");
+                var path = _sharedFolderResolver.RemapToFullPath(outputPath, Settings, serialNumber);
 
                 return new DownloadClientInfo
                 {
                     IsLocalhost = Settings.Host == "127.0.0.1" || Settings.Host == "localhost",
-                    OutputRootFolders = new List<OsPath> { _remotePathMappingService.RemapRemoteToLocal(Settings.Host, new OsPath(path)) }
+                    OutputRootFolders = new List<OsPath> { _remotePathMappingService.RemapRemoteToLocal(Settings.Host, path) }
                 };
             }
             catch (DownloadClientException e)

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
@@ -138,12 +138,15 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
         {
             try
             {
-                var path = GetDownloadDirectory();
+                var serialNumber = _serialNumberProvider.GetSerialNumber(Settings);
+                var sharedFolder = GetDownloadDirectory() ?? GetDefaultDir();
+                var outputPath = new OsPath($"/{sharedFolder.TrimStart('/')}");
+                var path = _sharedFolderResolver.RemapToFullPath(outputPath, Settings, serialNumber);
 
                 return new DownloadClientInfo
                 {
                     IsLocalhost = Settings.Host == "127.0.0.1" || Settings.Host == "localhost",
-                    OutputRootFolders = new List<OsPath> { _remotePathMappingService.RemapRemoteToLocal(Settings.Host, new OsPath(path)) }
+                    OutputRootFolders = new List<OsPath> { _remotePathMappingService.RemapRemoteToLocal(Settings.Host, path) }
                 };
             }
             catch (DownloadClientException e)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Map DSM shared folder to proper path in status for use in root path heath check.

Tested by gouty on discord.

#### Todos



#### Issues Fixed or Closed by this PR

* 
