### PR TITLE
Fixed: Lidarr Lists use correct metadata server

### DIFF
--- a/src/NzbDrone.Core.Test/MetadataSource/MetadataRequestBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/MetadataSource/MetadataRequestBuilderFixture.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.MetadataSource;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Common.Cloud;
+using NzbDrone.Common.Http;
+
+namespace NzbDrone.Core.Test.MetadataSource
+{
+    [TestFixture]
+    public class MetadataRequestBuilderFixture : CoreTest<MetadataRequestBuilder>
+    {
+        [SetUp]
+        public void Setup()
+        {
+            Mocker.GetMock<IConfigService>()
+                .Setup(s => s.MetadataSource)
+                .Returns("");
+
+            Mocker.GetMock<ILidarrCloudRequestBuilder>()
+                .Setup(s => s.Search)
+                .Returns(new HttpRequestBuilder("https://api.lidarr.audio/api/v0.4/{route}").CreateFactory());
+        }
+
+        private void WithCustomProvider()
+        {
+            Mocker.GetMock<IConfigService>()
+                .Setup(s => s.MetadataSource)
+                .Returns("http://api.lidarr.audio/api/testing/");
+        }
+
+        [TestCase]
+        public void should_use_user_definied_if_not_blank()
+        {
+            WithCustomProvider();
+
+            var details = Subject.GetRequestBuilder().Create();
+
+            details.BaseUrl.ToString().Should().Contain("testing");
+        }
+
+        [TestCase]
+        public void should_use_default_if_config_blank()
+        {
+            var details = Subject.GetRequestBuilder().Create();
+
+            details.BaseUrl.ToString().Should().Contain("v0.4");
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -311,6 +311,7 @@
     <Compile Include="MediaFiles\ImportApprovedTracksFixture.cs" />
     <Compile Include="MediaFiles\MediaFileRepositoryFixture.cs" />
     <Compile Include="Messaging\Commands\CommandQueueManagerFixture.cs" />
+    <Compile Include="MetadataSource\MetadataRequestBuilderFixture.cs" />
     <Compile Include="MetadataSource\SkyHook\SkyHookProxySearchFixture.cs" />
     <Compile Include="MetadataSource\SearchArtistComparerFixture.cs" />
     <Compile Include="MetadataSource\SkyHook\SkyHookProxyFixture.cs" />

--- a/src/NzbDrone.Core/ImportLists/LidarrLists/LidarrLists.cs
+++ b/src/NzbDrone.Core/ImportLists/LidarrLists/LidarrLists.cs
@@ -4,6 +4,7 @@ using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.ThingiProvider;
+using NzbDrone.Core.MetadataSource;
 
 namespace NzbDrone.Core.ImportLists.LidarrLists
 {
@@ -13,10 +14,12 @@ namespace NzbDrone.Core.ImportLists.LidarrLists
 
         public override int PageSize => 10;
 
-        public LidarrLists(IHttpClient httpClient, IImportListStatusService importListStatusService, IConfigService configService, IParsingService parsingService, Logger logger)
+        private readonly IMetadataRequestBuilder _requestBuilder;
+
+        public LidarrLists(IHttpClient httpClient, IImportListStatusService importListStatusService, IConfigService configService, IParsingService parsingService, IMetadataRequestBuilder requestBuilder, Logger logger)
             : base(httpClient, importListStatusService, configService, parsingService, logger)
         {
-
+            _requestBuilder = requestBuilder;
         }
 
         public override IEnumerable<ProviderDefinition> DefaultDefinitions
@@ -29,7 +32,6 @@ namespace NzbDrone.Core.ImportLists.LidarrLists
                 yield return GetDefinition("Apple Music New Albums", GetSettings("apple-music/album/new"));
                 yield return GetDefinition("Billboard Top Albums", GetSettings("billboard/album/top"));
                 yield return GetDefinition("Billboard Top Artists", GetSettings("billboard/artist/top"));
-                yield return GetDefinition("Last.fm Top Albums", GetSettings("lastfm/album/top"));
                 yield return GetDefinition("Last.fm Top Artists", GetSettings("lastfm/artist/top"));
             }
         }
@@ -54,7 +56,7 @@ namespace NzbDrone.Core.ImportLists.LidarrLists
 
         public override IImportListRequestGenerator GetRequestGenerator()
         {
-            return new LidarrListsRequestGenerator { Settings = Settings, PageSize = PageSize };
+            return new LidarrListsRequestGenerator(_requestBuilder) { Settings = Settings };
         }
 
         public override IParseImportListResponse GetParser()

--- a/src/NzbDrone.Core/ImportLists/LidarrLists/LidarrListsRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/LidarrLists/LidarrListsRequestGenerator.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-using NzbDrone.Common.Http;
+using NzbDrone.Core.MetadataSource;
 
 namespace NzbDrone.Core.ImportLists.LidarrLists
 {
@@ -7,13 +7,11 @@ namespace NzbDrone.Core.ImportLists.LidarrLists
     {
         public LidarrListsSettings Settings { get; set; }
 
-        public int MaxPages { get; set; }
-        public int PageSize { get; set; }
+        private readonly IMetadataRequestBuilder _requestBulder;
 
-        public LidarrListsRequestGenerator()
+        public LidarrListsRequestGenerator(IMetadataRequestBuilder requestBuilder)
         {
-            MaxPages = 1;
-            PageSize = 10;
+            _requestBulder = requestBuilder;
         }
 
         public virtual ImportListPageableRequestChain GetListItems()
@@ -27,8 +25,12 @@ namespace NzbDrone.Core.ImportLists.LidarrLists
 
         private IEnumerable<ImportListRequest> GetPagedRequests()
         {
-            yield return new ImportListRequest(string.Format("{0}{1}", Settings.BaseUrl, Settings.ListId), HttpAccept.Json);
-        }
+            var request = _requestBulder.GetRequestBuilder()
+                                        .Create()
+                                        .SetSegment("route", "chart/" + Settings.ListId)
+                                        .Build();
 
+            yield return new ImportListRequest(request);
+        }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/LidarrLists/LidarrListsSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/LidarrLists/LidarrListsSettings.cs
@@ -8,7 +8,6 @@ namespace NzbDrone.Core.ImportLists.LidarrLists
     {
         public LidarrListsSettingsValidator()
         {
-            RuleFor(c => c.BaseUrl).ValidRootUrl();
         }
     }
 
@@ -18,7 +17,7 @@ namespace NzbDrone.Core.ImportLists.LidarrLists
 
         public LidarrListsSettings()
         {
-            BaseUrl = "https://api.lidarr.audio/api/v0.3/chart/";
+            BaseUrl = "";
         }
 
         public string BaseUrl { get; set; }

--- a/src/NzbDrone.Core/MetadataSource/IMetadataRequestBuilder.cs
+++ b/src/NzbDrone.Core/MetadataSource/IMetadataRequestBuilder.cs
@@ -1,0 +1,37 @@
+using NzbDrone.Common.Cloud;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.Configuration;
+
+namespace NzbDrone.Core.MetadataSource
+{
+
+    public interface IMetadataRequestBuilder
+    {
+        IHttpRequestBuilderFactory GetRequestBuilder();
+    }
+    public class MetadataRequestBuilder : IMetadataRequestBuilder
+    {
+        private readonly IConfigService _configService;
+
+        private readonly ILidarrCloudRequestBuilder _defaultRequestFactory;
+
+        public MetadataRequestBuilder(IConfigService configService, ILidarrCloudRequestBuilder defaultRequestBuilder)
+        {
+            _configService = configService;
+            _defaultRequestFactory = defaultRequestBuilder;
+        }
+
+        public IHttpRequestBuilderFactory GetRequestBuilder()
+        {
+            if (_configService.MetadataSource.IsNotNullOrWhiteSpace())
+            {
+                return new HttpRequestBuilder(_configService.MetadataSource.TrimEnd("/") + "/{route}").CreateFactory();
+            }
+            else
+            {
+                return _defaultRequestFactory.Search;
+            }
+        }
+    }
+}

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -715,6 +715,7 @@
     <Compile Include="Languages\Language.cs" />
     <Compile Include="Languages\LanguageComparer.cs" />
     <Compile Include="Languages\LanguagesBelowCutoff.cs" />
+    <Compile Include="MetadataSource\IMetadataRequestBuilder.cs" />
     <Compile Include="Notifications\Discord\Discord.cs" />
     <Compile Include="Notifications\Discord\DiscordColors.cs" />
     <Compile Include="Notifications\Discord\DiscordException.cs" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- Use the metadata server default or the custom server defined in settings for the Lidarr Lists.

#### Todos
- [x] Tests
