### PR TITLE
Fixed: Prevent two Artists pointing to same ArtistMetadata

### DIFF
--- a/src/NzbDrone.Core.Test/Datastore/Migration/031_add_artistmetadataid_constraintFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/Migration/031_add_artistmetadataid_constraintFixture.cs
@@ -1,0 +1,113 @@
+using NUnit.Framework;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Datastore.Migration;
+using NzbDrone.Test.Common;
+using System.Linq;
+using FluentAssertions;
+using System.Collections.Generic;
+
+namespace NzbDrone.Core.Test.Datastore.Migration
+{
+    [TestFixture]
+    public class add_artistmetadataid_constraintFixture : MigrationTest<add_artistmetadataid_constraint>
+    {
+        private string _artistPath = null;
+
+        private void GivenArtistMetadata(add_artistmetadataid_constraint c, int id, string name)
+        {
+            c.Insert.IntoTable("ArtistMetadata").Row(new
+                {
+                    Id = id,
+                    ForeignArtistId = id,
+                    Name = name,
+                    Status = 1,
+                    Images = "images"
+                });
+        }
+        
+        private void GivenArtist(add_artistmetadataid_constraint c, int id, int artistMetadataId, string name)
+        {
+            _artistPath = $"/mnt/data/path/{name}".AsOsAgnostic();
+            c.Insert.IntoTable("Artists").Row(new
+                {
+                    Id = id,
+                    ArtistMetadataId = artistMetadataId,
+                    CleanName = name,
+                    Path = _artistPath,
+                    Monitored = 1,
+                    AlbumFolder = 1,
+                    LanguageProfileId = 1,
+                    MetadataProfileId = 1,
+                });
+        }
+        
+        private void VerifyArtists(IDirectDataMapper db, List<int> ids)
+        {
+            var artists = db.Query("SELECT Artists.* from Artists");
+
+            artists.Select(x => x["Id"]).ShouldBeEquivalentTo(ids);
+
+            var duplicates = artists.GroupBy(x => x["ArtistMetadataId"])
+                .Where(x => x.Count() > 1);
+
+            duplicates.Should().BeEmpty();
+        }
+        
+        [Test]
+        public void migration_031_should_not_remove_unique_artist()
+        {
+            var db = WithMigrationTestDb(c => {
+                    GivenArtistMetadata(c, 1, "test");
+                    GivenArtist(c, 1, 1, "test");
+                });
+
+            VerifyArtists(db, new List<int> { 1 });
+        }
+
+        [Test]
+        public void migration_031_should_not_remove_either_unique_artist()
+        {
+            var db = WithMigrationTestDb(c => {
+                    GivenArtistMetadata(c, 1, "test");
+                    GivenArtist(c, 1, 1, "test");
+
+                    GivenArtistMetadata(c, 2, "test2");
+                    GivenArtist(c, 2, 2, "test2");
+                });
+
+            VerifyArtists(db, new List<int> { 1, 2 });
+        }
+
+        [Test]
+        public void migration_031_should_remove_duplicate_artist()
+        {
+            var db = WithMigrationTestDb(c => {
+                    GivenArtistMetadata(c, 1, "test");
+                    GivenArtist(c, 1, 1, "test");
+
+                    GivenArtist(c, 2, 1, "test2");
+                });
+
+            VerifyArtists(db, new List<int> { 1 });
+        }
+
+        [Test]
+        public void migration_031_should_remove_all_duplicate_artists()
+        {
+            var db = WithMigrationTestDb(c => {
+                    GivenArtistMetadata(c, 1, "test");
+                    GivenArtist(c, 1, 1, "test");
+                    GivenArtist(c, 2, 1, "test");
+                    GivenArtist(c, 3, 1, "test");
+                    GivenArtist(c, 4, 1, "test");
+
+                    GivenArtistMetadata(c, 2, "test2");
+                    GivenArtist(c, 5, 2, "test2");
+                    GivenArtist(c, 6, 2, "test2");
+
+                });
+
+            VerifyArtists(db, new List<int> { 1, 5 });
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/Messaging/Commands/CommandQueueFixture.cs
+++ b/src/NzbDrone.Core.Test/Messaging/Commands/CommandQueueFixture.cs
@@ -89,6 +89,25 @@ namespace NzbDrone.Core.Test.Messaging.Commands
         }
 
         [Test]
+        public void should_not_return_type_exclusive_command_if_another_and_disk_access_command_running()
+        {
+            GivenStartedTypeExclusiveCommand();
+            GivenStartedDiskCommand();
+
+            var newCommandModel = Builder<CommandModel>
+                .CreateNew()
+                .With(c => c.Name = "ImportListSync")
+                .With(c => c.Body = new ImportListSyncCommand())
+                .Build();
+
+            Subject.Add(newCommandModel);
+
+            Subject.TryGet(out var command);
+
+            command.Should().BeNull();
+        }
+
+        [Test]
         public void should_return_type_exclusive_command_if_another_not_running()
         {
             GivenStartedDiskCommand();

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -52,6 +52,9 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data.SQLite">
+      <HintPath>..\Libraries\Sqlite\System.Data.SQLite.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ArtistStatsTests\ArtistStatisticsFixture.cs" />
@@ -79,6 +82,7 @@
     <Compile Include="Datastore\Migration\004_add_various_qualities_in_profileFixture.cs" />
     <Compile Include="Datastore\Migration\023_add_release_groups_etcFixture.cs" />
     <Compile Include="Datastore\Migration\030_add_mediafilerepository_mtimeFixture.cs" />
+    <Compile Include="Datastore\Migration\031_add_artistmetadataid_constraintFixture.cs" />
     <Compile Include="Datastore\ObjectDatabaseFixture.cs" />
     <Compile Include="Datastore\PagingSpecExtensionsTests\PagingOffsetFixture.cs" />
     <Compile Include="Datastore\PagingSpecExtensionsTests\ToSortDirectionFixture.cs" />

--- a/src/NzbDrone.Core/Datastore/Migration/031_add_artistmetadataid_constraint.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/031_add_artistmetadataid_constraint.cs
@@ -1,0 +1,25 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(31)]
+    public class add_artistmetadataid_constraint : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            // Remove any duplicate artists
+            Execute.Sql(@"DELETE FROM Artists
+                          WHERE Id NOT IN (
+                            SELECT MIN(Artists.id) from Artists
+                            JOIN ArtistMetadata ON Artists.ArtistMetadataId = ArtistMetadata.Id
+                            GROUP BY ArtistMetadata.Id)");
+
+            // The index exists but will be recreated as part of unique constraint
+            Delete.Index().OnTable("Artists").OnColumn("ArtistMetadataId");
+            
+            // Add a constraint to prevent any more duplicates
+            Alter.Column("ArtistMetadataId").OnTable("Artists").AsInt32().Unique();
+        }
+    }
+}

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -171,6 +171,7 @@
     <Compile Include="Datastore\Migration\026_rename_quality_profiles_add_upgrade_allowed.cs" />
     <Compile Include="Datastore\Migration\028_clean_artistmetadata_table.cs" />
     <Compile Include="Datastore\Migration\030_add_mediafilerepository_mtime.cs" />
+    <Compile Include="Datastore\Migration\031_add_artistmetadataid_constraint.cs" />
     <Compile Include="Datastore\Migration\Framework\MigrationContext.cs" />
     <Compile Include="Datastore\Migration\Framework\MigrationController.cs" />
     <Compile Include="Datastore\Migration\Framework\MigrationDbFactory.cs" />


### PR DESCRIPTION
#### Database Migration
YES (31)

#### Description
When we redid the database structure in 23, we allowed two artists to point to the same artist metadata entry and so same foreign artist id.  This should not be allowed.  This adds a unique constraint on `ArtistMetadataId` and removes any duplicate artists, keeping the one with the lowest `Id` (i.e. the first one created).

#### Todos
- [x] Tests


#### Issues Fixed or Closed by this PR

* Fixes Sentry 21C
* Fixes Sentry 22D
