### PR TITLE
Import Spotify playlist

### DIFF
--- a/src/NzbDrone.Core.Test/Files/ImportLists/Spotify/SpotifyPlaylistTracksFull.json
+++ b/src/NzbDrone.Core.Test/Files/ImportLists/Spotify/SpotifyPlaylistTracksFull.json
@@ -1,0 +1,2204 @@
+﻿{
+  "items": [
+    {
+      "track": {
+        "album": {
+          "id": "01Ik2xJ818NAN1xHdqK1P5",
+          "name": "Euclid"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/7yi9sGE0VX59Pss7hHTaJ3"
+            },
+            "href": "https://api.spotify.com/v1/artists/7yi9sGE0VX59Pss7hHTaJ3",
+            "id": "7yi9sGE0VX59Pss7hHTaJ3",
+            "name": "Tanooki Suit",
+            "type": "artist",
+            "uri": "spotify:artist:7yi9sGE0VX59Pss7hHTaJ3"
+          }
+        ],
+        "name": "Lordvessel"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "3giBVgh4bHYCRK53yvvoa5",
+          "name": "Darkest Hour"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4dso1lISV1Atdo3O6qbhqq"
+            },
+            "href": "https://api.spotify.com/v1/artists/4dso1lISV1Atdo3O6qbhqq",
+            "id": "4dso1lISV1Atdo3O6qbhqq",
+            "name": "Darkest Hour",
+            "type": "artist",
+            "uri": "spotify:artist:4dso1lISV1Atdo3O6qbhqq"
+          }
+        ],
+        "name": "The Misery We Make"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "68DKWCjmwJcCV8TwCxx52H",
+          "name": "All the Lights In the Sky"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3jULn43a6xfzqleyeFjPIq"
+            },
+            "href": "https://api.spotify.com/v1/artists/3jULn43a6xfzqleyeFjPIq",
+            "id": "3jULn43a6xfzqleyeFjPIq",
+            "name": "Area 11",
+            "type": "artist",
+            "uri": "spotify:artist:3jULn43a6xfzqleyeFjPIq"
+          }
+        ],
+        "name": "Heaven-Piercing Giga Drill"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "1aG8CTUfHQJJJHYLBuqv0v",
+          "name": "Orthodox [Bonus Track Version]"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4DGNqGOtNY9niSpCKwINyU"
+            },
+            "href": "https://api.spotify.com/v1/artists/4DGNqGOtNY9niSpCKwINyU",
+            "id": "4DGNqGOtNY9niSpCKwINyU",
+            "name": "Beware Of Darkness",
+            "type": "artist",
+            "uri": "spotify:artist:4DGNqGOtNY9niSpCKwINyU"
+          }
+        ],
+        "name": "Howl"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "1vXIt4f3khLgyHd3Uyw8R0",
+          "name": "War"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4ZgQDCtRqZlhLswVS6MHN4"
+            },
+            "href": "https://api.spotify.com/v1/artists/4ZgQDCtRqZlhLswVS6MHN4",
+            "id": "4ZgQDCtRqZlhLswVS6MHN4",
+            "name": "grandson",
+            "type": "artist",
+            "uri": "spotify:artist:4ZgQDCtRqZlhLswVS6MHN4"
+          }
+        ],
+        "name": "War"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "2MqYypIxDlwcPNc1T90fO2",
+          "name": "Restoring Force: Full Circle"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4tususHNaR68xdgLstlGBA"
+            },
+            "href": "https://api.spotify.com/v1/artists/4tususHNaR68xdgLstlGBA",
+            "id": "4tususHNaR68xdgLstlGBA",
+            "name": "Of Mice & Men",
+            "type": "artist",
+            "uri": "spotify:artist:4tususHNaR68xdgLstlGBA"
+          }
+        ],
+        "name": "Broken Generation"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "0ACUx5eosqeSTrgupiuhiL",
+          "name": "Free Falling"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2SmW1lFlBJn4IfBzBZDlSh"
+            },
+            "href": "https://api.spotify.com/v1/artists/2SmW1lFlBJn4IfBzBZDlSh",
+            "id": "2SmW1lFlBJn4IfBzBZDlSh",
+            "name": "The Warning",
+            "type": "artist",
+            "uri": "spotify:artist:2SmW1lFlBJn4IfBzBZDlSh"
+          }
+        ],
+        "name": "Free Falling"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "64SL0QEXxulD2QgwJmJbUL",
+          "name": "Era Vulgaris"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4pejUc4iciQfgdX6OKulQn"
+            },
+            "href": "https://api.spotify.com/v1/artists/4pejUc4iciQfgdX6OKulQn",
+            "id": "4pejUc4iciQfgdX6OKulQn",
+            "name": "Queens of the Stone Age",
+            "type": "artist",
+            "uri": "spotify:artist:4pejUc4iciQfgdX6OKulQn"
+          }
+        ],
+        "name": "3's & 7's"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "661Hz0qJK8WIp7vAWsqKvk",
+          "name": "Collide With The Sky"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4iJLPqClelZOBCBifm8Fzv"
+            },
+            "href": "https://api.spotify.com/v1/artists/4iJLPqClelZOBCBifm8Fzv",
+            "id": "4iJLPqClelZOBCBifm8Fzv",
+            "name": "Pierce The Veil",
+            "type": "artist",
+            "uri": "spotify:artist:4iJLPqClelZOBCBifm8Fzv"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3M9XAM57a4qFz3v6Lq27t2"
+            },
+            "href": "https://api.spotify.com/v1/artists/3M9XAM57a4qFz3v6Lq27t2",
+            "id": "3M9XAM57a4qFz3v6Lq27t2",
+            "name": "Kellin Quinn",
+            "type": "artist",
+            "uri": "spotify:artist:3M9XAM57a4qFz3v6Lq27t2"
+          }
+        ],
+        "name": "King For A Day"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "36LXzRarDP8TU8K0REGpt6",
+          "name": "Lazaretto"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4FZ3j1oH43e7cukCALsCwf"
+            },
+            "href": "https://api.spotify.com/v1/artists/4FZ3j1oH43e7cukCALsCwf",
+            "id": "4FZ3j1oH43e7cukCALsCwf",
+            "name": "Jack White",
+            "type": "artist",
+            "uri": "spotify:artist:4FZ3j1oH43e7cukCALsCwf"
+          }
+        ],
+        "name": "Lazaretto"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "01Ik2xJ818NAN1xHdqK1P5",
+          "name": "Euclid"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/7yi9sGE0VX59Pss7hHTaJ3"
+            },
+            "href": "https://api.spotify.com/v1/artists/7yi9sGE0VX59Pss7hHTaJ3",
+            "id": "7yi9sGE0VX59Pss7hHTaJ3",
+            "name": "Tanooki Suit",
+            "type": "artist",
+            "uri": "spotify:artist:7yi9sGE0VX59Pss7hHTaJ3"
+          }
+        ],
+        "name": "Lordvessel"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "3giBVgh4bHYCRK53yvvoa5",
+          "name": "Darkest Hour"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4dso1lISV1Atdo3O6qbhqq"
+            },
+            "href": "https://api.spotify.com/v1/artists/4dso1lISV1Atdo3O6qbhqq",
+            "id": "4dso1lISV1Atdo3O6qbhqq",
+            "name": "Darkest Hour",
+            "type": "artist",
+            "uri": "spotify:artist:4dso1lISV1Atdo3O6qbhqq"
+          }
+        ],
+        "name": "The Misery We Make"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "68DKWCjmwJcCV8TwCxx52H",
+          "name": "All the Lights In the Sky"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3jULn43a6xfzqleyeFjPIq"
+            },
+            "href": "https://api.spotify.com/v1/artists/3jULn43a6xfzqleyeFjPIq",
+            "id": "3jULn43a6xfzqleyeFjPIq",
+            "name": "Area 11",
+            "type": "artist",
+            "uri": "spotify:artist:3jULn43a6xfzqleyeFjPIq"
+          }
+        ],
+        "name": "Heaven-Piercing Giga Drill"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "1aG8CTUfHQJJJHYLBuqv0v",
+          "name": "Orthodox [Bonus Track Version]"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4DGNqGOtNY9niSpCKwINyU"
+            },
+            "href": "https://api.spotify.com/v1/artists/4DGNqGOtNY9niSpCKwINyU",
+            "id": "4DGNqGOtNY9niSpCKwINyU",
+            "name": "Beware Of Darkness",
+            "type": "artist",
+            "uri": "spotify:artist:4DGNqGOtNY9niSpCKwINyU"
+          }
+        ],
+        "name": "Howl"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "1vXIt4f3khLgyHd3Uyw8R0",
+          "name": "War"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4ZgQDCtRqZlhLswVS6MHN4"
+            },
+            "href": "https://api.spotify.com/v1/artists/4ZgQDCtRqZlhLswVS6MHN4",
+            "id": "4ZgQDCtRqZlhLswVS6MHN4",
+            "name": "grandson",
+            "type": "artist",
+            "uri": "spotify:artist:4ZgQDCtRqZlhLswVS6MHN4"
+          }
+        ],
+        "name": "War"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "2MqYypIxDlwcPNc1T90fO2",
+          "name": "Restoring Force: Full Circle"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4tususHNaR68xdgLstlGBA"
+            },
+            "href": "https://api.spotify.com/v1/artists/4tususHNaR68xdgLstlGBA",
+            "id": "4tususHNaR68xdgLstlGBA",
+            "name": "Of Mice & Men",
+            "type": "artist",
+            "uri": "spotify:artist:4tususHNaR68xdgLstlGBA"
+          }
+        ],
+        "name": "Broken Generation"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "0ACUx5eosqeSTrgupiuhiL",
+          "name": "Free Falling"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2SmW1lFlBJn4IfBzBZDlSh"
+            },
+            "href": "https://api.spotify.com/v1/artists/2SmW1lFlBJn4IfBzBZDlSh",
+            "id": "2SmW1lFlBJn4IfBzBZDlSh",
+            "name": "The Warning",
+            "type": "artist",
+            "uri": "spotify:artist:2SmW1lFlBJn4IfBzBZDlSh"
+          }
+        ],
+        "name": "Free Falling"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "64SL0QEXxulD2QgwJmJbUL",
+          "name": "Era Vulgaris"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4pejUc4iciQfgdX6OKulQn"
+            },
+            "href": "https://api.spotify.com/v1/artists/4pejUc4iciQfgdX6OKulQn",
+            "id": "4pejUc4iciQfgdX6OKulQn",
+            "name": "Queens of the Stone Age",
+            "type": "artist",
+            "uri": "spotify:artist:4pejUc4iciQfgdX6OKulQn"
+          }
+        ],
+        "name": "3's & 7's"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "661Hz0qJK8WIp7vAWsqKvk",
+          "name": "Collide With The Sky"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4iJLPqClelZOBCBifm8Fzv"
+            },
+            "href": "https://api.spotify.com/v1/artists/4iJLPqClelZOBCBifm8Fzv",
+            "id": "4iJLPqClelZOBCBifm8Fzv",
+            "name": "Pierce The Veil",
+            "type": "artist",
+            "uri": "spotify:artist:4iJLPqClelZOBCBifm8Fzv"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3M9XAM57a4qFz3v6Lq27t2"
+            },
+            "href": "https://api.spotify.com/v1/artists/3M9XAM57a4qFz3v6Lq27t2",
+            "id": "3M9XAM57a4qFz3v6Lq27t2",
+            "name": "Kellin Quinn",
+            "type": "artist",
+            "uri": "spotify:artist:3M9XAM57a4qFz3v6Lq27t2"
+          }
+        ],
+        "name": "King For A Day"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "36LXzRarDP8TU8K0REGpt6",
+          "name": "Lazaretto"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4FZ3j1oH43e7cukCALsCwf"
+            },
+            "href": "https://api.spotify.com/v1/artists/4FZ3j1oH43e7cukCALsCwf",
+            "id": "4FZ3j1oH43e7cukCALsCwf",
+            "name": "Jack White",
+            "type": "artist",
+            "uri": "spotify:artist:4FZ3j1oH43e7cukCALsCwf"
+          }
+        ],
+        "name": "Lazaretto"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "01Ik2xJ818NAN1xHdqK1P5",
+          "name": "Euclid"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/7yi9sGE0VX59Pss7hHTaJ3"
+            },
+            "href": "https://api.spotify.com/v1/artists/7yi9sGE0VX59Pss7hHTaJ3",
+            "id": "7yi9sGE0VX59Pss7hHTaJ3",
+            "name": "Tanooki Suit",
+            "type": "artist",
+            "uri": "spotify:artist:7yi9sGE0VX59Pss7hHTaJ3"
+          }
+        ],
+        "name": "Lordvessel"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "3giBVgh4bHYCRK53yvvoa5",
+          "name": "Darkest Hour"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4dso1lISV1Atdo3O6qbhqq"
+            },
+            "href": "https://api.spotify.com/v1/artists/4dso1lISV1Atdo3O6qbhqq",
+            "id": "4dso1lISV1Atdo3O6qbhqq",
+            "name": "Darkest Hour",
+            "type": "artist",
+            "uri": "spotify:artist:4dso1lISV1Atdo3O6qbhqq"
+          }
+        ],
+        "name": "The Misery We Make"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "68DKWCjmwJcCV8TwCxx52H",
+          "name": "All the Lights In the Sky"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3jULn43a6xfzqleyeFjPIq"
+            },
+            "href": "https://api.spotify.com/v1/artists/3jULn43a6xfzqleyeFjPIq",
+            "id": "3jULn43a6xfzqleyeFjPIq",
+            "name": "Area 11",
+            "type": "artist",
+            "uri": "spotify:artist:3jULn43a6xfzqleyeFjPIq"
+          }
+        ],
+        "name": "Heaven-Piercing Giga Drill"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "1aG8CTUfHQJJJHYLBuqv0v",
+          "name": "Orthodox [Bonus Track Version]"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4DGNqGOtNY9niSpCKwINyU"
+            },
+            "href": "https://api.spotify.com/v1/artists/4DGNqGOtNY9niSpCKwINyU",
+            "id": "4DGNqGOtNY9niSpCKwINyU",
+            "name": "Beware Of Darkness",
+            "type": "artist",
+            "uri": "spotify:artist:4DGNqGOtNY9niSpCKwINyU"
+          }
+        ],
+        "name": "Howl"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "1vXIt4f3khLgyHd3Uyw8R0",
+          "name": "War"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4ZgQDCtRqZlhLswVS6MHN4"
+            },
+            "href": "https://api.spotify.com/v1/artists/4ZgQDCtRqZlhLswVS6MHN4",
+            "id": "4ZgQDCtRqZlhLswVS6MHN4",
+            "name": "grandson",
+            "type": "artist",
+            "uri": "spotify:artist:4ZgQDCtRqZlhLswVS6MHN4"
+          }
+        ],
+        "name": "War"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "2MqYypIxDlwcPNc1T90fO2",
+          "name": "Restoring Force: Full Circle"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4tususHNaR68xdgLstlGBA"
+            },
+            "href": "https://api.spotify.com/v1/artists/4tususHNaR68xdgLstlGBA",
+            "id": "4tususHNaR68xdgLstlGBA",
+            "name": "Of Mice & Men",
+            "type": "artist",
+            "uri": "spotify:artist:4tususHNaR68xdgLstlGBA"
+          }
+        ],
+        "name": "Broken Generation"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "0ACUx5eosqeSTrgupiuhiL",
+          "name": "Free Falling"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2SmW1lFlBJn4IfBzBZDlSh"
+            },
+            "href": "https://api.spotify.com/v1/artists/2SmW1lFlBJn4IfBzBZDlSh",
+            "id": "2SmW1lFlBJn4IfBzBZDlSh",
+            "name": "The Warning",
+            "type": "artist",
+            "uri": "spotify:artist:2SmW1lFlBJn4IfBzBZDlSh"
+          }
+        ],
+        "name": "Free Falling"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "64SL0QEXxulD2QgwJmJbUL",
+          "name": "Era Vulgaris"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4pejUc4iciQfgdX6OKulQn"
+            },
+            "href": "https://api.spotify.com/v1/artists/4pejUc4iciQfgdX6OKulQn",
+            "id": "4pejUc4iciQfgdX6OKulQn",
+            "name": "Queens of the Stone Age",
+            "type": "artist",
+            "uri": "spotify:artist:4pejUc4iciQfgdX6OKulQn"
+          }
+        ],
+        "name": "3's & 7's"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "661Hz0qJK8WIp7vAWsqKvk",
+          "name": "Collide With The Sky"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4iJLPqClelZOBCBifm8Fzv"
+            },
+            "href": "https://api.spotify.com/v1/artists/4iJLPqClelZOBCBifm8Fzv",
+            "id": "4iJLPqClelZOBCBifm8Fzv",
+            "name": "Pierce The Veil",
+            "type": "artist",
+            "uri": "spotify:artist:4iJLPqClelZOBCBifm8Fzv"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3M9XAM57a4qFz3v6Lq27t2"
+            },
+            "href": "https://api.spotify.com/v1/artists/3M9XAM57a4qFz3v6Lq27t2",
+            "id": "3M9XAM57a4qFz3v6Lq27t2",
+            "name": "Kellin Quinn",
+            "type": "artist",
+            "uri": "spotify:artist:3M9XAM57a4qFz3v6Lq27t2"
+          }
+        ],
+        "name": "King For A Day"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "36LXzRarDP8TU8K0REGpt6",
+          "name": "Lazaretto"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4FZ3j1oH43e7cukCALsCwf"
+            },
+            "href": "https://api.spotify.com/v1/artists/4FZ3j1oH43e7cukCALsCwf",
+            "id": "4FZ3j1oH43e7cukCALsCwf",
+            "name": "Jack White",
+            "type": "artist",
+            "uri": "spotify:artist:4FZ3j1oH43e7cukCALsCwf"
+          }
+        ],
+        "name": "Lazaretto"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "01Ik2xJ818NAN1xHdqK1P5",
+          "name": "Euclid"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/7yi9sGE0VX59Pss7hHTaJ3"
+            },
+            "href": "https://api.spotify.com/v1/artists/7yi9sGE0VX59Pss7hHTaJ3",
+            "id": "7yi9sGE0VX59Pss7hHTaJ3",
+            "name": "Tanooki Suit",
+            "type": "artist",
+            "uri": "spotify:artist:7yi9sGE0VX59Pss7hHTaJ3"
+          }
+        ],
+        "name": "Lordvessel"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "3giBVgh4bHYCRK53yvvoa5",
+          "name": "Darkest Hour"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4dso1lISV1Atdo3O6qbhqq"
+            },
+            "href": "https://api.spotify.com/v1/artists/4dso1lISV1Atdo3O6qbhqq",
+            "id": "4dso1lISV1Atdo3O6qbhqq",
+            "name": "Darkest Hour",
+            "type": "artist",
+            "uri": "spotify:artist:4dso1lISV1Atdo3O6qbhqq"
+          }
+        ],
+        "name": "The Misery We Make"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "68DKWCjmwJcCV8TwCxx52H",
+          "name": "All the Lights In the Sky"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3jULn43a6xfzqleyeFjPIq"
+            },
+            "href": "https://api.spotify.com/v1/artists/3jULn43a6xfzqleyeFjPIq",
+            "id": "3jULn43a6xfzqleyeFjPIq",
+            "name": "Area 11",
+            "type": "artist",
+            "uri": "spotify:artist:3jULn43a6xfzqleyeFjPIq"
+          }
+        ],
+        "name": "Heaven-Piercing Giga Drill"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "1aG8CTUfHQJJJHYLBuqv0v",
+          "name": "Orthodox [Bonus Track Version]"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4DGNqGOtNY9niSpCKwINyU"
+            },
+            "href": "https://api.spotify.com/v1/artists/4DGNqGOtNY9niSpCKwINyU",
+            "id": "4DGNqGOtNY9niSpCKwINyU",
+            "name": "Beware Of Darkness",
+            "type": "artist",
+            "uri": "spotify:artist:4DGNqGOtNY9niSpCKwINyU"
+          }
+        ],
+        "name": "Howl"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "1vXIt4f3khLgyHd3Uyw8R0",
+          "name": "War"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4ZgQDCtRqZlhLswVS6MHN4"
+            },
+            "href": "https://api.spotify.com/v1/artists/4ZgQDCtRqZlhLswVS6MHN4",
+            "id": "4ZgQDCtRqZlhLswVS6MHN4",
+            "name": "grandson",
+            "type": "artist",
+            "uri": "spotify:artist:4ZgQDCtRqZlhLswVS6MHN4"
+          }
+        ],
+        "name": "War"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "2MqYypIxDlwcPNc1T90fO2",
+          "name": "Restoring Force: Full Circle"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4tususHNaR68xdgLstlGBA"
+            },
+            "href": "https://api.spotify.com/v1/artists/4tususHNaR68xdgLstlGBA",
+            "id": "4tususHNaR68xdgLstlGBA",
+            "name": "Of Mice & Men",
+            "type": "artist",
+            "uri": "spotify:artist:4tususHNaR68xdgLstlGBA"
+          }
+        ],
+        "name": "Broken Generation"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "0ACUx5eosqeSTrgupiuhiL",
+          "name": "Free Falling"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2SmW1lFlBJn4IfBzBZDlSh"
+            },
+            "href": "https://api.spotify.com/v1/artists/2SmW1lFlBJn4IfBzBZDlSh",
+            "id": "2SmW1lFlBJn4IfBzBZDlSh",
+            "name": "The Warning",
+            "type": "artist",
+            "uri": "spotify:artist:2SmW1lFlBJn4IfBzBZDlSh"
+          }
+        ],
+        "name": "Free Falling"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "64SL0QEXxulD2QgwJmJbUL",
+          "name": "Era Vulgaris"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4pejUc4iciQfgdX6OKulQn"
+            },
+            "href": "https://api.spotify.com/v1/artists/4pejUc4iciQfgdX6OKulQn",
+            "id": "4pejUc4iciQfgdX6OKulQn",
+            "name": "Queens of the Stone Age",
+            "type": "artist",
+            "uri": "spotify:artist:4pejUc4iciQfgdX6OKulQn"
+          }
+        ],
+        "name": "3's & 7's"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "661Hz0qJK8WIp7vAWsqKvk",
+          "name": "Collide With The Sky"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4iJLPqClelZOBCBifm8Fzv"
+            },
+            "href": "https://api.spotify.com/v1/artists/4iJLPqClelZOBCBifm8Fzv",
+            "id": "4iJLPqClelZOBCBifm8Fzv",
+            "name": "Pierce The Veil",
+            "type": "artist",
+            "uri": "spotify:artist:4iJLPqClelZOBCBifm8Fzv"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3M9XAM57a4qFz3v6Lq27t2"
+            },
+            "href": "https://api.spotify.com/v1/artists/3M9XAM57a4qFz3v6Lq27t2",
+            "id": "3M9XAM57a4qFz3v6Lq27t2",
+            "name": "Kellin Quinn",
+            "type": "artist",
+            "uri": "spotify:artist:3M9XAM57a4qFz3v6Lq27t2"
+          }
+        ],
+        "name": "King For A Day"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "36LXzRarDP8TU8K0REGpt6",
+          "name": "Lazaretto"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4FZ3j1oH43e7cukCALsCwf"
+            },
+            "href": "https://api.spotify.com/v1/artists/4FZ3j1oH43e7cukCALsCwf",
+            "id": "4FZ3j1oH43e7cukCALsCwf",
+            "name": "Jack White",
+            "type": "artist",
+            "uri": "spotify:artist:4FZ3j1oH43e7cukCALsCwf"
+          }
+        ],
+        "name": "Lazaretto"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "01Ik2xJ818NAN1xHdqK1P5",
+          "name": "Euclid"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/7yi9sGE0VX59Pss7hHTaJ3"
+            },
+            "href": "https://api.spotify.com/v1/artists/7yi9sGE0VX59Pss7hHTaJ3",
+            "id": "7yi9sGE0VX59Pss7hHTaJ3",
+            "name": "Tanooki Suit",
+            "type": "artist",
+            "uri": "spotify:artist:7yi9sGE0VX59Pss7hHTaJ3"
+          }
+        ],
+        "name": "Lordvessel"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "3giBVgh4bHYCRK53yvvoa5",
+          "name": "Darkest Hour"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4dso1lISV1Atdo3O6qbhqq"
+            },
+            "href": "https://api.spotify.com/v1/artists/4dso1lISV1Atdo3O6qbhqq",
+            "id": "4dso1lISV1Atdo3O6qbhqq",
+            "name": "Darkest Hour",
+            "type": "artist",
+            "uri": "spotify:artist:4dso1lISV1Atdo3O6qbhqq"
+          }
+        ],
+        "name": "The Misery We Make"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "68DKWCjmwJcCV8TwCxx52H",
+          "name": "All the Lights In the Sky"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3jULn43a6xfzqleyeFjPIq"
+            },
+            "href": "https://api.spotify.com/v1/artists/3jULn43a6xfzqleyeFjPIq",
+            "id": "3jULn43a6xfzqleyeFjPIq",
+            "name": "Area 11",
+            "type": "artist",
+            "uri": "spotify:artist:3jULn43a6xfzqleyeFjPIq"
+          }
+        ],
+        "name": "Heaven-Piercing Giga Drill"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "1aG8CTUfHQJJJHYLBuqv0v",
+          "name": "Orthodox [Bonus Track Version]"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4DGNqGOtNY9niSpCKwINyU"
+            },
+            "href": "https://api.spotify.com/v1/artists/4DGNqGOtNY9niSpCKwINyU",
+            "id": "4DGNqGOtNY9niSpCKwINyU",
+            "name": "Beware Of Darkness",
+            "type": "artist",
+            "uri": "spotify:artist:4DGNqGOtNY9niSpCKwINyU"
+          }
+        ],
+        "name": "Howl"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "1vXIt4f3khLgyHd3Uyw8R0",
+          "name": "War"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4ZgQDCtRqZlhLswVS6MHN4"
+            },
+            "href": "https://api.spotify.com/v1/artists/4ZgQDCtRqZlhLswVS6MHN4",
+            "id": "4ZgQDCtRqZlhLswVS6MHN4",
+            "name": "grandson",
+            "type": "artist",
+            "uri": "spotify:artist:4ZgQDCtRqZlhLswVS6MHN4"
+          }
+        ],
+        "name": "War"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "2MqYypIxDlwcPNc1T90fO2",
+          "name": "Restoring Force: Full Circle"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4tususHNaR68xdgLstlGBA"
+            },
+            "href": "https://api.spotify.com/v1/artists/4tususHNaR68xdgLstlGBA",
+            "id": "4tususHNaR68xdgLstlGBA",
+            "name": "Of Mice & Men",
+            "type": "artist",
+            "uri": "spotify:artist:4tususHNaR68xdgLstlGBA"
+          }
+        ],
+        "name": "Broken Generation"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "0ACUx5eosqeSTrgupiuhiL",
+          "name": "Free Falling"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2SmW1lFlBJn4IfBzBZDlSh"
+            },
+            "href": "https://api.spotify.com/v1/artists/2SmW1lFlBJn4IfBzBZDlSh",
+            "id": "2SmW1lFlBJn4IfBzBZDlSh",
+            "name": "The Warning",
+            "type": "artist",
+            "uri": "spotify:artist:2SmW1lFlBJn4IfBzBZDlSh"
+          }
+        ],
+        "name": "Free Falling"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "64SL0QEXxulD2QgwJmJbUL",
+          "name": "Era Vulgaris"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4pejUc4iciQfgdX6OKulQn"
+            },
+            "href": "https://api.spotify.com/v1/artists/4pejUc4iciQfgdX6OKulQn",
+            "id": "4pejUc4iciQfgdX6OKulQn",
+            "name": "Queens of the Stone Age",
+            "type": "artist",
+            "uri": "spotify:artist:4pejUc4iciQfgdX6OKulQn"
+          }
+        ],
+        "name": "3's & 7's"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "661Hz0qJK8WIp7vAWsqKvk",
+          "name": "Collide With The Sky"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4iJLPqClelZOBCBifm8Fzv"
+            },
+            "href": "https://api.spotify.com/v1/artists/4iJLPqClelZOBCBifm8Fzv",
+            "id": "4iJLPqClelZOBCBifm8Fzv",
+            "name": "Pierce The Veil",
+            "type": "artist",
+            "uri": "spotify:artist:4iJLPqClelZOBCBifm8Fzv"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3M9XAM57a4qFz3v6Lq27t2"
+            },
+            "href": "https://api.spotify.com/v1/artists/3M9XAM57a4qFz3v6Lq27t2",
+            "id": "3M9XAM57a4qFz3v6Lq27t2",
+            "name": "Kellin Quinn",
+            "type": "artist",
+            "uri": "spotify:artist:3M9XAM57a4qFz3v6Lq27t2"
+          }
+        ],
+        "name": "King For A Day"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "36LXzRarDP8TU8K0REGpt6",
+          "name": "Lazaretto"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4FZ3j1oH43e7cukCALsCwf"
+            },
+            "href": "https://api.spotify.com/v1/artists/4FZ3j1oH43e7cukCALsCwf",
+            "id": "4FZ3j1oH43e7cukCALsCwf",
+            "name": "Jack White",
+            "type": "artist",
+            "uri": "spotify:artist:4FZ3j1oH43e7cukCALsCwf"
+          }
+        ],
+        "name": "Lazaretto"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "01Ik2xJ818NAN1xHdqK1P5",
+          "name": "Euclid"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/7yi9sGE0VX59Pss7hHTaJ3"
+            },
+            "href": "https://api.spotify.com/v1/artists/7yi9sGE0VX59Pss7hHTaJ3",
+            "id": "7yi9sGE0VX59Pss7hHTaJ3",
+            "name": "Tanooki Suit",
+            "type": "artist",
+            "uri": "spotify:artist:7yi9sGE0VX59Pss7hHTaJ3"
+          }
+        ],
+        "name": "Lordvessel"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "3giBVgh4bHYCRK53yvvoa5",
+          "name": "Darkest Hour"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4dso1lISV1Atdo3O6qbhqq"
+            },
+            "href": "https://api.spotify.com/v1/artists/4dso1lISV1Atdo3O6qbhqq",
+            "id": "4dso1lISV1Atdo3O6qbhqq",
+            "name": "Darkest Hour",
+            "type": "artist",
+            "uri": "spotify:artist:4dso1lISV1Atdo3O6qbhqq"
+          }
+        ],
+        "name": "The Misery We Make"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "68DKWCjmwJcCV8TwCxx52H",
+          "name": "All the Lights In the Sky"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3jULn43a6xfzqleyeFjPIq"
+            },
+            "href": "https://api.spotify.com/v1/artists/3jULn43a6xfzqleyeFjPIq",
+            "id": "3jULn43a6xfzqleyeFjPIq",
+            "name": "Area 11",
+            "type": "artist",
+            "uri": "spotify:artist:3jULn43a6xfzqleyeFjPIq"
+          }
+        ],
+        "name": "Heaven-Piercing Giga Drill"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "1aG8CTUfHQJJJHYLBuqv0v",
+          "name": "Orthodox [Bonus Track Version]"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4DGNqGOtNY9niSpCKwINyU"
+            },
+            "href": "https://api.spotify.com/v1/artists/4DGNqGOtNY9niSpCKwINyU",
+            "id": "4DGNqGOtNY9niSpCKwINyU",
+            "name": "Beware Of Darkness",
+            "type": "artist",
+            "uri": "spotify:artist:4DGNqGOtNY9niSpCKwINyU"
+          }
+        ],
+        "name": "Howl"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "1vXIt4f3khLgyHd3Uyw8R0",
+          "name": "War"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4ZgQDCtRqZlhLswVS6MHN4"
+            },
+            "href": "https://api.spotify.com/v1/artists/4ZgQDCtRqZlhLswVS6MHN4",
+            "id": "4ZgQDCtRqZlhLswVS6MHN4",
+            "name": "grandson",
+            "type": "artist",
+            "uri": "spotify:artist:4ZgQDCtRqZlhLswVS6MHN4"
+          }
+        ],
+        "name": "War"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "2MqYypIxDlwcPNc1T90fO2",
+          "name": "Restoring Force: Full Circle"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4tususHNaR68xdgLstlGBA"
+            },
+            "href": "https://api.spotify.com/v1/artists/4tususHNaR68xdgLstlGBA",
+            "id": "4tususHNaR68xdgLstlGBA",
+            "name": "Of Mice & Men",
+            "type": "artist",
+            "uri": "spotify:artist:4tususHNaR68xdgLstlGBA"
+          }
+        ],
+        "name": "Broken Generation"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "0ACUx5eosqeSTrgupiuhiL",
+          "name": "Free Falling"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2SmW1lFlBJn4IfBzBZDlSh"
+            },
+            "href": "https://api.spotify.com/v1/artists/2SmW1lFlBJn4IfBzBZDlSh",
+            "id": "2SmW1lFlBJn4IfBzBZDlSh",
+            "name": "The Warning",
+            "type": "artist",
+            "uri": "spotify:artist:2SmW1lFlBJn4IfBzBZDlSh"
+          }
+        ],
+        "name": "Free Falling"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "64SL0QEXxulD2QgwJmJbUL",
+          "name": "Era Vulgaris"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4pejUc4iciQfgdX6OKulQn"
+            },
+            "href": "https://api.spotify.com/v1/artists/4pejUc4iciQfgdX6OKulQn",
+            "id": "4pejUc4iciQfgdX6OKulQn",
+            "name": "Queens of the Stone Age",
+            "type": "artist",
+            "uri": "spotify:artist:4pejUc4iciQfgdX6OKulQn"
+          }
+        ],
+        "name": "3's & 7's"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "661Hz0qJK8WIp7vAWsqKvk",
+          "name": "Collide With The Sky"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4iJLPqClelZOBCBifm8Fzv"
+            },
+            "href": "https://api.spotify.com/v1/artists/4iJLPqClelZOBCBifm8Fzv",
+            "id": "4iJLPqClelZOBCBifm8Fzv",
+            "name": "Pierce The Veil",
+            "type": "artist",
+            "uri": "spotify:artist:4iJLPqClelZOBCBifm8Fzv"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3M9XAM57a4qFz3v6Lq27t2"
+            },
+            "href": "https://api.spotify.com/v1/artists/3M9XAM57a4qFz3v6Lq27t2",
+            "id": "3M9XAM57a4qFz3v6Lq27t2",
+            "name": "Kellin Quinn",
+            "type": "artist",
+            "uri": "spotify:artist:3M9XAM57a4qFz3v6Lq27t2"
+          }
+        ],
+        "name": "King For A Day"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "36LXzRarDP8TU8K0REGpt6",
+          "name": "Lazaretto"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4FZ3j1oH43e7cukCALsCwf"
+            },
+            "href": "https://api.spotify.com/v1/artists/4FZ3j1oH43e7cukCALsCwf",
+            "id": "4FZ3j1oH43e7cukCALsCwf",
+            "name": "Jack White",
+            "type": "artist",
+            "uri": "spotify:artist:4FZ3j1oH43e7cukCALsCwf"
+          }
+        ],
+        "name": "Lazaretto"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "01Ik2xJ818NAN1xHdqK1P5",
+          "name": "Euclid"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/7yi9sGE0VX59Pss7hHTaJ3"
+            },
+            "href": "https://api.spotify.com/v1/artists/7yi9sGE0VX59Pss7hHTaJ3",
+            "id": "7yi9sGE0VX59Pss7hHTaJ3",
+            "name": "Tanooki Suit",
+            "type": "artist",
+            "uri": "spotify:artist:7yi9sGE0VX59Pss7hHTaJ3"
+          }
+        ],
+        "name": "Lordvessel"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "3giBVgh4bHYCRK53yvvoa5",
+          "name": "Darkest Hour"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4dso1lISV1Atdo3O6qbhqq"
+            },
+            "href": "https://api.spotify.com/v1/artists/4dso1lISV1Atdo3O6qbhqq",
+            "id": "4dso1lISV1Atdo3O6qbhqq",
+            "name": "Darkest Hour",
+            "type": "artist",
+            "uri": "spotify:artist:4dso1lISV1Atdo3O6qbhqq"
+          }
+        ],
+        "name": "The Misery We Make"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "68DKWCjmwJcCV8TwCxx52H",
+          "name": "All the Lights In the Sky"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3jULn43a6xfzqleyeFjPIq"
+            },
+            "href": "https://api.spotify.com/v1/artists/3jULn43a6xfzqleyeFjPIq",
+            "id": "3jULn43a6xfzqleyeFjPIq",
+            "name": "Area 11",
+            "type": "artist",
+            "uri": "spotify:artist:3jULn43a6xfzqleyeFjPIq"
+          }
+        ],
+        "name": "Heaven-Piercing Giga Drill"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "1aG8CTUfHQJJJHYLBuqv0v",
+          "name": "Orthodox [Bonus Track Version]"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4DGNqGOtNY9niSpCKwINyU"
+            },
+            "href": "https://api.spotify.com/v1/artists/4DGNqGOtNY9niSpCKwINyU",
+            "id": "4DGNqGOtNY9niSpCKwINyU",
+            "name": "Beware Of Darkness",
+            "type": "artist",
+            "uri": "spotify:artist:4DGNqGOtNY9niSpCKwINyU"
+          }
+        ],
+        "name": "Howl"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "1vXIt4f3khLgyHd3Uyw8R0",
+          "name": "War"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4ZgQDCtRqZlhLswVS6MHN4"
+            },
+            "href": "https://api.spotify.com/v1/artists/4ZgQDCtRqZlhLswVS6MHN4",
+            "id": "4ZgQDCtRqZlhLswVS6MHN4",
+            "name": "grandson",
+            "type": "artist",
+            "uri": "spotify:artist:4ZgQDCtRqZlhLswVS6MHN4"
+          }
+        ],
+        "name": "War"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "2MqYypIxDlwcPNc1T90fO2",
+          "name": "Restoring Force: Full Circle"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4tususHNaR68xdgLstlGBA"
+            },
+            "href": "https://api.spotify.com/v1/artists/4tususHNaR68xdgLstlGBA",
+            "id": "4tususHNaR68xdgLstlGBA",
+            "name": "Of Mice & Men",
+            "type": "artist",
+            "uri": "spotify:artist:4tususHNaR68xdgLstlGBA"
+          }
+        ],
+        "name": "Broken Generation"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "0ACUx5eosqeSTrgupiuhiL",
+          "name": "Free Falling"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2SmW1lFlBJn4IfBzBZDlSh"
+            },
+            "href": "https://api.spotify.com/v1/artists/2SmW1lFlBJn4IfBzBZDlSh",
+            "id": "2SmW1lFlBJn4IfBzBZDlSh",
+            "name": "The Warning",
+            "type": "artist",
+            "uri": "spotify:artist:2SmW1lFlBJn4IfBzBZDlSh"
+          }
+        ],
+        "name": "Free Falling"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "64SL0QEXxulD2QgwJmJbUL",
+          "name": "Era Vulgaris"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4pejUc4iciQfgdX6OKulQn"
+            },
+            "href": "https://api.spotify.com/v1/artists/4pejUc4iciQfgdX6OKulQn",
+            "id": "4pejUc4iciQfgdX6OKulQn",
+            "name": "Queens of the Stone Age",
+            "type": "artist",
+            "uri": "spotify:artist:4pejUc4iciQfgdX6OKulQn"
+          }
+        ],
+        "name": "3's & 7's"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "661Hz0qJK8WIp7vAWsqKvk",
+          "name": "Collide With The Sky"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4iJLPqClelZOBCBifm8Fzv"
+            },
+            "href": "https://api.spotify.com/v1/artists/4iJLPqClelZOBCBifm8Fzv",
+            "id": "4iJLPqClelZOBCBifm8Fzv",
+            "name": "Pierce The Veil",
+            "type": "artist",
+            "uri": "spotify:artist:4iJLPqClelZOBCBifm8Fzv"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3M9XAM57a4qFz3v6Lq27t2"
+            },
+            "href": "https://api.spotify.com/v1/artists/3M9XAM57a4qFz3v6Lq27t2",
+            "id": "3M9XAM57a4qFz3v6Lq27t2",
+            "name": "Kellin Quinn",
+            "type": "artist",
+            "uri": "spotify:artist:3M9XAM57a4qFz3v6Lq27t2"
+          }
+        ],
+        "name": "King For A Day"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "36LXzRarDP8TU8K0REGpt6",
+          "name": "Lazaretto"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4FZ3j1oH43e7cukCALsCwf"
+            },
+            "href": "https://api.spotify.com/v1/artists/4FZ3j1oH43e7cukCALsCwf",
+            "id": "4FZ3j1oH43e7cukCALsCwf",
+            "name": "Jack White",
+            "type": "artist",
+            "uri": "spotify:artist:4FZ3j1oH43e7cukCALsCwf"
+          }
+        ],
+        "name": "Lazaretto"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "01Ik2xJ818NAN1xHdqK1P5",
+          "name": "Euclid"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/7yi9sGE0VX59Pss7hHTaJ3"
+            },
+            "href": "https://api.spotify.com/v1/artists/7yi9sGE0VX59Pss7hHTaJ3",
+            "id": "7yi9sGE0VX59Pss7hHTaJ3",
+            "name": "Tanooki Suit",
+            "type": "artist",
+            "uri": "spotify:artist:7yi9sGE0VX59Pss7hHTaJ3"
+          }
+        ],
+        "name": "Lordvessel"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "3giBVgh4bHYCRK53yvvoa5",
+          "name": "Darkest Hour"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4dso1lISV1Atdo3O6qbhqq"
+            },
+            "href": "https://api.spotify.com/v1/artists/4dso1lISV1Atdo3O6qbhqq",
+            "id": "4dso1lISV1Atdo3O6qbhqq",
+            "name": "Darkest Hour",
+            "type": "artist",
+            "uri": "spotify:artist:4dso1lISV1Atdo3O6qbhqq"
+          }
+        ],
+        "name": "The Misery We Make"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "68DKWCjmwJcCV8TwCxx52H",
+          "name": "All the Lights In the Sky"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3jULn43a6xfzqleyeFjPIq"
+            },
+            "href": "https://api.spotify.com/v1/artists/3jULn43a6xfzqleyeFjPIq",
+            "id": "3jULn43a6xfzqleyeFjPIq",
+            "name": "Area 11",
+            "type": "artist",
+            "uri": "spotify:artist:3jULn43a6xfzqleyeFjPIq"
+          }
+        ],
+        "name": "Heaven-Piercing Giga Drill"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "1aG8CTUfHQJJJHYLBuqv0v",
+          "name": "Orthodox [Bonus Track Version]"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4DGNqGOtNY9niSpCKwINyU"
+            },
+            "href": "https://api.spotify.com/v1/artists/4DGNqGOtNY9niSpCKwINyU",
+            "id": "4DGNqGOtNY9niSpCKwINyU",
+            "name": "Beware Of Darkness",
+            "type": "artist",
+            "uri": "spotify:artist:4DGNqGOtNY9niSpCKwINyU"
+          }
+        ],
+        "name": "Howl"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "1vXIt4f3khLgyHd3Uyw8R0",
+          "name": "War"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4ZgQDCtRqZlhLswVS6MHN4"
+            },
+            "href": "https://api.spotify.com/v1/artists/4ZgQDCtRqZlhLswVS6MHN4",
+            "id": "4ZgQDCtRqZlhLswVS6MHN4",
+            "name": "grandson",
+            "type": "artist",
+            "uri": "spotify:artist:4ZgQDCtRqZlhLswVS6MHN4"
+          }
+        ],
+        "name": "War"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "2MqYypIxDlwcPNc1T90fO2",
+          "name": "Restoring Force: Full Circle"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4tususHNaR68xdgLstlGBA"
+            },
+            "href": "https://api.spotify.com/v1/artists/4tususHNaR68xdgLstlGBA",
+            "id": "4tususHNaR68xdgLstlGBA",
+            "name": "Of Mice & Men",
+            "type": "artist",
+            "uri": "spotify:artist:4tususHNaR68xdgLstlGBA"
+          }
+        ],
+        "name": "Broken Generation"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "0ACUx5eosqeSTrgupiuhiL",
+          "name": "Free Falling"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2SmW1lFlBJn4IfBzBZDlSh"
+            },
+            "href": "https://api.spotify.com/v1/artists/2SmW1lFlBJn4IfBzBZDlSh",
+            "id": "2SmW1lFlBJn4IfBzBZDlSh",
+            "name": "The Warning",
+            "type": "artist",
+            "uri": "spotify:artist:2SmW1lFlBJn4IfBzBZDlSh"
+          }
+        ],
+        "name": "Free Falling"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "64SL0QEXxulD2QgwJmJbUL",
+          "name": "Era Vulgaris"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4pejUc4iciQfgdX6OKulQn"
+            },
+            "href": "https://api.spotify.com/v1/artists/4pejUc4iciQfgdX6OKulQn",
+            "id": "4pejUc4iciQfgdX6OKulQn",
+            "name": "Queens of the Stone Age",
+            "type": "artist",
+            "uri": "spotify:artist:4pejUc4iciQfgdX6OKulQn"
+          }
+        ],
+        "name": "3's & 7's"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "661Hz0qJK8WIp7vAWsqKvk",
+          "name": "Collide With The Sky"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4iJLPqClelZOBCBifm8Fzv"
+            },
+            "href": "https://api.spotify.com/v1/artists/4iJLPqClelZOBCBifm8Fzv",
+            "id": "4iJLPqClelZOBCBifm8Fzv",
+            "name": "Pierce The Veil",
+            "type": "artist",
+            "uri": "spotify:artist:4iJLPqClelZOBCBifm8Fzv"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3M9XAM57a4qFz3v6Lq27t2"
+            },
+            "href": "https://api.spotify.com/v1/artists/3M9XAM57a4qFz3v6Lq27t2",
+            "id": "3M9XAM57a4qFz3v6Lq27t2",
+            "name": "Kellin Quinn",
+            "type": "artist",
+            "uri": "spotify:artist:3M9XAM57a4qFz3v6Lq27t2"
+          }
+        ],
+        "name": "King For A Day"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "36LXzRarDP8TU8K0REGpt6",
+          "name": "Lazaretto"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4FZ3j1oH43e7cukCALsCwf"
+            },
+            "href": "https://api.spotify.com/v1/artists/4FZ3j1oH43e7cukCALsCwf",
+            "id": "4FZ3j1oH43e7cukCALsCwf",
+            "name": "Jack White",
+            "type": "artist",
+            "uri": "spotify:artist:4FZ3j1oH43e7cukCALsCwf"
+          }
+        ],
+        "name": "Lazaretto"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "01Ik2xJ818NAN1xHdqK1P5",
+          "name": "Euclid"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/7yi9sGE0VX59Pss7hHTaJ3"
+            },
+            "href": "https://api.spotify.com/v1/artists/7yi9sGE0VX59Pss7hHTaJ3",
+            "id": "7yi9sGE0VX59Pss7hHTaJ3",
+            "name": "Tanooki Suit",
+            "type": "artist",
+            "uri": "spotify:artist:7yi9sGE0VX59Pss7hHTaJ3"
+          }
+        ],
+        "name": "Lordvessel"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "3giBVgh4bHYCRK53yvvoa5",
+          "name": "Darkest Hour"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4dso1lISV1Atdo3O6qbhqq"
+            },
+            "href": "https://api.spotify.com/v1/artists/4dso1lISV1Atdo3O6qbhqq",
+            "id": "4dso1lISV1Atdo3O6qbhqq",
+            "name": "Darkest Hour",
+            "type": "artist",
+            "uri": "spotify:artist:4dso1lISV1Atdo3O6qbhqq"
+          }
+        ],
+        "name": "The Misery We Make"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "68DKWCjmwJcCV8TwCxx52H",
+          "name": "All the Lights In the Sky"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3jULn43a6xfzqleyeFjPIq"
+            },
+            "href": "https://api.spotify.com/v1/artists/3jULn43a6xfzqleyeFjPIq",
+            "id": "3jULn43a6xfzqleyeFjPIq",
+            "name": "Area 11",
+            "type": "artist",
+            "uri": "spotify:artist:3jULn43a6xfzqleyeFjPIq"
+          }
+        ],
+        "name": "Heaven-Piercing Giga Drill"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "1aG8CTUfHQJJJHYLBuqv0v",
+          "name": "Orthodox [Bonus Track Version]"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4DGNqGOtNY9niSpCKwINyU"
+            },
+            "href": "https://api.spotify.com/v1/artists/4DGNqGOtNY9niSpCKwINyU",
+            "id": "4DGNqGOtNY9niSpCKwINyU",
+            "name": "Beware Of Darkness",
+            "type": "artist",
+            "uri": "spotify:artist:4DGNqGOtNY9niSpCKwINyU"
+          }
+        ],
+        "name": "Howl"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "1vXIt4f3khLgyHd3Uyw8R0",
+          "name": "War"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4ZgQDCtRqZlhLswVS6MHN4"
+            },
+            "href": "https://api.spotify.com/v1/artists/4ZgQDCtRqZlhLswVS6MHN4",
+            "id": "4ZgQDCtRqZlhLswVS6MHN4",
+            "name": "grandson",
+            "type": "artist",
+            "uri": "spotify:artist:4ZgQDCtRqZlhLswVS6MHN4"
+          }
+        ],
+        "name": "War"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "2MqYypIxDlwcPNc1T90fO2",
+          "name": "Restoring Force: Full Circle"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4tususHNaR68xdgLstlGBA"
+            },
+            "href": "https://api.spotify.com/v1/artists/4tususHNaR68xdgLstlGBA",
+            "id": "4tususHNaR68xdgLstlGBA",
+            "name": "Of Mice & Men",
+            "type": "artist",
+            "uri": "spotify:artist:4tususHNaR68xdgLstlGBA"
+          }
+        ],
+        "name": "Broken Generation"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "0ACUx5eosqeSTrgupiuhiL",
+          "name": "Free Falling"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2SmW1lFlBJn4IfBzBZDlSh"
+            },
+            "href": "https://api.spotify.com/v1/artists/2SmW1lFlBJn4IfBzBZDlSh",
+            "id": "2SmW1lFlBJn4IfBzBZDlSh",
+            "name": "The Warning",
+            "type": "artist",
+            "uri": "spotify:artist:2SmW1lFlBJn4IfBzBZDlSh"
+          }
+        ],
+        "name": "Free Falling"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "64SL0QEXxulD2QgwJmJbUL",
+          "name": "Era Vulgaris"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4pejUc4iciQfgdX6OKulQn"
+            },
+            "href": "https://api.spotify.com/v1/artists/4pejUc4iciQfgdX6OKulQn",
+            "id": "4pejUc4iciQfgdX6OKulQn",
+            "name": "Queens of the Stone Age",
+            "type": "artist",
+            "uri": "spotify:artist:4pejUc4iciQfgdX6OKulQn"
+          }
+        ],
+        "name": "3's & 7's"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "661Hz0qJK8WIp7vAWsqKvk",
+          "name": "Collide With The Sky"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4iJLPqClelZOBCBifm8Fzv"
+            },
+            "href": "https://api.spotify.com/v1/artists/4iJLPqClelZOBCBifm8Fzv",
+            "id": "4iJLPqClelZOBCBifm8Fzv",
+            "name": "Pierce The Veil",
+            "type": "artist",
+            "uri": "spotify:artist:4iJLPqClelZOBCBifm8Fzv"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3M9XAM57a4qFz3v6Lq27t2"
+            },
+            "href": "https://api.spotify.com/v1/artists/3M9XAM57a4qFz3v6Lq27t2",
+            "id": "3M9XAM57a4qFz3v6Lq27t2",
+            "name": "Kellin Quinn",
+            "type": "artist",
+            "uri": "spotify:artist:3M9XAM57a4qFz3v6Lq27t2"
+          }
+        ],
+        "name": "King For A Day"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "36LXzRarDP8TU8K0REGpt6",
+          "name": "Lazaretto"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4FZ3j1oH43e7cukCALsCwf"
+            },
+            "href": "https://api.spotify.com/v1/artists/4FZ3j1oH43e7cukCALsCwf",
+            "id": "4FZ3j1oH43e7cukCALsCwf",
+            "name": "Jack White",
+            "type": "artist",
+            "uri": "spotify:artist:4FZ3j1oH43e7cukCALsCwf"
+          }
+        ],
+        "name": "Lazaretto"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "01Ik2xJ818NAN1xHdqK1P5",
+          "name": "Euclid"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/7yi9sGE0VX59Pss7hHTaJ3"
+            },
+            "href": "https://api.spotify.com/v1/artists/7yi9sGE0VX59Pss7hHTaJ3",
+            "id": "7yi9sGE0VX59Pss7hHTaJ3",
+            "name": "Tanooki Suit",
+            "type": "artist",
+            "uri": "spotify:artist:7yi9sGE0VX59Pss7hHTaJ3"
+          }
+        ],
+        "name": "Lordvessel"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "3giBVgh4bHYCRK53yvvoa5",
+          "name": "Darkest Hour"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4dso1lISV1Atdo3O6qbhqq"
+            },
+            "href": "https://api.spotify.com/v1/artists/4dso1lISV1Atdo3O6qbhqq",
+            "id": "4dso1lISV1Atdo3O6qbhqq",
+            "name": "Darkest Hour",
+            "type": "artist",
+            "uri": "spotify:artist:4dso1lISV1Atdo3O6qbhqq"
+          }
+        ],
+        "name": "The Misery We Make"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "68DKWCjmwJcCV8TwCxx52H",
+          "name": "All the Lights In the Sky"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3jULn43a6xfzqleyeFjPIq"
+            },
+            "href": "https://api.spotify.com/v1/artists/3jULn43a6xfzqleyeFjPIq",
+            "id": "3jULn43a6xfzqleyeFjPIq",
+            "name": "Area 11",
+            "type": "artist",
+            "uri": "spotify:artist:3jULn43a6xfzqleyeFjPIq"
+          }
+        ],
+        "name": "Heaven-Piercing Giga Drill"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "1aG8CTUfHQJJJHYLBuqv0v",
+          "name": "Orthodox [Bonus Track Version]"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4DGNqGOtNY9niSpCKwINyU"
+            },
+            "href": "https://api.spotify.com/v1/artists/4DGNqGOtNY9niSpCKwINyU",
+            "id": "4DGNqGOtNY9niSpCKwINyU",
+            "name": "Beware Of Darkness",
+            "type": "artist",
+            "uri": "spotify:artist:4DGNqGOtNY9niSpCKwINyU"
+          }
+        ],
+        "name": "Howl"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "1vXIt4f3khLgyHd3Uyw8R0",
+          "name": "War"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4ZgQDCtRqZlhLswVS6MHN4"
+            },
+            "href": "https://api.spotify.com/v1/artists/4ZgQDCtRqZlhLswVS6MHN4",
+            "id": "4ZgQDCtRqZlhLswVS6MHN4",
+            "name": "grandson",
+            "type": "artist",
+            "uri": "spotify:artist:4ZgQDCtRqZlhLswVS6MHN4"
+          }
+        ],
+        "name": "War"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "2MqYypIxDlwcPNc1T90fO2",
+          "name": "Restoring Force: Full Circle"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4tususHNaR68xdgLstlGBA"
+            },
+            "href": "https://api.spotify.com/v1/artists/4tususHNaR68xdgLstlGBA",
+            "id": "4tususHNaR68xdgLstlGBA",
+            "name": "Of Mice & Men",
+            "type": "artist",
+            "uri": "spotify:artist:4tususHNaR68xdgLstlGBA"
+          }
+        ],
+        "name": "Broken Generation"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "0ACUx5eosqeSTrgupiuhiL",
+          "name": "Free Falling"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2SmW1lFlBJn4IfBzBZDlSh"
+            },
+            "href": "https://api.spotify.com/v1/artists/2SmW1lFlBJn4IfBzBZDlSh",
+            "id": "2SmW1lFlBJn4IfBzBZDlSh",
+            "name": "The Warning",
+            "type": "artist",
+            "uri": "spotify:artist:2SmW1lFlBJn4IfBzBZDlSh"
+          }
+        ],
+        "name": "Free Falling"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "64SL0QEXxulD2QgwJmJbUL",
+          "name": "Era Vulgaris"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4pejUc4iciQfgdX6OKulQn"
+            },
+            "href": "https://api.spotify.com/v1/artists/4pejUc4iciQfgdX6OKulQn",
+            "id": "4pejUc4iciQfgdX6OKulQn",
+            "name": "Queens of the Stone Age",
+            "type": "artist",
+            "uri": "spotify:artist:4pejUc4iciQfgdX6OKulQn"
+          }
+        ],
+        "name": "3's & 7's"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "661Hz0qJK8WIp7vAWsqKvk",
+          "name": "Collide With The Sky"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4iJLPqClelZOBCBifm8Fzv"
+            },
+            "href": "https://api.spotify.com/v1/artists/4iJLPqClelZOBCBifm8Fzv",
+            "id": "4iJLPqClelZOBCBifm8Fzv",
+            "name": "Pierce The Veil",
+            "type": "artist",
+            "uri": "spotify:artist:4iJLPqClelZOBCBifm8Fzv"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3M9XAM57a4qFz3v6Lq27t2"
+            },
+            "href": "https://api.spotify.com/v1/artists/3M9XAM57a4qFz3v6Lq27t2",
+            "id": "3M9XAM57a4qFz3v6Lq27t2",
+            "name": "Kellin Quinn",
+            "type": "artist",
+            "uri": "spotify:artist:3M9XAM57a4qFz3v6Lq27t2"
+          }
+        ],
+        "name": "King For A Day"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "36LXzRarDP8TU8K0REGpt6",
+          "name": "Lazaretto"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4FZ3j1oH43e7cukCALsCwf"
+            },
+            "href": "https://api.spotify.com/v1/artists/4FZ3j1oH43e7cukCALsCwf",
+            "id": "4FZ3j1oH43e7cukCALsCwf",
+            "name": "Jack White",
+            "type": "artist",
+            "uri": "spotify:artist:4FZ3j1oH43e7cukCALsCwf"
+          }
+        ],
+        "name": "Lazaretto"
+      }
+    }
+  ]
+}

