### PR TITLE
Fixed: Tracked Download Cache Keeps Deleted Albums

### DIFF
--- a/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
@@ -11,6 +11,7 @@ using NzbDrone.Core.Test.Framework;
 using NzbDrone.Core.Music;
 using NzbDrone.Core.Indexers;
 using System.Linq;
+using NzbDrone.Core.Music.Events;
 
 namespace NzbDrone.Core.Test.Download.TrackedDownloads
 {
@@ -72,5 +73,54 @@ namespace NzbDrone.Core.Test.Download.TrackedDownloads
             trackedDownload.RemoteAlbum.Albums.First().Id.Should().Be(4);
         }
 
+        [Test]
+        public void should_unmap_tracked_download_if_album_deleted()
+        {
+            GivenDownloadHistory();
+
+            var remoteAlbum = new RemoteAlbum
+            {
+                Artist = new Artist() { Id = 5 },
+                Albums = new List<Album> { new Album { Id = 4 } },
+                ParsedAlbumInfo = new ParsedAlbumInfo()
+                {
+                    AlbumTitle = "Audio Album",
+                    ArtistName = "Audio Artist"
+                }
+            };
+
+            Mocker.GetMock<IParsingService>()
+                  .Setup(s => s.Map(It.Is<ParsedAlbumInfo>(i => i.AlbumTitle == "Audio Album" && i.ArtistName == "Audio Artist"), It.IsAny<int>(), It.IsAny<IEnumerable<int>>()))
+                  .Returns(remoteAlbum);
+
+            var client = new DownloadClientDefinition()
+            {
+                Id = 1,
+                Protocol = DownloadProtocol.Torrent
+            };
+
+            var item = new DownloadClientItem()
+            {
+                Title = "Audio Artist - Audio Album [2018 - FLAC]",
+                DownloadId = "35238",
+            };
+
+            // get a tracked download in place
+            var trackedDownload = Subject.TrackDownload(client, item);
+            Subject.GetTrackedDownloads().Should().HaveCount(1);
+
+            // simulate deletion - album no longer maps
+            Mocker.GetMock<IParsingService>()
+                .Setup(s => s.Map(It.Is<ParsedAlbumInfo>(i => i.AlbumTitle == "Audio Album" && i.ArtistName == "Audio Artist"), It.IsAny<int>(), It.IsAny<IEnumerable<int>>()))
+                .Returns(default(RemoteAlbum));
+
+            // handle deletion event
+            Subject.Handle(new AlbumDeletedEvent(remoteAlbum.Albums.First(), false));
+
+            // verify download has null remote album
+            var trackedDownloads = Subject.GetTrackedDownloads();
+            trackedDownloads.Should().HaveCount(1);
+            trackedDownloads.First().RemoteAlbum.Should().BeNull();
+        }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Currently the tracked download service cache references to albums that match to tracked downloads. If albums are deleted (via metadata change, or other) those references create errors during queue lookup (#707). Thus we need to update tracked downloads to remove deleted album reference when an album is deleted. 

@ta264 not sure if this is the best way to go about this, but it seems to work for me?

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR
Fixes #707 (For Albums)
Fixes LIDARR-1X1
* 
