### PR TITLE
Fixed: Make sure modified/size set by manual import and tag sync

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/TrackImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/TrackImport/Manual/ManualImportService.cs
@@ -255,6 +255,7 @@ namespace NzbDrone.Core.MediaFiles.TrackImport.Manual
                     var release = _releaseService.GetRelease(file.AlbumReleaseId);
                     var tracks = _trackService.GetTracks(file.TrackIds);
                     var fileTrackInfo = _audioTagService.ReadTags(file.Path) ?? new ParsedTrackInfo();
+                    var fileInfo = _diskProvider.GetFileInfo(file.Path);
 
                     var localTrack = new LocalTrack
                     {
@@ -262,6 +263,8 @@ namespace NzbDrone.Core.MediaFiles.TrackImport.Manual
                         Tracks = tracks,
                         FileTrackInfo = fileTrackInfo,
                         Path = file.Path,
+                        Size = fileInfo.Length,
+                        Modified = fileInfo.LastWriteTimeUtc,
                         Quality = file.Quality,
                         Language = file.Language,
                         Artist = artist,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Now that we only scan changed files, it's important to make sure sizes/last modified are populated and kept up to date if we make a deliberate change.

This PR fixes two issues:
- Manual import wasn't setting modified or size when importing, so files would get rescanned on next scan
- Tag sync would change modified/size on disk but this wasn't noted in the database so files would be rescanned on next scan

#### Todos
- [x] Tests (There aren't currently any tests for manual import)