--- a/src/NzbDrone.Core.Test/Files/ImportLists/Spotify/SpotifyPlaylistTracksNotFull.json
+++ b/src/NzbDrone.Core.Test/Files/ImportLists/Spotify/SpotifyPlaylistTracksNotFull.json
@@ -1,0 +1,224 @@
+﻿{
+  "items": [
+    {
+      "track": {
+        "album": {
+          "id": "01Ik2xJ818NAN1xHdqK1P5",
+          "name": "Euclid"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/7yi9sGE0VX59Pss7hHTaJ3"
+            },
+            "href": "https://api.spotify.com/v1/artists/7yi9sGE0VX59Pss7hHTaJ3",
+            "id": "7yi9sGE0VX59Pss7hHTaJ3",
+            "name": "Tanooki Suit",
+            "type": "artist",
+            "uri": "spotify:artist:7yi9sGE0VX59Pss7hHTaJ3"
+          }
+        ],
+        "name": "Lordvessel"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "3giBVgh4bHYCRK53yvvoa5",
+          "name": "Darkest Hour"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4dso1lISV1Atdo3O6qbhqq"
+            },
+            "href": "https://api.spotify.com/v1/artists/4dso1lISV1Atdo3O6qbhqq",
+            "id": "4dso1lISV1Atdo3O6qbhqq",
+            "name": "Darkest Hour",
+            "type": "artist",
+            "uri": "spotify:artist:4dso1lISV1Atdo3O6qbhqq"
+          }
+        ],
+        "name": "The Misery We Make"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "68DKWCjmwJcCV8TwCxx52H",
+          "name": "All the Lights In the Sky"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3jULn43a6xfzqleyeFjPIq"
+            },
+            "href": "https://api.spotify.com/v1/artists/3jULn43a6xfzqleyeFjPIq",
+            "id": "3jULn43a6xfzqleyeFjPIq",
+            "name": "Area 11",
+            "type": "artist",
+            "uri": "spotify:artist:3jULn43a6xfzqleyeFjPIq"
+          }
+        ],
+        "name": "Heaven-Piercing Giga Drill"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "1aG8CTUfHQJJJHYLBuqv0v",
+          "name": "Orthodox [Bonus Track Version]"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4DGNqGOtNY9niSpCKwINyU"
+            },
+            "href": "https://api.spotify.com/v1/artists/4DGNqGOtNY9niSpCKwINyU",
+            "id": "4DGNqGOtNY9niSpCKwINyU",
+            "name": "Beware Of Darkness",
+            "type": "artist",
+            "uri": "spotify:artist:4DGNqGOtNY9niSpCKwINyU"
+          }
+        ],
+        "name": "Howl"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "1vXIt4f3khLgyHd3Uyw8R0",
+          "name": "War"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4ZgQDCtRqZlhLswVS6MHN4"
+            },
+            "href": "https://api.spotify.com/v1/artists/4ZgQDCtRqZlhLswVS6MHN4",
+            "id": "4ZgQDCtRqZlhLswVS6MHN4",
+            "name": "grandson",
+            "type": "artist",
+            "uri": "spotify:artist:4ZgQDCtRqZlhLswVS6MHN4"
+          }
+        ],
+        "name": "War"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "2MqYypIxDlwcPNc1T90fO2",
+          "name": "Restoring Force: Full Circle"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4tususHNaR68xdgLstlGBA"
+            },
+            "href": "https://api.spotify.com/v1/artists/4tususHNaR68xdgLstlGBA",
+            "id": "4tususHNaR68xdgLstlGBA",
+            "name": "Of Mice & Men",
+            "type": "artist",
+            "uri": "spotify:artist:4tususHNaR68xdgLstlGBA"
+          }
+        ],
+        "name": "Broken Generation"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "0ACUx5eosqeSTrgupiuhiL",
+          "name": "Free Falling"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/2SmW1lFlBJn4IfBzBZDlSh"
+            },
+            "href": "https://api.spotify.com/v1/artists/2SmW1lFlBJn4IfBzBZDlSh",
+            "id": "2SmW1lFlBJn4IfBzBZDlSh",
+            "name": "The Warning",
+            "type": "artist",
+            "uri": "spotify:artist:2SmW1lFlBJn4IfBzBZDlSh"
+          }
+        ],
+        "name": "Free Falling"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "64SL0QEXxulD2QgwJmJbUL",
+          "name": "Era Vulgaris"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4pejUc4iciQfgdX6OKulQn"
+            },
+            "href": "https://api.spotify.com/v1/artists/4pejUc4iciQfgdX6OKulQn",
+            "id": "4pejUc4iciQfgdX6OKulQn",
+            "name": "Queens of the Stone Age",
+            "type": "artist",
+            "uri": "spotify:artist:4pejUc4iciQfgdX6OKulQn"
+          }
+        ],
+        "name": "3's & 7's"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "661Hz0qJK8WIp7vAWsqKvk",
+          "name": "Collide With The Sky"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4iJLPqClelZOBCBifm8Fzv"
+            },
+            "href": "https://api.spotify.com/v1/artists/4iJLPqClelZOBCBifm8Fzv",
+            "id": "4iJLPqClelZOBCBifm8Fzv",
+            "name": "Pierce The Veil",
+            "type": "artist",
+            "uri": "spotify:artist:4iJLPqClelZOBCBifm8Fzv"
+          },
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/3M9XAM57a4qFz3v6Lq27t2"
+            },
+            "href": "https://api.spotify.com/v1/artists/3M9XAM57a4qFz3v6Lq27t2",
+            "id": "3M9XAM57a4qFz3v6Lq27t2",
+            "name": "Kellin Quinn",
+            "type": "artist",
+            "uri": "spotify:artist:3M9XAM57a4qFz3v6Lq27t2"
+          }
+        ],
+        "name": "King For A Day"
+      }
+    },
+    {
+      "track": {
+        "album": {
+          "id": "36LXzRarDP8TU8K0REGpt6",
+          "name": "Lazaretto"
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/4FZ3j1oH43e7cukCALsCwf"
+            },
+            "href": "https://api.spotify.com/v1/artists/4FZ3j1oH43e7cukCALsCwf",
+            "id": "4FZ3j1oH43e7cukCALsCwf",
+            "name": "Jack White",
+            "type": "artist",
+            "uri": "spotify:artist:4FZ3j1oH43e7cukCALsCwf"
+          }
+        ],
+        "name": "Lazaretto"
+      }
+    }
+  ]
+}

