### PR TITLE
New: Bump Moq to 4.12

### DIFF
--- a/src/NzbDrone.Api.Test/NzbDrone.Api.Test.csproj
+++ b/src/NzbDrone.Api.Test/NzbDrone.Api.Test.csproj
@@ -94,7 +94,7 @@
       <Version>4.19.0</Version>
     </PackageReference>
     <PackageReference Include="Moq">
-      <Version>4.0.10827</Version>
+      <Version>4.12.0</Version>
     </PackageReference>
     <PackageReference Include="NBuilder">
       <Version>4.0.0</Version>

--- a/src/NzbDrone.App.Test/NzbDrone.Host.Test.csproj
+++ b/src/NzbDrone.App.Test/NzbDrone.Host.Test.csproj
@@ -95,7 +95,7 @@
       <Version>4.19.0</Version>
     </PackageReference>
     <PackageReference Include="Moq">
-      <Version>4.0.10827</Version>
+      <Version>4.12.0</Version>
     </PackageReference>
     <PackageReference Include="NBuilder">
       <Version>4.0.0</Version>

--- a/src/NzbDrone.Common.Test/NzbDrone.Common.Test.csproj
+++ b/src/NzbDrone.Common.Test/NzbDrone.Common.Test.csproj
@@ -147,7 +147,7 @@
       <Version>4.19.0</Version>
     </PackageReference>
     <PackageReference Include="Moq">
-      <Version>4.0.10827</Version>
+      <Version>4.12.0</Version>
     </PackageReference>
     <PackageReference Include="NLog">
       <Version>4.5.4</Version>

--- a/src/NzbDrone.Core.Test/Framework/CoreTest.cs
+++ b/src/NzbDrone.Core.Test/Framework/CoreTest.cs
@@ -10,6 +10,7 @@ using NzbDrone.Test.Common;
 using NzbDrone.Common.Http.Proxy;
 using NzbDrone.Core.Http;
 using NzbDrone.Core.Configuration;
+using NzbDrone.Core.MetadataSource;
 
 namespace NzbDrone.Core.Test.Framework
 {
@@ -28,6 +29,7 @@ namespace NzbDrone.Core.Test.Framework
             Mocker.SetConstant<IHttpProvider>(new HttpProvider(TestLogger));
             Mocker.SetConstant<IHttpClient>(new HttpClient(new IHttpRequestInterceptor[0], Mocker.Resolve<CacheManager>(), Mocker.Resolve<RateLimitService>(), Mocker.Resolve<FallbackHttpDispatcher>(), Mocker.Resolve<UserAgentBuilder>(), TestLogger));
             Mocker.SetConstant<ILidarrCloudRequestBuilder>(new LidarrCloudRequestBuilder());
+            Mocker.SetConstant<IMetadataRequestBuilder>(Mocker.Resolve<MetadataRequestBuilder>());
         }
     }
 

--- a/src/NzbDrone.Core.Test/MediaFiles/DiskScanServiceTests/ScanFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/DiskScanServiceTests/ScanFixture.cs
@@ -58,7 +58,7 @@ namespace NzbDrone.Core.Test.MediaFiles.DiskScanServiceTests
 
             Mocker.GetMock<IMediaFileService>()
                 .Setup(v => v.FilterUnchangedFiles(It.IsAny<List<IFileInfo>>(), It.IsAny<Artist>(), It.IsAny<FilterFilesType>()))
-                .Returns((List<IFileInfo> files, Artist artist) => files);
+                .Returns((List<IFileInfo> files, Artist artist, FilterFilesType filter) => files);
         }
 
         private void GivenRootFolder(params string[] subfolders)

--- a/src/NzbDrone.Core.Test/MediaFiles/TrackImport/ImportDecisionMakerFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/TrackImport/ImportDecisionMakerFixture.cs
@@ -114,7 +114,7 @@ namespace NzbDrone.Core.Test.MediaFiles.TrackImport
 
             Mocker.GetMock<IMediaFileService>()
                 .Setup(c => c.FilterUnchangedFiles(It.IsAny<List<IFileInfo>>(), It.IsAny<Artist>(), It.IsAny<FilterFilesType>()))
-                .Returns((List<IFileInfo> files, Artist artist) => files);
+                .Returns((List<IFileInfo> files, Artist artist, FilterFilesType filter) => files);
 
             GivenSpecifications(_albumpass1);
         }

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -594,7 +594,7 @@
       <Version>15.0.0</Version>
     </PackageReference>
     <PackageReference Include="Moq">
-      <Version>4.0.10827</Version>
+      <Version>4.12.0</Version>
     </PackageReference>
     <PackageReference Include="NBuilder">
       <Version>4.0.0</Version>

--- a/src/NzbDrone.Integration.Test/NzbDrone.Integration.Test.csproj
+++ b/src/NzbDrone.Integration.Test/NzbDrone.Integration.Test.csproj
@@ -151,7 +151,7 @@
       <Version>3.1.0</Version>
     </PackageReference>
     <PackageReference Include="Moq">
-      <Version>4.0.10827</Version>
+      <Version>4.12.0</Version>
     </PackageReference>
     <PackageReference Include="Nancy">
       <Version>1.4.4</Version>

--- a/src/NzbDrone.Mono.Test/NzbDrone.Mono.Test.csproj
+++ b/src/NzbDrone.Mono.Test/NzbDrone.Mono.Test.csproj
@@ -131,7 +131,7 @@
       <Version>4.19.0</Version>
     </PackageReference>
     <PackageReference Include="Moq">
-      <Version>4.0.10827</Version>
+      <Version>4.12.0</Version>
     </PackageReference>
     <PackageReference Include="NUnit">
       <Version>3.11.0</Version>

--- a/src/NzbDrone.Test.Common/NzbDrone.Test.Common.csproj
+++ b/src/NzbDrone.Test.Common/NzbDrone.Test.Common.csproj
@@ -97,7 +97,7 @@
       <Version>6.2.1</Version>
     </PackageReference>
     <PackageReference Include="Moq">
-      <Version>4.0.10827</Version>
+      <Version>4.12.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>11.0.2</Version>

--- a/src/NzbDrone.Update.Test/NzbDrone.Update.Test.csproj
+++ b/src/NzbDrone.Update.Test/NzbDrone.Update.Test.csproj
@@ -83,7 +83,7 @@
       <Version>4.19.0</Version>
     </PackageReference>
     <PackageReference Include="Moq">
-      <Version>4.0.10827</Version>
+      <Version>4.12.0</Version>
     </PackageReference>
     <PackageReference Include="NBuilder">
       <Version>4.0.0</Version>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- Update Moq (previous version was from 2011!).  One of the fixes is required for tests in #838.  
- Fix `UseRealHttp()` for metadata requests following addition of `MetadataRequestBuilder

