### PR TITLE
Fixed: Don't show cmd.exe window when fpcalc runs

### DIFF
--- a/src/NzbDrone.Core/Parser/FingerprintingService.cs
+++ b/src/NzbDrone.Core/Parser/FingerprintingService.cs
@@ -89,6 +89,7 @@ namespace NzbDrone.Core.Parser
                 p.StartInfo.FileName = path;
                 p.StartInfo.Arguments = "-version";
                 p.StartInfo.UseShellExecute = false;
+                p.StartInfo.CreateNoWindow = true;
                 p.StartInfo.RedirectStandardOutput = true;
 
                 try
@@ -135,6 +136,7 @@ namespace NzbDrone.Core.Parser
             p.StartInfo.FileName = _fpcalcPath;
             p.StartInfo.Arguments = $"-version";
             p.StartInfo.UseShellExecute = false;
+            p.StartInfo.CreateNoWindow = true;
             p.StartInfo.RedirectStandardOutput = true;
 
             p.Start();
@@ -238,6 +240,7 @@ namespace NzbDrone.Core.Parser
                 p.StartInfo.FileName = _fpcalcPath;
                 p.StartInfo.Arguments = $"{_fpcalcArgs} \"{file}\"";
                 p.StartInfo.UseShellExecute = false;
+                p.StartInfo.CreateNoWindow = true;
                 p.StartInfo.RedirectStandardOutput = true;
                 p.StartInfo.RedirectStandardError = true;
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Try to prevent `cmd.exe` windows popping up on windows every time `fpcalc` runs