--- a/src/NzbDrone.Core.Test/Files/ImportLists/Spotify/SpotifyToken.json
+++ b/src/NzbDrone.Core.Test/Files/ImportLists/Spotify/SpotifyToken.json
@@ -1,0 +1,6 @@
+﻿{
+	"access_token": "the_token",
+	"token_type": "Bearer",
+	"expires_in": 3600,
+	"scope": ""
+}

--- a/src/NzbDrone.Core.Test/ImportListTests/SpotifyTests/SpotifyPlaylistTracksFixture.cs
+++ b/src/NzbDrone.Core.Test/ImportListTests/SpotifyTests/SpotifyPlaylistTracksFixture.cs
@@ -1,0 +1,134 @@
+using System.Linq;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.ImportLists;
+using NzbDrone.Core.ImportLists.Spotify;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.ImportListTests.SpotifyTests
+{
+    [TestFixture]
+    public class SpotifyPlaylistTracksFixture : CoreTest<SpotifyPlaylistTracks>
+    {
+        [SetUp]
+        public void Setup()
+        {
+            Subject.Definition = new ImportListDefinition()
+            {
+                Name = "Spotify playlist tracks",
+                Settings = new SpotifyPlaylistTracksSettings()
+                {
+                    ClientId = "abc",
+                    ClientSecret = "xyz",
+                    BaseUrl = "SpotifyBaseUrl",
+                    Count = 410,
+                    PlaylistId = "playlistID"
+                }
+            };
+        }
+
+        [Test]
+        public void should_have_default_page_size_of_100()
+        {
+            Subject.PageSize.Should().Be(100);
+        }
+
+        [Test]
+        public void should_parse_albums_and_artists_from_spotifyplaylisttracks_response_and_make_a_single_call_if_one_page()
+        {
+            var tokenResponse = ReadAllText(@"Files/ImportLists/Spotify/SpotifyToken.json");
+            var base64ClientIdAndSecret = "YWJjOnh5eg==";
+            Mocker.GetMock<IHttpClient>()
+                .Setup(o => o.Execute(It.Is<HttpRequest>(r => r.Method == HttpMethod.POST && r.Url.FullUri == "https://accounts.spotify.com/api/token" && r.Headers["Authorization"] == $"Basic {base64ClientIdAndSecret}")))
+                .Returns<HttpRequest>(r => new HttpResponse(r, new HttpHeader(), tokenResponse));
+            
+            var tracksResponse = ReadAllText(@"Files/ImportLists/Spotify/SpotifyPlaylistTracksNotFull.json");
+            Mocker.GetMock<IHttpClient>()
+                .Setup(o => o.Execute(It.Is<HttpRequest>(r => r.Method == HttpMethod.GET && r.Url.FullUri == "SpotifyBaseUrl/playlists/playlistID/tracks?fields=items(track(name,album(name,id),artists))&limit=100&offset=0" && r.Headers["Authorization"] == "Bearer the_token")))
+                .Returns<HttpRequest>(r => new HttpResponse(r, new HttpHeader(), tracksResponse));
+
+            var importListResults = Subject.Fetch();
+
+            importListResults.Should().HaveCount(10);
+
+            importListResults.First().Should().BeOfType<ImportListItemInfo>();
+            var firstResult = importListResults.First() as ImportListItemInfo;
+
+            firstResult.Artist.Should().Be("Tanooki Suit");
+            firstResult.Album.Should().Be("Euclid");
+        }
+
+        [Test]
+        public void should_cleanup_duplicates()
+        {
+            var tokenResponse = ReadAllText(@"Files/ImportLists/Spotify/SpotifyToken.json");
+            var base64ClientIdAndSecret = "YWJjOnh5eg==";
+            Mocker.GetMock<IHttpClient>()
+                .Setup(o => o.Execute(It.Is<HttpRequest>(r => r.Method == HttpMethod.POST && r.Url.FullUri == "https://accounts.spotify.com/api/token" && r.Headers["Authorization"] == $"Basic {base64ClientIdAndSecret}")))
+                .Returns<HttpRequest>(r => new HttpResponse(r, new HttpHeader(), tokenResponse));
+
+            var tracksResponseFull = ReadAllText(@"Files/ImportLists/Spotify/SpotifyPlaylistTracksFull.json");
+            Mocker.GetMock<IHttpClient>()
+                .Setup(o => o.Execute(It.Is<HttpRequest>(r => r.Method == HttpMethod.GET && r.Url.FullUri == "SpotifyBaseUrl/playlists/playlistID/tracks?fields=items(track(name,album(name,id),artists))&limit=100&offset=0" && r.Headers["Authorization"] == "Bearer the_token")))
+                .Returns<HttpRequest>(r => new HttpResponse(r, new HttpHeader(), tracksResponseFull));
+
+            var tracksResponseNotFull = ReadAllText(@"Files/ImportLists/Spotify/SpotifyPlaylistTracksNotFull.json");
+            Mocker.GetMock<IHttpClient>()
+                .Setup(o => o.Execute(It.Is<HttpRequest>(r => r.Method == HttpMethod.GET && r.Url.FullUri == "SpotifyBaseUrl/playlists/playlistID/tracks?fields=items(track(name,album(name,id),artists))&limit=100&offset=100" && r.Headers["Authorization"] == "Bearer the_token")))
+                .Returns<HttpRequest>(r => new HttpResponse(r, new HttpHeader(), tracksResponseNotFull));
+
+            var importListResults = Subject.Fetch();
+
+            importListResults.Should().HaveCount(10); // SpotifyPlaylistTracksFull contains the same 10 results as SpotifyPlaylistTracksNotFull repeated 10 times
+        }
+
+        [Test]
+        public void should_make_multiple_calls_if_multiple_pages_and_calls_token_only_once()
+        {
+            var tokenResponse = ReadAllText(@"Files/ImportLists/Spotify/SpotifyToken.json");
+            var base64ClientIdAndSecret = "YWJjOnh5eg==";
+            Mocker.GetMock<IHttpClient>()
+                .Setup(o => o.Execute(It.Is<HttpRequest>(r => r.Method == HttpMethod.POST && r.Url.FullUri == "https://accounts.spotify.com/api/token" && r.Headers["Authorization"] == $"Basic {base64ClientIdAndSecret}")))
+                .Returns<HttpRequest>(r => new HttpResponse(r, new HttpHeader(), tokenResponse));
+
+            var tracksResponseFull = ReadAllText(@"Files/ImportLists/Spotify/SpotifyPlaylistTracksFull.json");
+            Mocker.GetMock<IHttpClient>()
+                .Setup(o => o.Execute(It.Is<HttpRequest>(r => r.Method == HttpMethod.GET && r.Url.FullUri == "SpotifyBaseUrl/playlists/playlistID/tracks?fields=items(track(name,album(name,id),artists))&limit=100&offset=0" && r.Headers["Authorization"] == "Bearer the_token")))
+                .Returns<HttpRequest>(r => new HttpResponse(r, new HttpHeader(), tracksResponseFull));
+            Mocker.GetMock<IHttpClient>()
+                .Setup(o => o.Execute(It.Is<HttpRequest>(r => r.Method == HttpMethod.GET && r.Url.FullUri == "SpotifyBaseUrl/playlists/playlistID/tracks?fields=items(track(name,album(name,id),artists))&limit=100&offset=100" && r.Headers["Authorization"] == "Bearer the_token")))
+                .Returns<HttpRequest>(r => new HttpResponse(r, new HttpHeader(), tracksResponseFull));
+            Mocker.GetMock<IHttpClient>()
+                .Setup(o => o.Execute(It.Is<HttpRequest>(r => r.Method == HttpMethod.GET && r.Url.FullUri == "SpotifyBaseUrl/playlists/playlistID/tracks?fields=items(track(name,album(name,id),artists))&limit=100&offset=200" && r.Headers["Authorization"] == "Bearer the_token")))
+                .Returns<HttpRequest>(r => new HttpResponse(r, new HttpHeader(), tracksResponseFull));
+            Mocker.GetMock<IHttpClient>()
+                .Setup(o => o.Execute(It.Is<HttpRequest>(r => r.Method == HttpMethod.GET && r.Url.FullUri == "SpotifyBaseUrl/playlists/playlistID/tracks?fields=items(track(name,album(name,id),artists))&limit=100&offset=300" && r.Headers["Authorization"] == "Bearer the_token")))
+                .Returns<HttpRequest>(r => new HttpResponse(r, new HttpHeader(), tracksResponseFull));
+
+            var tracksResponseNotFull = ReadAllText(@"Files/ImportLists/Spotify/SpotifyPlaylistTracksNotFull.json");
+            Mocker.GetMock<IHttpClient>()
+                .Setup(o => o.Execute(It.Is<HttpRequest>(r => r.Method == HttpMethod.GET && r.Url.FullUri == "SpotifyBaseUrl/playlists/playlistID/tracks?fields=items(track(name,album(name,id),artists))&limit=10&offset=400" && r.Headers["Authorization"] == "Bearer the_token")))
+                .Returns<HttpRequest>(r => new HttpResponse(r, new HttpHeader(), tracksResponseNotFull));
+
+            var importListResults = Subject.Fetch();
+
+            Mocker.GetMock<IHttpClient>()
+                .Verify(c => c.Execute(It.IsAny<HttpRequest>()), Times.Exactly(6));
+            Mocker.GetMock<IHttpClient>()
+                .Verify(c => c.Execute(It.Is<HttpRequest>(r => r.Method == HttpMethod.POST && r.Url.FullUri == "https://accounts.spotify.com/api/token" && r.Headers["Authorization"] == $"Basic {base64ClientIdAndSecret}")));
+            Mocker.GetMock<IHttpClient>()
+                .Verify(c => c.Execute(It.Is<HttpRequest>(r => r.Method == HttpMethod.GET && r.Url.FullUri == "SpotifyBaseUrl/playlists/playlistID/tracks?fields=items(track(name,album(name,id),artists))&limit=100&offset=0" && r.Headers["Authorization"] == "Bearer the_token")));
+            Mocker.GetMock<IHttpClient>()
+                .Verify(c => c.Execute(It.Is<HttpRequest>(r => r.Method == HttpMethod.GET && r.Url.FullUri == "SpotifyBaseUrl/playlists/playlistID/tracks?fields=items(track(name,album(name,id),artists))&limit=100&offset=100" && r.Headers["Authorization"] == "Bearer the_token")));
+            Mocker.GetMock<IHttpClient>()
+                .Verify(c => c.Execute(It.Is<HttpRequest>(r => r.Method == HttpMethod.GET && r.Url.FullUri == "SpotifyBaseUrl/playlists/playlistID/tracks?fields=items(track(name,album(name,id),artists))&limit=100&offset=200" && r.Headers["Authorization"] == "Bearer the_token")));
+            Mocker.GetMock<IHttpClient>()
+                .Verify(c => c.Execute(It.Is<HttpRequest>(r => r.Method == HttpMethod.GET && r.Url.FullUri == "SpotifyBaseUrl/playlists/playlistID/tracks?fields=items(track(name,album(name,id),artists))&limit=100&offset=300" && r.Headers["Authorization"] == "Bearer the_token")));
+            Mocker.GetMock<IHttpClient>()
+                .Verify(c => c.Execute(It.Is<HttpRequest>(r => r.Method == HttpMethod.GET && r.Url.FullUri == "SpotifyBaseUrl/playlists/playlistID/tracks?fields=items(track(name,album(name,id),artists))&limit=10&offset=400" && r.Headers["Authorization"] == "Bearer the_token")));
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -146,6 +146,12 @@
     <Compile Include="Download\Pending\PendingReleaseServiceTests\RemoveRejectedFixture.cs" />
     <Compile Include="Download\Pending\PendingReleaseServiceTests\RemoveGrabbedFixture.cs" />
     <Compile Include="Download\Pending\PendingReleaseServiceTests\AddFixture.cs" />
+    <Content Include="Files\ImportLists\Spotify\SpotifyPlaylistTracksNotFull.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Files\ImportLists\Spotify\SpotifyPlaylistTracksFull.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <None Include="Files\Indexers\Gazelle\GazelleIndex.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -205,6 +211,7 @@
     <Compile Include="ImportListTests\ImportListServiceFixture.cs" />
     <Compile Include="ImportListTests\ImportListStatusServiceFixture.cs" />
     <Compile Include="ImportListTests\ImportListSyncServiceFixture.cs" />
+    <Compile Include="ImportListTests\SpotifyTests\SpotifyPlaylistTracksFixture.cs" />
     <Compile Include="IndexerSearchTests\ArtistSearchServiceFixture.cs" />
     <Compile Include="IndexerSearchTests\SearchDefinitionFixture.cs" />
     <Compile Include="IndexerTests\BasicRssParserFixture.cs" />
@@ -406,6 +413,9 @@
     <None Include="Files\Indexers\Gazelle\Gazelle.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <Content Include="Files\ImportLists\Spotify\SpotifyToken.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="Files\Indexers\Headphones\Headphones.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/src/NzbDrone.Core/ImportLists/Exceptions/ImportListTokenException.cs
+++ b/src/NzbDrone.Core/ImportLists/Exceptions/ImportListTokenException.cs
@@ -1,0 +1,11 @@
+using NzbDrone.Common.Exceptions;
+
+namespace NzbDrone.Core.ImportLists.Exceptions
+{
+    public class ImportListTokenException : NzbDroneException
+    {
+        public ImportListTokenException(string message, params object[] args)
+            : base(message, args)
+        { }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/HttpImportListBase.cs
+++ b/src/NzbDrone.Core/ImportLists/HttpImportListBase.cs
@@ -208,11 +208,16 @@ namespace NzbDrone.Core.ImportLists
 
         protected virtual ValidationFailure TestConnection()
         {
+            var generator = GetRequestGenerator();
+            return TestConnection(generator.GetListItems().GetAllTiers().First().First());
+        }
+
+        protected virtual ValidationFailure TestConnection(ImportListRequest testRequest)
+        {
             try
             {
                 var parser = GetParser();
-                var generator = GetRequestGenerator();
-                var releases = FetchPage(generator.GetListItems().GetAllTiers().First().First(), parser);
+                var releases = FetchPage(testRequest, parser);
 
                 if (releases.Empty())
                 {

--- a/src/NzbDrone.Core/ImportLists/HttpImportListBase.cs
+++ b/src/NzbDrone.Core/ImportLists/HttpImportListBase.cs
@@ -12,7 +12,6 @@ using NzbDrone.Core.ImportLists.Exceptions;
 using NzbDrone.Core.Indexers.Exceptions;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Parser.Model;
-using NzbDrone.Core.ThingiProvider;
 
 namespace NzbDrone.Core.ImportLists
 {
@@ -44,15 +43,19 @@ namespace NzbDrone.Core.ImportLists
 
         protected virtual IList<ImportListItemInfo> FetchReleases(Func<IImportListRequestGenerator, ImportListPageableRequestChain> pageableRequestChainSelector, bool isRecent = false)
         {
+            var generator = GetRequestGenerator();
+            var pageableRequestChain = pageableRequestChainSelector(generator);
+            return FetchReleases(pageableRequestChain);
+        }
+
+        protected virtual IList<ImportListItemInfo> FetchReleases(ImportListPageableRequestChain pageableRequestChain)
+        {
             var releases = new List<ImportListItemInfo>();
             var url = string.Empty;
 
             try
             {
-                var generator = GetRequestGenerator();
                 var parser = GetParser();
-
-                var pageableRequestChain = pageableRequestChainSelector(generator);
 
                 for (int i = 0; i < pageableRequestChain.Tiers; i++)
                 {

--- a/src/NzbDrone.Core/ImportLists/HttpImportListWithExpiringTokenBase.cs
+++ b/src/NzbDrone.Core/ImportLists/HttpImportListWithExpiringTokenBase.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using NLog;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Parser;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.ImportLists
+{
+    public abstract class HttpImportListWithExpiringTokenBase<TSettings, TToken> : HttpImportListBase<TSettings>
+        where TSettings : IImportListSettings, new()
+    {
+        public HttpImportListWithExpiringTokenBase(IHttpClient httpClient, IImportListStatusService importListStatusService, IConfigService configService, IParsingService parsingService, Logger logger)
+            : base(httpClient, importListStatusService, configService, parsingService, logger)
+        { }
+
+        public abstract ImportListRequestGeneratorWithExpiringTokenBase<TToken> GetRequestGeneratorWithExpiringToken();
+        public abstract TToken ParseResponseForToken(HttpResponse tokenResponse);
+
+        public override IImportListRequestGenerator GetRequestGenerator()
+        {
+            return GetRequestGeneratorWithExpiringToken();
+        }
+
+        public override IList<ImportListItemInfo> Fetch()
+        {
+            return FetchReleases(g => g.GetListItems(), true);
+        }
+
+        protected virtual IList<ImportListItemInfo> FetchReleases(Func<ImportListRequestGeneratorWithExpiringTokenBase<TToken>, ImportListPageableRequestChain> pageableRequestChainSelector, bool isRecent = false)
+        {
+            var generator = GetRequestGeneratorWithExpiringToken();
+            GetAuthorizationToken(generator);
+
+            var pageableRequestChain = pageableRequestChainSelector(generator);
+            return FetchReleases(pageableRequestChain);
+        }
+
+        private void GetAuthorizationToken(ImportListRequestGeneratorWithExpiringTokenBase<TToken> generator)
+        {
+            var refreshTokenRequest = generator.GetRefreshTokenRequest();
+
+            try
+            {
+                var tokenResponse = _httpClient.Execute(refreshTokenRequest);
+                var token = ParseResponseForToken(tokenResponse);
+                generator.Token = token;
+            }
+            catch (WebException webException)
+            {
+                if (webException.Status == WebExceptionStatus.NameResolutionFailure ||
+                    webException.Status == WebExceptionStatus.ConnectFailure)
+                {
+                    _importListStatusService.RecordConnectionFailure(Definition.Id);
+                }
+                else
+                {
+                    _importListStatusService.RecordFailure(Definition.Id);
+                }
+
+                if (webException.Message.Contains("502") || webException.Message.Contains("503") ||
+                    webException.Message.Contains("timed out"))
+                {
+                    _logger.Warn("{0} server is currently unavailable. {1} {2}", this, refreshTokenRequest.Url, webException.Message);
+                }
+                else
+                {
+                    _logger.Warn("{0} {1} {2}", this, refreshTokenRequest.Url, webException.Message);
+                }
+            }
+            catch (TooManyRequestsException ex)
+            {
+                if (ex.RetryAfter != TimeSpan.Zero)
+                {
+                    _importListStatusService.RecordFailure(Definition.Id, ex.RetryAfter);
+                }
+                else
+                {
+                    _importListStatusService.RecordFailure(Definition.Id, TimeSpan.FromHours(1));
+                }
+                _logger.Warn("API Request Limit reached for {0}", this);
+            }
+            catch (HttpException ex)
+            {
+                _importListStatusService.RecordFailure(Definition.Id);
+                _logger.Warn("{0} {1}", this, ex.Message);
+            }
+            catch (Exception ex)
+            {
+                _importListStatusService.RecordFailure(Definition.Id);
+                ex.WithData("FeedUrl", refreshTokenRequest.Url);
+                _logger.Error(ex, "An error occurred while processing feed. {0}", refreshTokenRequest.Url);
+            }
+        }
+    }
+
+}

--- a/src/NzbDrone.Core/ImportLists/ImportListRequestGeneratorWithExpiringTokenBase.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListRequestGeneratorWithExpiringTokenBase.cs
@@ -5,11 +5,11 @@ namespace NzbDrone.Core.ImportLists
 {
     public abstract class ImportListRequestGeneratorWithExpiringTokenBase<TToken> : IImportListRequestGenerator
     {
-        public TToken Token { private get; set; }
+        public TToken Token { protected get; set; }
 
         public abstract HttpRequest GetRefreshTokenRequest();
 
-        public abstract ImportListPageableRequestChain GetListItems(TToken token);
+        public abstract ImportListPageableRequestChain GetListItemsWithExpiringToken();
 
         public ImportListPageableRequestChain GetListItems()
         {
@@ -17,7 +17,9 @@ namespace NzbDrone.Core.ImportLists
             {
                 throw new ImportListTokenException("The token needs to be set before generating requests that need the Authorization token");
             }
-            return GetListItems(Token);
+            return GetListItemsWithExpiringToken();
         }
+
+        protected abstract ImportListRequest AddTokenToRequest(ImportListRequest request);
     }
 }

--- a/src/NzbDrone.Core/ImportLists/ImportListRequestGeneratorWithExpiringTokenBase.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListRequestGeneratorWithExpiringTokenBase.cs
@@ -1,0 +1,23 @@
+using NzbDrone.Common.Http;
+using NzbDrone.Core.ImportLists.Exceptions;
+
+namespace NzbDrone.Core.ImportLists
+{
+    public abstract class ImportListRequestGeneratorWithExpiringTokenBase<TToken> : IImportListRequestGenerator
+    {
+        public TToken Token { private get; set; }
+
+        public abstract HttpRequest GetRefreshTokenRequest();
+
+        public abstract ImportListPageableRequestChain GetListItems(TToken token);
+
+        public ImportListPageableRequestChain GetListItems()
+        {
+            if (Token == null)
+            {
+                throw new ImportListTokenException("The token needs to be set before generating requests that need the Authorization token");
+            }
+            return GetListItems(Token);
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
@@ -124,7 +124,7 @@ namespace NzbDrone.Core.ImportLists
 
                 if (excludedArtist != null)
                 {
-                    _logger.Debug("{0} [{1}] Rejected due to list exlcusion", report.ArtistMusicBrainzId, report.Artist);
+                    _logger.Debug("{0} [{1}] Rejected due to list exclusion", report.ArtistMusicBrainzId, report.Artist);
                 }
 
                 // Append Artist if not already in DB or already on add list

--- a/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
@@ -102,8 +102,8 @@ namespace NzbDrone.Core.ImportLists
 
                     report.AlbumMusicBrainzId = mappedAlbum.ForeignAlbumId;
                     report.Album = mappedAlbum.Title;
-                    report.Artist = mappedAlbum.ArtistMetadata?.Value?.Name;
-                    report.ArtistMusicBrainzId = mappedAlbum?.ArtistMetadata?.Value?.ForeignArtistId;
+                    report.Artist = mappedAlbum.ArtistMetadata?.Value?.Name ?? mappedAlbum.Artist?.Value?.Name;
+                    report.ArtistMusicBrainzId = mappedAlbum?.ArtistMetadata?.Value?.ForeignArtistId ?? mappedAlbum.Artist?.Value?.ForeignArtistId;
 
                 }
 

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyApi.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyApi.cs
@@ -1,0 +1,57 @@
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace NzbDrone.Core.ImportLists.Spotify
+{
+    public class SpotifyToken
+    {
+        [JsonProperty("access_token")]
+        public string AccessToken { get; set; }
+
+        [JsonProperty("token_type")]
+        public string TokenType { get; set; }
+
+        [JsonProperty("expires_in")]
+        public int ExpiresIn { get; set; }
+
+        [JsonProperty("scope")]
+        public string Scope { get; set; }
+
+        public override string ToString()
+        {
+            return $"{TokenType} {AccessToken}";
+        }
+    }
+
+    public class SpotifyPlaylistTracksReponse
+    {
+        [JsonProperty("items")]
+        public IEnumerable<SpotifyTrack> Tracks { get; set; }
+    }
+
+    public class SpotifyTrack
+    {
+        public SpotifyTrackContent Track { get; set; }
+    }
+
+    public class SpotifyTrackContent
+    {
+        public SpotifyAlbum Album { get; set; }
+
+        public IEnumerable<SpotifyArtist> Artists { get; set; }
+    }
+
+    public class SpotifyAlbum
+    {
+        public string Id { get; set; }
+
+        public string Name { get; set; }
+    }
+
+    public class SpotifyArtist
+    {
+        public string Id { get; set; }
+
+        public string Name { get; set; }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyImportListBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyImportListBase.cs
@@ -1,0 +1,28 @@
+using NLog;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Parser;
+
+namespace NzbDrone.Core.ImportLists.Spotify
+{
+    public abstract class SpotifyImportListBase<TSettings> : HttpImportListWithExpiringTokenBase<TSettings, SpotifyToken>
+        where TSettings: SpotifySettingsBase<TSettings>, new()
+    {
+        public SpotifyImportListBase(IHttpClient httpClient, IImportListStatusService importListStatusService, IConfigService configService, IParsingService parsingService, Logger logger)
+            : base(httpClient, importListStatusService, configService, parsingService, logger)
+        {
+        }
+
+        public abstract SpotifyRequestGeneratorBase<TSettings> GetSpotifyRequestGenerator();
+
+        public override ImportListRequestGeneratorWithExpiringTokenBase<SpotifyToken> GetRequestGeneratorWithExpiringToken()
+        {
+            return GetSpotifyRequestGenerator();
+        }
+
+        public override SpotifyToken ParseResponseForToken(HttpResponse tokenResponse)
+        {
+            return new SpotifyTokenParser().ParseResponse(tokenResponse);
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyPlaylistTracks.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyPlaylistTracks.cs
@@ -9,7 +9,7 @@ namespace NzbDrone.Core.ImportLists.Spotify
     {
         public override string Name => "Spotify playlist tracks";
 
-        public override int PageSize => 1000;
+        public override int PageSize => 100;
 
         public SpotifyPlaylistTracks(IHttpClient httpClient, IImportListStatusService importListStatusService, IConfigService configService, IParsingService parsingService, Logger logger)
             : base(httpClient, importListStatusService, configService, parsingService, logger)
@@ -18,7 +18,10 @@ namespace NzbDrone.Core.ImportLists.Spotify
 
         public override SpotifyRequestGeneratorBase<SpotifyPlaylistTracksSettings> GetSpotifyRequestGenerator()
         {
-            return new SpotifyPlaylistTracksRequestGenerator { Settings = Settings };
+            return new SpotifyPlaylistTracksRequestGenerator {
+                Settings = Settings,
+                PageSize = PageSize
+            };
         }
 
         public override IParseImportListResponse GetParser()

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyPlaylistTracks.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyPlaylistTracks.cs
@@ -1,0 +1,29 @@
+using NLog;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Parser;
+
+namespace NzbDrone.Core.ImportLists.Spotify
+{
+    public class SpotifyPlaylistTracks : SpotifyImportListBase<SpotifyPlaylistTracksSettings>
+    {
+        public override string Name => "Spotify playlist tracks";
+
+        public override int PageSize => 1000;
+
+        public SpotifyPlaylistTracks(IHttpClient httpClient, IImportListStatusService importListStatusService, IConfigService configService, IParsingService parsingService, Logger logger)
+            : base(httpClient, importListStatusService, configService, parsingService, logger)
+        {
+        }
+
+        public override SpotifyRequestGeneratorBase<SpotifyPlaylistTracksSettings> GetSpotifyRequestGenerator()
+        {
+            return new SpotifyPlaylistTracksRequestGenerator { Settings = Settings };
+        }
+
+        public override IParseImportListResponse GetParser()
+        {
+            return new SpotifyPlaylistTracksParser();
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyPlaylistTracksParser.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyPlaylistTracksParser.cs
@@ -1,0 +1,62 @@
+using NzbDrone.Core.ImportLists.Exceptions;
+using NzbDrone.Core.Parser.Model;
+using System.Collections.Generic;
+using System.Net;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Serializer;
+using System.Linq;
+
+namespace NzbDrone.Core.ImportLists.Spotify
+{
+    public class SpotifyPlaylistTracksParser : IParseImportListResponse
+    {
+        private ImportListResponse _importListResponse;
+
+        public IList<ImportListItemInfo> ParseResponse(ImportListResponse importListResponse)
+        {
+            _importListResponse = importListResponse;
+
+            var items = new List<ImportListItemInfo>();
+
+            if (!PreProcess(_importListResponse))
+            {
+                return items;
+            }
+
+            var jsonResponse = Json.Deserialize<SpotifyPlaylistTracksReponse>(_importListResponse.Content);
+
+            if (jsonResponse == null)
+            {
+                return items;
+            }
+
+            foreach (var item in jsonResponse.Tracks)
+            {
+                items.AddIfNotNull(new ImportListItemInfo
+                {
+                    Artist = item.Track.Artists.FirstOrDefault()?.Name,
+                    Album = item.Track.Album.Name
+                });
+            }
+
+            return items;
+        }
+
+        protected virtual bool PreProcess(ImportListResponse importListResponse)
+        {
+            if (importListResponse.HttpResponse.StatusCode != HttpStatusCode.OK)
+            {
+                throw new ImportListException(importListResponse, "Import List API call resulted in an unexpected StatusCode [{0}]", importListResponse.HttpResponse.StatusCode);
+            }
+
+            if (importListResponse.HttpResponse.Headers.ContentType != null && importListResponse.HttpResponse.Headers.ContentType.Contains("text/json") &&
+                importListResponse.HttpRequest.Headers.Accept != null && !importListResponse.HttpRequest.Headers.Accept.Contains("text/json"))
+            {
+                throw new ImportListException(importListResponse, "Import List responded with html content. Site is likely blocked or unavailable.");
+            }
+
+            return true;
+        }
+
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyPlaylistTracksRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyPlaylistTracksRequestGenerator.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using NzbDrone.Common.Http;
+
+namespace NzbDrone.Core.ImportLists.Spotify
+{
+    public class SpotifyPlaylistTracksRequestGenerator : SpotifyRequestGeneratorBase<SpotifyPlaylistTracksSettings>
+    {
+
+        public override ImportListPageableRequestChain GetSpotifyListItems()
+        {
+            var pageableRequests = new ImportListPageableRequestChain();
+
+            pageableRequests.Add(GetPagedRequests());
+
+            return pageableRequests;
+        }
+
+        private IEnumerable<ImportListRequest> GetPagedRequests()
+        {
+            yield return AddTokenToRequest(new ImportListRequest($"{Settings.BaseUrl.TrimEnd('/')}/playlists/{Settings.PlaylistId}/tracks?fields=items(track(name,album(name,id),artists))&limit={Settings.Count}", HttpAccept.Json));
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyPlaylistTracksRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyPlaylistTracksRequestGenerator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using NzbDrone.Common.Http;
 
@@ -5,7 +6,6 @@ namespace NzbDrone.Core.ImportLists.Spotify
 {
     public class SpotifyPlaylistTracksRequestGenerator : SpotifyRequestGeneratorBase<SpotifyPlaylistTracksSettings>
     {
-
         public override ImportListPageableRequestChain GetSpotifyListItems()
         {
             var pageableRequests = new ImportListPageableRequestChain();
@@ -17,7 +17,13 @@ namespace NzbDrone.Core.ImportLists.Spotify
 
         private IEnumerable<ImportListRequest> GetPagedRequests()
         {
-            yield return AddTokenToRequest(new ImportListRequest($"{Settings.BaseUrl.TrimEnd('/')}/playlists/{Settings.PlaylistId}/tracks?fields=items(track(name,album(name,id),artists))&limit={Settings.Count}", HttpAccept.Json));
+            var maxPages = PageSize <= 0 ? 1 : (int)Math.Ceiling((double)Settings.Count / PageSize);
+            var baseUrl = $"{Settings.BaseUrl.TrimEnd('/')}/playlists/{Settings.PlaylistId}/tracks?fields=items(track(name,album(name,id),artists))&limit={PageSize}";
+
+            for (var page = 0; page < maxPages; page++)
+            {
+                yield return AddTokenToRequest(new ImportListRequest($"{baseUrl}&offset={page * PageSize}", HttpAccept.Json));
+            }
         }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyPlaylistTracksRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyPlaylistTracksRequestGenerator.cs
@@ -6,7 +6,7 @@ namespace NzbDrone.Core.ImportLists.Spotify
 {
     public class SpotifyPlaylistTracksRequestGenerator : SpotifyRequestGeneratorBase<SpotifyPlaylistTracksSettings>
     {
-        public override ImportListPageableRequestChain GetSpotifyListItems()
+        public override ImportListPageableRequestChain GetListItemsWithExpiringToken()
         {
             var pageableRequests = new ImportListPageableRequestChain();
 
@@ -18,11 +18,11 @@ namespace NzbDrone.Core.ImportLists.Spotify
         private IEnumerable<ImportListRequest> GetPagedRequests()
         {
             var maxPages = PageSize <= 0 ? 1 : (int)Math.Ceiling((double)Settings.Count / PageSize);
-            var baseUrl = $"{Settings.BaseUrl.TrimEnd('/')}/playlists/{Settings.PlaylistId}/tracks?fields=items(track(name,album(name,id),artists))&limit={PageSize}";
+            var baseUrl = $"{Settings.BaseUrl.TrimEnd('/')}/playlists/{Settings.PlaylistId}/tracks?fields=items(track(name,album(name,id),artists))";
 
             for (var page = 0; page < maxPages; page++)
             {
-                yield return AddTokenToRequest(new ImportListRequest($"{baseUrl}&offset={page * PageSize}", HttpAccept.Json));
+                yield return AddTokenToRequest(new ImportListRequest($"{baseUrl}&limit={Math.Min(Settings.Count - (page * PageSize), PageSize)}&offset={page * PageSize}", HttpAccept.Json));
             }
         }
     }

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyPlaylistTracksSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyPlaylistTracksSettings.cs
@@ -1,6 +1,5 @@
 using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.ImportLists.Spotify
 {
@@ -10,7 +9,7 @@ namespace NzbDrone.Core.ImportLists.Spotify
             : base()
         {
             RuleFor(c => c.PlaylistId).NotEmpty();
-            RuleFor(c => c.Count).LessThanOrEqualTo(100);
+            RuleFor(c => c.Count).LessThanOrEqualTo(10000);
         }
     }
 
@@ -20,13 +19,13 @@ namespace NzbDrone.Core.ImportLists.Spotify
 
         public SpotifyPlaylistTracksSettings()
         {
-            Count = 100;
+            Count = 10000;
         }
 
         [FieldDefinition(0, Label = "Spotify Playlist ID", HelpText = "Playlist ID to pull artists from. Can be obtained by copying a playlist URL and keeping only the last part.")]
         public string PlaylistId { get; set; }
 
-        [FieldDefinition(1, Label = "Count", HelpText = "Number of results to pull from list (Max 100)", Type = FieldType.Number)]
+        [FieldDefinition(1, Label = "Count", HelpText = "Number of results to pull from list (Max 10000)", Type = FieldType.Number)]
         public int Count { get; set; }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyPlaylistTracksSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyPlaylistTracksSettings.cs
@@ -1,0 +1,32 @@
+using FluentValidation;
+using NzbDrone.Core.Annotations;
+using NzbDrone.Core.Validation;
+
+namespace NzbDrone.Core.ImportLists.Spotify
+{
+    public class SpotifyPlaylistTracksSettingsValidator : SpotifySettingsBaseValidator<SpotifyPlaylistTracksSettings>
+    {
+        public SpotifyPlaylistTracksSettingsValidator()
+            : base()
+        {
+            RuleFor(c => c.PlaylistId).NotEmpty();
+            RuleFor(c => c.Count).LessThanOrEqualTo(100);
+        }
+    }
+
+    public class SpotifyPlaylistTracksSettings : SpotifySettingsBase<SpotifyPlaylistTracksSettings>
+    {
+        protected override AbstractValidator<SpotifyPlaylistTracksSettings> Validator => new SpotifyPlaylistTracksSettingsValidator();
+
+        public SpotifyPlaylistTracksSettings()
+        {
+            Count = 100;
+        }
+
+        [FieldDefinition(0, Label = "Spotify Playlist ID", HelpText = "Playlist ID to pull artists from. Can be obtained by copying a playlist URL and keeping only the last part.")]
+        public string PlaylistId { get; set; }
+
+        [FieldDefinition(1, Label = "Count", HelpText = "Number of results to pull from list (Max 100)", Type = FieldType.Number)]
+        public int Count { get; set; }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyRequestGeneratorBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyRequestGeneratorBase.cs
@@ -10,14 +10,7 @@ namespace NzbDrone.Core.ImportLists.Spotify
 
         public TSettings Settings { get; set; }
 
-        public int MaxPages { get; set; }
         public int PageSize { get; set; }
-
-        public SpotifyRequestGeneratorBase()
-        {
-            MaxPages = 1;
-            PageSize = 100;
-        }
 
         public abstract ImportListPageableRequestChain GetSpotifyListItems();
 

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyRequestGeneratorBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyRequestGeneratorBase.cs
@@ -1,0 +1,47 @@
+using NzbDrone.Common.Http;
+using System.Net;
+
+namespace NzbDrone.Core.ImportLists.Spotify
+{
+    public abstract class SpotifyRequestGeneratorBase<TSettings> : ImportListRequestGeneratorWithExpiringTokenBase<SpotifyToken>
+        where TSettings : SpotifySettingsBase<TSettings>
+    {
+        private const string SPOTIFY_ACCOUNTS_API_BASE_URL = "https://accounts.spotify.com/api/";
+
+        public TSettings Settings { get; set; }
+
+        public int MaxPages { get; set; }
+        public int PageSize { get; set; }
+
+        public SpotifyRequestGeneratorBase()
+        {
+            MaxPages = 1;
+            PageSize = 100;
+        }
+
+        public abstract ImportListPageableRequestChain GetSpotifyListItems();
+
+        public override ImportListPageableRequestChain GetListItemsWithExpiringToken()
+        {
+            return GetSpotifyListItems();
+        }
+
+        protected override ImportListRequest AddTokenToRequest(ImportListRequest importListRequest)
+        {
+            importListRequest.HttpRequest.Headers.Add(HttpRequestHeader.Authorization.ToString(), $"{Token.TokenType} {Token.AccessToken}");
+            return importListRequest;
+        }
+
+        public override HttpRequest GetRefreshTokenRequest()
+        {
+            var requestBuilder = new HttpRequestBuilder(SPOTIFY_ACCOUNTS_API_BASE_URL)
+                .Resource("token")
+                .Post()
+                .AddFormParameter("grant_type", "client_credentials");
+            requestBuilder.Headers.ContentType = "application/x-www-form-urlencoded";
+            var tokenRequest = requestBuilder.Build();
+            tokenRequest.AddBasicAuthentication(Settings.ClientId, Settings.ClientSecret);
+            return tokenRequest;
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyRequestGeneratorBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyRequestGeneratorBase.cs
@@ -12,13 +12,6 @@ namespace NzbDrone.Core.ImportLists.Spotify
 
         public int PageSize { get; set; }
 
-        public abstract ImportListPageableRequestChain GetSpotifyListItems();
-
-        public override ImportListPageableRequestChain GetListItemsWithExpiringToken()
-        {
-            return GetSpotifyListItems();
-        }
-
         protected override ImportListRequest AddTokenToRequest(ImportListRequest importListRequest)
         {
             importListRequest.HttpRequest.Headers.Add(HttpRequestHeader.Authorization.ToString(), $"{Token.TokenType} {Token.AccessToken}");

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifySettingsBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifySettingsBase.cs
@@ -1,0 +1,42 @@
+using FluentValidation;
+using NzbDrone.Core.Annotations;
+using NzbDrone.Core.Validation;
+
+namespace NzbDrone.Core.ImportLists.Spotify
+{
+    public class SpotifySettingsBaseValidator<TSettings> : AbstractValidator<TSettings>
+        where TSettings : SpotifySettingsBase<TSettings>
+    {
+        public SpotifySettingsBaseValidator()
+        {
+            RuleFor(c => c.ClientId).NotEmpty();
+            RuleFor(c => c.ClientSecret).NotEmpty();
+        }
+    }
+
+    public class SpotifySettingsBase<TSettings> : IImportListSettings
+        where TSettings : SpotifySettingsBase<TSettings>
+    {
+        protected virtual AbstractValidator<TSettings> Validator => new SpotifySettingsBaseValidator<TSettings>();
+
+        public SpotifySettingsBase()
+        {
+            BaseUrl = "https://api.spotify.com/v1";
+            ClientId = "ec110b65c5a247ada633baeebfbeb0ba";
+            ClientSecret = "b8dc353479614c878c5f8c439f7b05a2";
+        }
+
+        public string BaseUrl { get; set; }
+
+        [FieldDefinition(0, Label = "Spotify API Client ID", HelpText = "Specify your own Client ID if you prefer. Create an app on Spotify's API dashboard to get a Client ID and a Client Secret (https://developer.spotify.com/dashboard/applications). Default : Lidarr's Client ID")]
+        public string ClientId { get; set; }
+
+        [FieldDefinition(0, Label = "Spotify API Client Secret", HelpText = "Specify your own Client Secret if you specified your own Client ID. Create an app on Spotify's API dashboard to get a Client ID and a Client Secret (https://developer.spotify.com/dashboard/applications). Default : Lidarr's Client Secret")]
+        public string ClientSecret { get; set; }
+
+        public NzbDroneValidationResult Validate()
+        {
+            return new NzbDroneValidationResult(Validator.Validate((TSettings)this));
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyTokenParser.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyTokenParser.cs
@@ -1,0 +1,37 @@
+using NzbDrone.Core.ImportLists.Exceptions;
+using System.Net;
+using NzbDrone.Common.Serializer;
+using NzbDrone.Common.Http;
+
+namespace NzbDrone.Core.ImportLists.Spotify
+{
+    public class SpotifyTokenParser
+    {
+
+        public SpotifyToken ParseResponse(HttpResponse tokenResponse)
+        {
+            if (!PreProcess(tokenResponse))
+            {
+                return null;
+            }
+
+            return Json.Deserialize<SpotifyToken>(tokenResponse.Content);
+        }
+
+        protected virtual bool PreProcess(HttpResponse tokenResponse)
+        {
+            if (tokenResponse.StatusCode != HttpStatusCode.OK)
+            {
+                throw new ImportListTokenException($"Error getting Spotify API token. Status code : {tokenResponse.StatusCode}");
+            }
+
+            if (tokenResponse.Headers.ContentType != null && tokenResponse.Headers.ContentType.Contains("text/json"))
+            {
+                throw new ImportListTokenException("Spotify responded to a token request with html content. Site is likely blocked or unavailable.");
+            }
+
+            return true;
+        }
+
+    }
+}

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -521,6 +521,7 @@
     <Compile Include="Http\CloudFlare\CloudFlareHttpInterceptor.cs" />
     <Compile Include="Http\HttpProxySettingsProvider.cs" />
     <Compile Include="Http\TorcacheHttpInterceptor.cs" />
+    <Compile Include="ImportLists\Exceptions\ImportListTokenException.cs" />
     <Compile Include="ImportLists\Exceptions\ImportListException.cs" />
     <Compile Include="ImportLists\Exclusions\ImportListExclusionExistsValidator.cs" />
     <Compile Include="ImportLists\Exclusions\ImportListExclusionService.cs" />
@@ -532,8 +533,10 @@
     <Compile Include="ImportLists\HeadphonesImport\HeadphonesImportParser.cs" />
     <Compile Include="ImportLists\HeadphonesImport\HeadphonesImportRequestGenerator.cs" />
     <Compile Include="ImportLists\HeadphonesImport\HeadphonesImportSettings.cs" />
+    <Compile Include="ImportLists\HttpImportListWithExpiringTokenBase.cs" />
     <Compile Include="ImportLists\HttpImportListBase.cs" />
     <Compile Include="ImportLists\IImportList.cs" />
+    <Compile Include="ImportLists\ImportListRequestGeneratorWithExpiringTokenBase.cs" />
     <Compile Include="ImportLists\IImportListSettings.cs" />
     <Compile Include="ImportLists\IImportListRequestGenerator.cs" />
     <Compile Include="ImportLists\ImportListDefinition.cs" />

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -568,6 +568,15 @@
     <Compile Include="ImportLists\LidarrLists\LidarrListsParser.cs" />
     <Compile Include="ImportLists\LidarrLists\LidarrListsRequestGenerator.cs" />
     <Compile Include="ImportLists\LidarrLists\LidarrListsSettings.cs" />
+    <Compile Include="ImportLists\Spotify\SpotifyPlaylistTracksRequestGenerator.cs" />
+    <Compile Include="ImportLists\Spotify\SpotifyPlaylistTracksSettings.cs" />
+    <Compile Include="ImportLists\Spotify\SpotifyPlaylistTracks.cs" />
+    <Compile Include="ImportLists\Spotify\SpotifyApi.cs" />
+    <Compile Include="ImportLists\Spotify\SpotifyImportListBase.cs" />
+    <Compile Include="ImportLists\Spotify\SpotifyTokenParser.cs" />
+    <Compile Include="ImportLists\Spotify\SpotifyPlaylistTracksParser.cs" />
+    <Compile Include="ImportLists\Spotify\SpotifyRequestGeneratorBase.cs" />
+    <Compile Include="ImportLists\Spotify\SpotifySettingsBase.cs" />
     <Compile Include="IndexerSearch\AlbumSearchCommand.cs" />
     <Compile Include="IndexerSearch\AlbumSearchService.cs" />
     <Compile Include="IndexerSearch\ArtistSearchCommand.cs" />

--- a/src/NzbDrone.Test.Dummy/NzbDrone.Test.Dummy.csproj
+++ b/src/NzbDrone.Test.Dummy/NzbDrone.Test.Dummy.csproj
@@ -16,6 +16,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <PlatformTarget>x86</PlatformTarget>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This pull request adds a Spotify Import List to fetch albums/artists for tracks in a playlist and, hopefully, an easier time to add other import lists from services where the API token needs to be refreshed.

The import list does not use the OAuth login process because I personally do not need it and at least being able to import from playlists is going to be useful to a lot of people waiting on this feature like me.

Private playlists can be accessed via the API even if not logged in as long as you have the playlist ID.

I am opening this PR early to get feedback if I am doing something wrong. 

One of the feedback I am looking towards : Default Client ID/Secret. Do we want it or do we force users to create an "Application" in the Spotify Developer dashboard? Right now, I put in my test application, which I will remove or reset the Client Secret before pushing this into develop (if it does end up in develop :) ). If we keep the defaults, who is/will be responsible to create the application in the Spotify Dashboard?

This is still a work in progress ~~as the import process only works on the first page. I am still not sure how the paging part is supposed to work in other import lists, so it is hard to see how I am supposed to implement it based on them.~~ Found out how paging works based on indexer requests.

#### Todos
- [X] Tests
- [ ] Documentation


#### Issues Fixed or Closed by this PR

* #334 (or part of it)
