### PR TITLE
Fixed: Correctly handle Repack Releases

### DIFF
--- a/frontend/src/Settings/MediaManagement/MediaManagement.js
+++ b/frontend/src/Settings/MediaManagement/MediaManagement.js
@@ -25,6 +25,12 @@ const allowFingerprintingOptions = [
   { key: 'never', value: 'Never' }
 ];
 
+const downloadPropersAndRepacksOptions = [
+  { key: 'preferAndUpgrade', value: 'Prefer and Upgrade' },
+  { key: 'doNotUpgrade', value: 'Do not Upgrade Automatically' },
+  { key: 'doNotPrefer', value: 'Do not Prefer' }
+];
+
 const fileDateOptions = [
   { key: 'none', value: 'None' },
   { key: 'albumReleaseDate', value: 'Album Release Date' }
@@ -209,14 +215,23 @@ class MediaManagement extends Component {
                     isAdvanced={true}
                     size={sizes.MEDIUM}
                   >
-                    <FormLabel>Download Propers</FormLabel>
+                    <FormLabel>Propers and Repacks</FormLabel>
 
                     <FormInputGroup
-                      type={inputTypes.CHECK}
-                      name="autoDownloadPropers"
-                      helpText="Should Lidarr automatically upgrade to propers when available?"
+                      type={inputTypes.SELECT}
+                      name="downloadPropersAndRepacks"
+                      helpTexts={[
+                        'Whether or not to automatically upgrade to Propers/Repacks',
+                        'Use \'Do not Prefer\' to sort by preferred word score over propers/repacks'
+                      ]}
+                      helpTextWarning={
+                        settings.downloadPropersAndRepacks.value === 'doNotPrefer' ?
+                          'Use preferred words for automatic upgrades to propers/repacks' :
+                          undefined
+                      }
+                      values={downloadPropersAndRepacksOptions}
                       onChange={onInputChange}
-                      {...settings.autoDownloadPropers}
+                      {...settings.downloadPropersAndRepacks}
                     />
                   </FormGroup>
 

--- a/src/Lidarr.Api.V1/Config/MediaManagementConfigResource.cs
+++ b/src/Lidarr.Api.V1/Config/MediaManagementConfigResource.cs
@@ -1,6 +1,7 @@
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.MediaFiles;
 using Lidarr.Http.REST;
+using NzbDrone.Core.Qualities;
 
 namespace Lidarr.Api.V1.Config
 {
@@ -8,7 +9,7 @@ namespace Lidarr.Api.V1.Config
     {
         public bool AutoUnmonitorPreviouslyDownloadedTracks { get; set; }
         public string RecycleBin { get; set; }
-        public bool AutoDownloadPropers { get; set; }
+        public ProperDownloadTypes DownloadPropersAndRepacks { get; set; }
         public bool CreateEmptyArtistFolders { get; set; }
         public bool DeleteEmptyFolders { get; set; }
         public FileDateType FileDate { get; set; }
@@ -35,7 +36,7 @@ namespace Lidarr.Api.V1.Config
             {
                 AutoUnmonitorPreviouslyDownloadedTracks = model.AutoUnmonitorPreviouslyDownloadedTracks,
                 RecycleBin = model.RecycleBin,
-                AutoDownloadPropers = model.AutoDownloadPropers,
+                DownloadPropersAndRepacks = model.DownloadPropersAndRepacks,
                 CreateEmptyArtistFolders = model.CreateEmptyArtistFolders,
                 DeleteEmptyFolders = model.DeleteEmptyFolders,
                 FileDate = model.FileDate,

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/RepackSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/RepackSpecificationFixture.cs
@@ -1,0 +1,203 @@
+using System.Collections.Generic;
+using System.Linq;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Qualities;
+using NzbDrone.Core.DecisionEngine.Specifications;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Music;
+using Moq;
+
+namespace NzbDrone.Core.Test.DecisionEngineTests
+{
+    [TestFixture]
+    public class RepackSpecificationFixture : CoreTest<RepackSpecification>
+    {
+        private ParsedAlbumInfo _parsedAlbumInfo;
+        private List<Album> _albums;
+        private List<TrackFile> _trackFiles;
+
+        [SetUp]
+        public void Setup()
+        {
+            Mocker.Resolve<UpgradableSpecification>();
+
+            _parsedAlbumInfo = Builder<ParsedAlbumInfo>.CreateNew()
+                                                           .With(p => p.Quality = new QualityModel(Quality.FLAC,
+                                                               new Revision(2, 0, false)))
+                                                           .With(p => p.ReleaseGroup = "Lidarr")
+                                                           .Build();
+
+            _albums = Builder<Album>.CreateListOfSize(1)
+                                        .All()
+                                        .BuildList();
+
+            _trackFiles = Builder<TrackFile>.CreateListOfSize(3)
+                                            .All()
+                                            .With(t => t.AlbumId = _albums.First().Id)
+                                            .BuildList();
+
+            Mocker.GetMock<IMediaFileService>()
+                  .Setup(c => c.GetFilesByAlbum(It.IsAny<int>()))
+                  .Returns(_trackFiles);
+        }
+
+        [Test]
+        public void should_return_true_if_it_is_not_a_repack()
+        {
+            var remoteAlbum = Builder<RemoteAlbum>.CreateNew()
+                                                      .With(e => e.ParsedAlbumInfo = _parsedAlbumInfo)
+                                                      .With(e => e.Albums = _albums)
+                                                      .Build();
+
+            Subject.IsSatisfiedBy(remoteAlbum, null)
+                   .Accepted
+                   .Should()
+                   .BeTrue();
+        }
+
+        [Test]
+        public void should_return_true_if_there_are_is_no_track_files()
+        {
+            Mocker.GetMock<IMediaFileService>()
+                  .Setup(c => c.GetFilesByAlbum(It.IsAny<int>()))
+                  .Returns(new List<TrackFile>());
+
+            _parsedAlbumInfo.Quality.Revision.IsRepack = true;
+
+            var remoteAlbum = Builder<RemoteAlbum>.CreateNew()
+                                                      .With(e => e.ParsedAlbumInfo = _parsedAlbumInfo)
+                                                      .With(e => e.Albums = _albums)
+                                                      .Build();
+
+            Subject.IsSatisfiedBy(remoteAlbum, null)
+                   .Accepted
+                   .Should()
+                   .BeTrue();
+        }
+
+        [Test]
+        public void should_return_true_if_is_a_repack_for_a_different_quality()
+        {
+            _parsedAlbumInfo.Quality.Revision.IsRepack = true;
+
+            _trackFiles.Select(c => { c.ReleaseGroup = "Lidarr"; return c; }).ToList();
+            _trackFiles.Select(c => { c.Quality = new QualityModel(Quality.MP3_256); return c; }).ToList();
+
+            var remoteAlbum = Builder<RemoteAlbum>.CreateNew()
+                                                      .With(e => e.ParsedAlbumInfo = _parsedAlbumInfo)
+                                                      .With(e => e.Albums = _albums)
+                                                      .Build();
+
+            Subject.IsSatisfiedBy(remoteAlbum, null)
+                   .Accepted
+                   .Should()
+                   .BeTrue();
+        }
+
+        [Test]
+        public void should_return_true_if_is_a_repack_for_all_existing_files()
+        {
+            _parsedAlbumInfo.Quality.Revision.IsRepack = true;
+
+            _trackFiles.Select(c => { c.ReleaseGroup = "Lidarr"; return c; }).ToList();
+            _trackFiles.Select(c => { c.Quality = new QualityModel(Quality.FLAC); return c; }).ToList();
+
+            var remoteAlbum = Builder<RemoteAlbum>.CreateNew()
+                                                      .With(e => e.ParsedAlbumInfo = _parsedAlbumInfo)
+                                                      .With(e => e.Albums = _albums)
+                                                      .Build();
+
+            Subject.IsSatisfiedBy(remoteAlbum, null)
+                   .Accepted
+                   .Should()
+                   .BeTrue();
+        }
+
+        [Test]
+        public void should_return_false_if_is_a_repack_for_some_but_not_all_trackfiles()
+        {
+            _parsedAlbumInfo.Quality.Revision.IsRepack = true;
+
+            _trackFiles.Select(c => { c.ReleaseGroup = "Lidarr"; return c; }).ToList();
+            _trackFiles.Select(c => { c.Quality = new QualityModel(Quality.FLAC); return c; }).ToList();
+
+            _trackFiles.First().ReleaseGroup = "NotLidarr";
+
+            var remoteAlbum = Builder<RemoteAlbum>.CreateNew()
+                                                      .With(e => e.ParsedAlbumInfo = _parsedAlbumInfo)
+                                                      .With(e => e.Albums = _albums)
+                                                      .Build();
+
+            Subject.IsSatisfiedBy(remoteAlbum, null)
+                   .Accepted
+                   .Should()
+                   .BeFalse();
+        }
+
+
+        [Test]
+        public void should_return_false_if_is_a_repack_for_different_group()
+        {
+            _parsedAlbumInfo.Quality.Revision.IsRepack = true;
+
+            _trackFiles.Select(c => { c.ReleaseGroup = "NotLidarr"; return c; }).ToList();
+            _trackFiles.Select(c => { c.Quality = new QualityModel(Quality.FLAC); return c; }).ToList();
+
+            var remoteAlbum = Builder<RemoteAlbum>.CreateNew()
+                                                      .With(e => e.ParsedAlbumInfo = _parsedAlbumInfo)
+                                                      .With(e => e.Albums = _albums)
+                                                      .Build();
+
+            Subject.IsSatisfiedBy(remoteAlbum, null)
+                   .Accepted
+                   .Should()
+                   .BeFalse();
+        }
+
+
+        [Test]
+        public void should_return_false_if_release_group_for_existing_file_is_unknown()
+        {
+            _parsedAlbumInfo.Quality.Revision.IsRepack = true;
+
+            _trackFiles.Select(c => { c.ReleaseGroup = ""; return c; }).ToList();
+            _trackFiles.Select(c => { c.Quality = new QualityModel(Quality.FLAC); return c; }).ToList();
+
+
+            var remoteAlbum = Builder<RemoteAlbum>.CreateNew()
+                                                      .With(e => e.ParsedAlbumInfo = _parsedAlbumInfo)
+                                                      .With(e => e.Albums = _albums)
+                                                      .Build();
+
+            Subject.IsSatisfiedBy(remoteAlbum, null)
+                   .Accepted
+                   .Should()
+                   .BeFalse();
+        }
+
+        [Test]
+        public void should_return_false_if_release_group_for_release_is_unknown()
+        {
+            _parsedAlbumInfo.Quality.Revision.IsRepack = true;
+            _parsedAlbumInfo.ReleaseGroup = null;
+
+            _trackFiles.Select(c => { c.ReleaseGroup = "Lidarr"; return c; }).ToList();
+            _trackFiles.Select(c => { c.Quality = new QualityModel(Quality.FLAC); return c; }).ToList();
+
+
+            var remoteAlbum = Builder<RemoteAlbum>.CreateNew()
+                                                      .With(e => e.ParsedAlbumInfo = _parsedAlbumInfo)
+                                                      .With(e => e.Albums = _albums)
+                                                      .Build();
+
+            Subject.IsSatisfiedBy(remoteAlbum, null)
+                   .Accepted
+                   .Should()
+                   .BeFalse();
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/UpgradeSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/UpgradeSpecificationFixture.cs
@@ -38,17 +38,17 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
         private static readonly int NoPreferredWordScore = 0;
 
-        private void GivenAutoDownloadPropers(bool autoDownloadPropers)
+        private void GivenAutoDownloadPropers(ProperDownloadTypes type)
         {
             Mocker.GetMock<IConfigService>()
-                  .SetupGet(s => s.AutoDownloadPropers)
-                  .Returns(autoDownloadPropers);
+                  .SetupGet(s => s.DownloadPropersAndRepacks)
+                  .Returns(type);
         }
 
         [Test, TestCaseSource(nameof(IsUpgradeTestCases))]
         public void IsUpgradeTest(Quality current, int currentVersion, Quality newQuality, int newVersion, Quality cutoff, bool expected)
         {
-            GivenAutoDownloadPropers(true);
+            GivenAutoDownloadPropers(ProperDownloadTypes.PreferAndUpgrade);
 
             var profile = new QualityProfile
             {
@@ -78,7 +78,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         [Test, TestCaseSource(nameof(IsUpgradeTestCasesLanguages))]
         public void IsUpgradeTestLanguage(Quality current, int currentVersion, Language currentLanguage, Quality newQuality, int newVersion, Language newLanguage, Quality cutoff, Language languageCutoff, bool expected)
         {
-            GivenAutoDownloadPropers(true);
+            GivenAutoDownloadPropers(ProperDownloadTypes.PreferAndUpgrade);
 
             var profile = new QualityProfile
             {
@@ -107,9 +107,9 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         }
 
         [Test]
-        public void should_return_false_if_proper_and_autoDownloadPropers_is_false()
+        public void should_return_true_if_proper_and_download_propers_is_do_not_download()
         {
-            GivenAutoDownloadPropers(false);
+            GivenAutoDownloadPropers(ProperDownloadTypes.DoNotUpgrade);
 
             var profile = new QualityProfile
             {
@@ -126,13 +126,41 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             Subject.IsUpgradable(
                         profile,
                         langProfile,
-                        new List<QualityModel> { new QualityModel(Quality.MP3_256, new Revision(version: 2)) },
+                        new List<QualityModel> { new QualityModel(Quality.MP3_256, new Revision(version: 1)) },
                         new List<Language> { Language.English },
                         NoPreferredWordScore,
-                        new QualityModel(Quality.MP3_256, new Revision(version: 1)),
+                        new QualityModel(Quality.MP3_256, new Revision(version: 2)),
                         Language.English,
                         NoPreferredWordScore)
-                .Should().BeFalse();
+                    .Should().BeTrue();
+        }
+
+        [Test]
+        public void should_return_false_if_proper_and_autoDownloadPropers_is_do_not_prefer()
+        {
+            GivenAutoDownloadPropers(ProperDownloadTypes.DoNotPrefer);
+
+            var profile = new QualityProfile
+            {
+                Items = Qualities.QualityFixture.GetDefaultQualities(),
+            };
+
+            var langProfile = new LanguageProfile
+            {
+                Languages = LanguageFixture.GetDefaultLanguages(),
+                Cutoff = Language.English
+            };
+
+            Subject.IsUpgradable(
+                        profile,
+                        langProfile,
+                        new List<QualityModel> { new QualityModel(Quality.MP3_256, new Revision(version: 1)) },
+                        new List<Language> { Language.English },
+                        NoPreferredWordScore,
+                        new QualityModel(Quality.MP3_256, new Revision(version: 2)),
+                        Language.English,
+                        NoPreferredWordScore)
+                    .Should().BeFalse();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -103,6 +103,7 @@
     <Compile Include="DecisionEngineTests\ReleaseRestrictionsSpecificationFixture.cs" />
     <Compile Include="DecisionEngineTests\PrioritizeDownloadDecisionFixture.cs" />
     <Compile Include="DecisionEngineTests\QualityAllowedByProfileSpecificationFixture.cs" />
+    <Compile Include="DecisionEngineTests\RepackSpecificationFixture.cs" />
     <Compile Include="DecisionEngineTests\UpgradeAllowedSpecificationFixture.cs" />
     <Compile Include="DecisionEngineTests\UpgradeSpecificationFixture.cs" />
     <Compile Include="DecisionEngineTests\MinimumAgeSpecificationFixture.cs" />

--- a/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
@@ -298,6 +298,16 @@ namespace NzbDrone.Core.Test.ParserTests
             QualityParser.ParseCodec(null, null).Should().Be(Codec.Unknown);
         }
 
+        [TestCase("Artist Title - Album Title 2017 REPACK FLAC aAF", true)]
+        [TestCase("Artist Title - Album Title 2017 RERIP FLAC aAF", true)]
+        [TestCase("Artist Title - Album Title 2017 PROPER FLAC aAF", false)]
+        public void should_be_able_to_parse_repack(string title, bool isRepack)
+        {
+            var result = QualityParser.ParseQuality(title, null, 0);
+            result.Revision.Version.Should().Be(2);
+            result.Revision.IsRepack.Should().Be(isRepack);
+        }
+
         private void ParseAndVerifyQuality(string name, string desc, int bitrate, Quality quality, int sampleSize = 0)
         {
             var result = QualityParser.ParseQuality(name, desc, bitrate, sampleSize);

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -8,6 +8,7 @@ using NzbDrone.Core.Configuration.Events;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Common.Http.Proxy;
+using NzbDrone.Core.Qualities;
 
 namespace NzbDrone.Core.Configuration
 {
@@ -112,11 +113,11 @@ namespace NzbDrone.Core.Configuration
             set { SetValue("MinimumAge", value); }
         }
 
-        public bool AutoDownloadPropers
+        public ProperDownloadTypes DownloadPropersAndRepacks
         {
-            get { return GetValueBoolean("AutoDownloadPropers", true); }
+            get { return GetValueEnum("DownloadPropersAndRepacks", ProperDownloadTypes.PreferAndUpgrade); }
 
-            set { SetValue("AutoDownloadPropers", value); }
+            set { SetValue("DownloadPropersAndRepacks", value); }
         }
 
         public bool EnableCompletedDownloadHandling

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Common.Http.Proxy;
+using NzbDrone.Core.Qualities;
 
 namespace NzbDrone.Core.Configuration
 {
@@ -24,7 +25,7 @@ namespace NzbDrone.Core.Configuration
         //Media Management
         bool AutoUnmonitorPreviouslyDownloadedTracks { get; set; }
         string RecycleBin { get; set; }
-        bool AutoDownloadPropers { get; set; }
+        ProperDownloadTypes DownloadPropersAndRepacks { get; set; }
         bool CreateEmptyArtistFolders { get; set; }
         bool DeleteEmptyFolders { get; set; }
         FileDateType FileDate { get; set; }

--- a/src/NzbDrone.Core/Datastore/Migration/033_download_propers_config.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/033_download_propers_config.cs
@@ -1,0 +1,43 @@
+using System.Data;
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(033)]
+    public class download_propers_config : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Execute.WithConnection(SetConfigValue);
+            Execute.Sql("DELETE FROM Config WHERE Key = 'autodownloadpropers'");
+        }
+
+        private void SetConfigValue(IDbConnection conn, IDbTransaction tran)
+        {
+            using (var cmd = conn.CreateCommand())
+            {
+                cmd.Transaction = tran;
+                cmd.CommandText = "SELECT Value FROM Config WHERE Key = 'autodownloadpropers'";
+
+                using (var reader = cmd.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        var value = reader.GetString(0);
+                        var newValue = bool.Parse(value) ? "PreferAndUpgrade" : "DoNotUpgrade";
+
+                        using (var updateCmd = conn.CreateCommand())
+                        {
+                            updateCmd.Transaction = tran;
+                            updateCmd.CommandText = "INSERT INTO Config (key, value) VALUES ('downloadpropersandrepacks', ?)";
+                            updateCmd.AddParameter(newValue);
+
+                            updateCmd.ExecuteNonQuery();
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionPriorizationService.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionPriorizationService.cs
@@ -1,7 +1,7 @@
 using System.Linq;
 using System.Collections.Generic;
+using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Profiles.Delay;
-using NzbDrone.Core.Languages;
 
 namespace NzbDrone.Core.DecisionEngine
 {
@@ -12,10 +12,12 @@ namespace NzbDrone.Core.DecisionEngine
 
     public class DownloadDecisionPriorizationService : IPrioritizeDownloadDecision
     {
+        private readonly IConfigService _configService;
         private readonly IDelayProfileService _delayProfileService;
 
-        public DownloadDecisionPriorizationService(IDelayProfileService delayProfileService)
+        public DownloadDecisionPriorizationService(IConfigService configService, IDelayProfileService delayProfileService)
         {
+            _configService = configService;
             _delayProfileService = delayProfileService;
         }
 
@@ -24,7 +26,7 @@ namespace NzbDrone.Core.DecisionEngine
             return decisions.Where(c => c.RemoteAlbum.DownloadAllowed)
                             .GroupBy(c => c.RemoteAlbum.Artist.Id, (artistId, downloadDecisions) =>
                                 {
-                                    return downloadDecisions.OrderByDescending(decision => decision, new DownloadDecisionComparer(_delayProfileService));
+                                    return downloadDecisions.OrderByDescending(decision => decision, new DownloadDecisionComparer(_configService, _delayProfileService));
                                 })
                             .SelectMany(c => c)
                             .Union(decisions.Where(c => !c.RemoteAlbum.DownloadAllowed))

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RepackSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RepackSpecification.cs
@@ -1,0 +1,67 @@
+using System;
+using NLog;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.IndexerSearch.Definitions;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.DecisionEngine.Specifications
+{
+    public class RepackSpecification : IDecisionEngineSpecification
+    {
+        private readonly IMediaFileService _mediaFileService;
+        private readonly UpgradableSpecification _upgradableSpecification;
+        private readonly Logger _logger;
+
+        public RepackSpecification(IMediaFileService mediaFileService, UpgradableSpecification upgradableSpecification, Logger logger)
+        {
+            _mediaFileService = mediaFileService;
+            _upgradableSpecification = upgradableSpecification;
+            _logger = logger;
+        }
+
+        public SpecificationPriority Priority => SpecificationPriority.Database;
+        public RejectionType Type => RejectionType.Permanent;
+
+        public Decision IsSatisfiedBy(RemoteAlbum subject, SearchCriteriaBase searchCriteria)
+        {
+            if (!subject.ParsedAlbumInfo.Quality.Revision.IsRepack)
+            {
+                return Decision.Accept();
+            }
+
+            foreach (var album in subject.Albums)
+            {
+                var releaseGroup = subject.ParsedAlbumInfo.ReleaseGroup;
+                var trackFiles = _mediaFileService.GetFilesByAlbum(album.Id);
+
+                foreach (var file in trackFiles)
+                {
+                    if (_upgradableSpecification.IsRevisionUpgrade(file.Quality, subject.ParsedAlbumInfo.Quality))
+                    {
+                        var fileReleaseGroup = file.ReleaseGroup;
+
+                        if (fileReleaseGroup.IsNullOrWhiteSpace())
+                        {
+                            return Decision.Reject("Unable to determine release group for the existing file");
+                        }
+
+                        if (releaseGroup.IsNullOrWhiteSpace())
+                        {
+                            return Decision.Reject("Unable to determine release group for this release");
+                        }
+
+                        if (!fileReleaseGroup.Equals(releaseGroup, StringComparison.InvariantCultureIgnoreCase))
+                        {
+                            _logger.Debug("Release is a repack for a different release group. Release Group: {0}. File release group: {0}", releaseGroup, fileReleaseGroup);
+                            return Decision.Reject("Release is a repack for a different release group. Release Group: {0}. File release group: {0}", releaseGroup, fileReleaseGroup);
+                        }
+                    }
+                }
+                
+            }
+
+            return Decision.Accept();
+        }
+    }
+}

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradableSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradableSpecification.cs
@@ -1,9 +1,11 @@
 using NLog;
+using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Languages;
 using NzbDrone.Core.Profiles.Languages;
 using NzbDrone.Core.Profiles.Qualities;
 using NzbDrone.Core.Qualities;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace NzbDrone.Core.DecisionEngine.Specifications
 {
@@ -19,10 +21,12 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 
     public class UpgradableSpecification : IUpgradableSpecification
     {
+        private readonly IConfigService _configService;
         private readonly Logger _logger;
 
-        public UpgradableSpecification(Logger logger)
+        public UpgradableSpecification(IConfigService configService, Logger logger)
         {
+            _configService = configService;
             _logger = logger;
         }
 
@@ -75,6 +79,13 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 
                 // Not upgradable if new quality is equal to all current qualities
                 if (totalCompare == 0) {
+                    return ProfileComparisonResult.Equal;
+                }
+
+                // Quality Treated as Equal if Propers are not Prefered
+                if (_configService.DownloadPropersAndRepacks == ProperDownloadTypes.DoNotPrefer &&
+                    newQuality.Revision.CompareTo(currentQualities.Min(q => q.Revision)) > 0)
+                {
                     return ProfileComparisonResult.Equal;
                 }
             }

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -173,6 +173,7 @@
     <Compile Include="Datastore\Migration\030_add_mediafilerepository_mtime.cs" />
     <Compile Include="Datastore\Migration\031_add_artistmetadataid_constraint.cs" />
     <Compile Include="Datastore\Migration\032_old_ids_and_artist_alias.cs" />
+    <Compile Include="Datastore\Migration\033_download_propers_config.cs" />
     <Compile Include="Datastore\Migration\Framework\MigrationContext.cs" />
     <Compile Include="Datastore\Migration\Framework\MigrationController.cs" />
     <Compile Include="Datastore\Migration\Framework\MigrationDbFactory.cs" />
@@ -200,6 +201,7 @@
     <Compile Include="DecisionEngine\IRejectWithReason.cs" />
     <Compile Include="DecisionEngine\Rejection.cs" />
     <Compile Include="DecisionEngine\RejectionType.cs" />
+    <Compile Include="DecisionEngine\Specifications\RepackSpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\SameTracksSpecification.cs" />
     <Compile Include="DecisionEngine\SpecificationPriority.cs" />
     <Compile Include="DecisionEngine\Specifications\AcceptableSizeSpecification.cs" />
@@ -1033,6 +1035,7 @@
     <Compile Include="Profiles\Releases\TermMatchers\ITermMatcher.cs" />
     <Compile Include="Profiles\Releases\TermMatchers\RegexTermMatcher.cs" />
     <Compile Include="ProgressMessaging\ProgressMessageContext.cs" />
+    <Compile Include="Qualities\ProperDownloadTypes.cs" />
     <Compile Include="Qualities\QualityDetectionSource.cs" />
     <Compile Include="Qualities\Revision.cs" />
     <Compile Include="Queue\EstimatedCompletionTimeComparer.cs" />

--- a/src/NzbDrone.Core/Parser/QualityParser.cs
+++ b/src/NzbDrone.Core/Parser/QualityParser.cs
@@ -13,7 +13,10 @@ namespace NzbDrone.Core.Parser
     {
         private static readonly Logger Logger = NzbDroneLogger.GetLogger(typeof(QualityParser));
 
-        private static readonly Regex ProperRegex = new Regex(@"\b(?<proper>proper|repack|rerip)\b",
+        private static readonly Regex ProperRegex = new Regex(@"\b(?<proper>proper)\b",
+                                                                RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private static readonly Regex RepackRegex = new Regex(@"\b(?<repack>repack|rerip)\b",
                                                                 RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly Regex VersionRegex = new Regex(@"\dv(?<version>\d)\b|\[v(?<version>\d)\]",
@@ -286,6 +289,12 @@ namespace NzbDrone.Core.Parser
                 result.Revision.Version = 2;
             }
 
+            if (RepackRegex.IsMatch(normalizedName))
+            {
+                result.Revision.Version = 2;
+                result.Revision.IsRepack = true;
+            }
+
             Match versionRegexResult = VersionRegex.Match(normalizedName);
 
             if (versionRegexResult.Success)
@@ -294,7 +303,6 @@ namespace NzbDrone.Core.Parser
             }
 
             //TODO: re-enable this when we have a reliable way to determine real
-            //TODO: Only treat it as a real if it comes AFTER the season/epsiode number
             MatchCollection realRegexResult = RealRegex.Matches(name);
 
             if (realRegexResult.Count > 0)

--- a/src/NzbDrone.Core/Qualities/ProperDownloadTypes.cs
+++ b/src/NzbDrone.Core/Qualities/ProperDownloadTypes.cs
@@ -1,0 +1,9 @@
+namespace NzbDrone.Core.Qualities
+{
+    public enum ProperDownloadTypes
+    {
+        PreferAndUpgrade,
+        DoNotUpgrade,
+        DoNotPrefer
+    }
+}

--- a/src/NzbDrone.Core/Qualities/Revision.cs
+++ b/src/NzbDrone.Core/Qualities/Revision.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text;
 
 namespace NzbDrone.Core.Qualities
@@ -9,14 +9,16 @@ namespace NzbDrone.Core.Qualities
         {
         }
         
-        public Revision(int version = 1, int real = 0)
+        public Revision(int version = 1, int real = 0, bool isRepack = false)
         {
             Version = version;
             Real = real;
+            IsRepack = isRepack;
         }
 
         public int Version { get; set; }
         public int Real { get; set; }
+        public bool IsRepack { get; set; }
 
         public bool Equals(Revision other)
         {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Repack releases should only be grabbed for same release group. This PR enforces that repack releases will only be grabbed if the release group is the same as the current album on file. As written all files for a specific album have to be from the release group, if there are mixed groups the release is rejected.

#### Todos
- [x] Tests
- [x] Handle Null Cases
- [x] Make quality aware
- [x] Fix tests
