### PR TITLE
Fixed: Correctly delete trackfiles on AlbumDeletedEvent

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/MediaFileRepositoryFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaFileRepositoryFixture.cs
@@ -6,6 +6,7 @@ using NzbDrone.Core.Qualities;
 using NzbDrone.Core.Music;
 using NzbDrone.Core.Test.Framework;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace NzbDrone.Core.Test.MediaFiles
 {
@@ -139,6 +140,15 @@ namespace NzbDrone.Core.Test.MediaFiles
                 file.Artist.Value.Metadata.IsLoaded.Should().BeTrue();
                 file.Artist.Value.Metadata.Value.Should().NotBeNull();
             }
+        }
+
+        [Test]
+        public void delete_files_by_album_should_work_if_join_fails()
+        {
+            Db.Delete(album);
+            Subject.DeleteFilesByAlbum(album.Id);
+            
+            Db.All<TrackFile>().Where(x => x.AlbumId == album.Id).Should().HaveCount(0);
         }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/MediaFileRepository.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileRepository.cs
@@ -14,6 +14,7 @@ namespace NzbDrone.Core.MediaFiles
         List<TrackFile> GetFilesByRelease(int releaseId);
         List<TrackFile> GetFilesWithBasePath(string path);
         TrackFile GetFileWithPath(string path);
+        void DeleteFilesByAlbum(int albumId);
     }
 
 
@@ -49,6 +50,12 @@ namespace NzbDrone.Core.MediaFiles
                 .Where<AlbumRelease>(r => r.Monitored == true)
                 .AndWhere(f => f.AlbumId == albumId)
                 .ToList();
+        }
+
+        public void DeleteFilesByAlbum(int albumId)
+        {
+            var ids = DataMapper.Query<TrackFile>().Where(x => x.AlbumId == albumId);
+            DeleteMany(ids);
         }
 
         public List<TrackFile> GetFilesByRelease(int releaseId)

--- a/src/NzbDrone.Core/MediaFiles/MediaFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileService.cs
@@ -148,8 +148,7 @@ namespace NzbDrone.Core.MediaFiles
 
         public void HandleAsync(AlbumDeletedEvent message)
         {
-            var files = GetFilesByAlbum(message.Album.Id);
-            _mediaFileRepository.DeleteMany(files);
+            _mediaFileRepository.DeleteFilesByAlbum(message.Album.Id);
         }
 
         public List<TrackFile> GetFilesByArtist(int artistId)


### PR DESCRIPTION


#### Database Migration
NO

#### Description
GetFilesByAlbum performs a join on the album releases under the hood,
which won't be populated once the album is deleted.  Fix by providing
a special delete method which omits the join and just looks at albumId.

#### Todos
- [x] Tests
