### PR TITLE
New: Spotify integration

### DIFF
--- a/frontend/src/Components/Form/FormInputGroup.js
+++ b/frontend/src/Components/Form/FormInputGroup.js
@@ -6,6 +6,7 @@ import AutoCompleteInput from './AutoCompleteInput';
 import CaptchaInputConnector from './CaptchaInputConnector';
 import CheckInput from './CheckInput';
 import DeviceInputConnector from './DeviceInputConnector';
+import PlaylistInputConnector from './PlaylistInputConnector';
 import KeyValueListInput from './KeyValueListInput';
 import MonitorAlbumsSelectInput from './MonitorAlbumsSelectInput';
 import NumberInput from './NumberInput';
@@ -38,6 +39,9 @@ function getComponent(type) {
 
     case inputTypes.DEVICE:
       return DeviceInputConnector;
+
+    case inputTypes.PLAYLIST:
+      return PlaylistInputConnector;
 
     case inputTypes.KEY_VALUE_LIST:
       return KeyValueListInput;

--- a/frontend/src/Components/Form/PlaylistInput.css
+++ b/frontend/src/Components/Form/PlaylistInput.css
@@ -1,0 +1,9 @@
+.playlistInputWrapper {
+  display: flex;
+  flex-direction: column;
+}
+
+.input {
+  composes: input from '~./TagInput.css';
+  composes: hasButton from '~Components/Form/Input.css';
+}

--- a/frontend/src/Components/Form/PlaylistInput.js
+++ b/frontend/src/Components/Form/PlaylistInput.js
@@ -1,0 +1,186 @@
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import tagShape from 'Helpers/Props/Shapes/tagShape';
+import getSelectedIds from 'Utilities/Table/getSelectedIds';
+import selectAll from 'Utilities/Table/selectAll';
+import toggleSelected from 'Utilities/Table/toggleSelected';
+import LoadingIndicator from 'Components/Loading/LoadingIndicator';
+import Table from 'Components/Table/Table';
+import TableBody from 'Components/Table/TableBody';
+import TableRow from 'Components/Table/TableRow';
+import TableRowCell from 'Components/Table/Cells/TableRowCell';
+import TableSelectCell from 'Components/Table/Cells/TableSelectCell';
+import styles from './PlaylistInput.css';
+
+const columns = [
+  {
+    name: 'name',
+    label: 'Playlist',
+    isSortable: false,
+    isVisible: true
+  }
+];
+
+class PlaylistInput extends Component {
+
+  //
+  // Lifecycle
+
+  constructor(props, context) {
+    super(props, context);
+
+    const initialSelection = _.mapValues(_.keyBy(props.value), () => true);
+
+    this.state = {
+      allSelected: false,
+      allUnselected: false,
+      selectedState: initialSelection
+    };
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    const {
+      name,
+      onChange
+    } = this.props;
+
+    const oldSelected = getSelectedIds(prevState.selectedState, { parseIds: false }).sort();
+    const newSelected = this.getSelectedIds().sort();
+
+    if (!_.isEqual(oldSelected, newSelected)) {
+      onChange({
+        name,
+        value: newSelected
+      });
+    }
+  }
+
+  //
+  // Control
+
+  getSelectedIds = () => {
+    return getSelectedIds(this.state.selectedState, { parseIds: false });
+  }
+
+  //
+  // Listeners
+
+  onSelectAllChange = ({ value }) => {
+    this.setState(selectAll(this.state.selectedState, value));
+  }
+
+  onSelectedChange = ({ id, value, shiftKey = false }) => {
+    this.setState((state, props) => {
+      return toggleSelected(state, props.items, id, value, shiftKey);
+    });
+  }
+
+  //
+  // Render
+
+  render() {
+    const {
+      className,
+      items,
+      user,
+      isFetching,
+      isPopulated
+    } = this.props;
+
+    const {
+      allSelected,
+      allUnselected,
+      selectedState
+    } = this.state;
+
+    return (
+      <div className={className}>
+        {
+          isFetching &&
+            <LoadingIndicator />
+        }
+
+        {
+          !isPopulated && !isFetching &&
+            <div>
+              Authenticate with spotify to retrieve playlists to import.
+            </div>
+        }
+
+        {
+          isPopulated && !isFetching && !user &&
+            <div>
+              Could not retrieve data from Spotify.  Try re-authenticating.
+            </div>
+        }
+
+        {
+          isPopulated && !isFetching && user && !items.length &&
+            <div>
+              No playlists found for Spotify user {user}.
+            </div>
+        }
+
+        {
+          isPopulated && !isFetching && user && !!items.length &&
+            <div className={className}>
+              Select playlists to import from Spotify user {user}.
+              <Table
+                columns={columns}
+                selectAll={true}
+                allSelected={allSelected}
+                allUnselected={allUnselected}
+                onSelectAllChange={this.onSelectAllChange}
+              >
+                <TableBody>
+                  {
+                    items.map((item) => {
+                      return (
+                        <TableRow
+                          key={item.id}
+                        >
+                          <TableSelectCell
+                            id={item.id}
+                            isSelected={selectedState[item.id]}
+                            onSelectedChange={this.onSelectedChange}
+                          />
+
+                          <TableRowCell
+                            className={styles.relativePath}
+                            title={item.name}
+                          >
+                            {item.name}
+                          </TableRowCell>
+                        </TableRow>
+                      );
+                    })
+                  }
+                </TableBody>
+              </Table>
+            </div>
+        }
+      </div>
+    );
+  }
+}
+
+PlaylistInput.propTypes = {
+  className: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  value: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])).isRequired,
+  user: PropTypes.string.isRequired,
+  items: PropTypes.arrayOf(PropTypes.shape(tagShape)).isRequired,
+  hasError: PropTypes.bool,
+  hasWarning: PropTypes.bool,
+  isFetching: PropTypes.bool.isRequired,
+  isPopulated: PropTypes.bool.isRequired,
+  onChange: PropTypes.func.isRequired
+};
+
+PlaylistInput.defaultProps = {
+  className: styles.playlistInputWrapper,
+  inputClassName: styles.input
+};
+
+export default PlaylistInput;

--- a/frontend/src/Components/Form/PlaylistInputConnector.js
+++ b/frontend/src/Components/Form/PlaylistInputConnector.js
@@ -1,0 +1,97 @@
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
+import { fetchOptions, clearOptions } from 'Store/Actions/providerOptionActions';
+import PlaylistInput from './PlaylistInput';
+
+function createMapStateToProps() {
+  return createSelector(
+    (state) => state.providerOptions,
+    (state) => {
+      const {
+        items,
+        ...otherState
+      } = state;
+      return ({
+        user: items.user ? items.user : '',
+        items: items.playlists ? items.playlists : [],
+        ...otherState
+      });
+    }
+  );
+}
+
+const mapDispatchToProps = {
+  dispatchFetchOptions: fetchOptions,
+  dispatchClearOptions: clearOptions
+};
+
+class PlaylistInputConnector extends Component {
+
+  //
+  // Lifecycle
+
+  componentDidMount = () => {
+    if (this._getAccessToken(this.props)) {
+      this._populate();
+    }
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    const newToken = this._getAccessToken(this.props);
+    const oldToken = this._getAccessToken(prevProps);
+    if (newToken && newToken !== oldToken) {
+      this._populate();
+    }
+  }
+
+  componentWillUnmount = () => {
+    this.props.dispatchClearOptions();
+  }
+
+  //
+  // Control
+
+  _populate() {
+    const {
+      provider,
+      providerData,
+      dispatchFetchOptions
+    } = this.props;
+
+    dispatchFetchOptions({
+      action: 'getPlaylists',
+      provider,
+      providerData
+    });
+  }
+
+  _getAccessToken(props) {
+    return _.filter(props.providerData.fields, { name: 'accessToken' })[0].value;
+  }
+
+  //
+  // Render
+
+  render() {
+    return (
+      <PlaylistInput
+        {...this.props}
+        onRefreshPress={this.onRefreshPress}
+      />
+    );
+  }
+}
+
+PlaylistInputConnector.propTypes = {
+  provider: PropTypes.string.isRequired,
+  providerData: PropTypes.object.isRequired,
+  name: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  dispatchFetchOptions: PropTypes.func.isRequired,
+  dispatchClearOptions: PropTypes.func.isRequired
+};
+
+export default connect(createMapStateToProps, mapDispatchToProps)(PlaylistInputConnector);

--- a/frontend/src/Components/Form/ProviderFieldFormGroup.js
+++ b/frontend/src/Components/Form/ProviderFieldFormGroup.js
@@ -14,6 +14,8 @@ function getType(type) {
       return inputTypes.CHECK;
     case 'device':
       return inputTypes.DEVICE;
+    case 'playlist':
+      return inputTypes.PLAYLIST;
     case 'password':
       return inputTypes.PASSWORD;
     case 'number':

--- a/frontend/src/Helpers/Props/inputTypes.js
+++ b/frontend/src/Helpers/Props/inputTypes.js
@@ -2,6 +2,7 @@ export const AUTO_COMPLETE = 'autoComplete';
 export const CAPTCHA = 'captcha';
 export const CHECK = 'check';
 export const DEVICE = 'device';
+export const PLAYLIST = 'playlist';
 export const KEY_VALUE_LIST = 'keyValueList';
 export const MONITOR_ALBUMS_SELECT = 'monitorAlbumsSelect';
 export const NUMBER = 'number';
@@ -24,6 +25,7 @@ export const all = [
   CAPTCHA,
   CHECK,
   DEVICE,
+  PLAYLIST,
   KEY_VALUE_LIST,
   MONITOR_ALBUMS_SELECT,
   NUMBER,

--- a/frontend/src/Settings/ImportLists/ImportLists/AddImportListModalContent.js
+++ b/frontend/src/Settings/ImportLists/ImportLists/AddImportListModalContent.js
@@ -11,6 +11,7 @@ import ModalBody from 'Components/Modal/ModalBody';
 import ModalFooter from 'Components/Modal/ModalFooter';
 import AddImportListItem from './AddImportListItem';
 import styles from './AddImportListModalContent.css';
+import titleCase from 'Utilities/String/titleCase';
 
 class AddImportListModalContent extends Component {
 
@@ -22,7 +23,7 @@ class AddImportListModalContent extends Component {
       isSchemaFetching,
       isSchemaPopulated,
       schemaError,
-      allLists,
+      listGroups,
       onImportListSelect,
       onModalClose
     } = this.props;
@@ -52,23 +53,28 @@ class AddImportListModalContent extends Component {
                   <div>Lidarr supports multiple lists for importing Albums and Artists into the database.</div>
                   <div>For more information on the individual lists, click on the info buttons.</div>
                 </Alert>
-
-                <FieldSet legend="Import Lists">
-                  <div className={styles.lists}>
-                    {
-                      allLists.map((list) => {
-                        return (
-                          <AddImportListItem
-                            key={list.implementation}
-                            implementation={list.implementation}
-                            {...list}
-                            onImportListSelect={onImportListSelect}
-                          />
-                        );
-                      })
-                    }
-                  </div>
-                </FieldSet>
+                {
+                  Object.keys(listGroups).map((key) => {
+                    return (
+                      <FieldSet legend={`${titleCase(key)} List`} key={key}>
+                        <div className={styles.lists}>
+                          {
+                            listGroups[key].map((list) => {
+                              return (
+                                <AddImportListItem
+                                  key={list.implementation}
+                                  implementation={list.implementation}
+                                  {...list}
+                                  onImportListSelect={onImportListSelect}
+                                />
+                              );
+                            })
+                          }
+                        </div>
+                      </FieldSet>
+                    );
+                  })
+                }
               </div>
           }
         </ModalBody>
@@ -88,7 +94,7 @@ AddImportListModalContent.propTypes = {
   isSchemaFetching: PropTypes.bool.isRequired,
   isSchemaPopulated: PropTypes.bool.isRequired,
   schemaError: PropTypes.object,
-  allLists: PropTypes.arrayOf(PropTypes.object).isRequired,
+  listGroups: PropTypes.object.isRequired,
   onImportListSelect: PropTypes.func.isRequired,
   onModalClose: PropTypes.func.isRequired
 };

--- a/frontend/src/Settings/ImportLists/ImportLists/AddImportListModalContentConnector.js
+++ b/frontend/src/Settings/ImportLists/ImportLists/AddImportListModalContentConnector.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -16,13 +17,13 @@ function createMapStateToProps() {
         schema
       } = importLists;
 
-      const allLists = schema;
+      const listGroups = _.groupBy(schema, 'listType');
 
       return {
         isSchemaFetching,
         isSchemaPopulated,
         schemaError,
-        allLists
+        listGroups
       };
     }
   );

--- a/frontend/src/Settings/ImportLists/ImportLists/AddImportListModalContentConnector.js
+++ b/frontend/src/Settings/ImportLists/ImportLists/AddImportListModalContentConnector.js
@@ -17,7 +17,10 @@ function createMapStateToProps() {
         schema
       } = importLists;
 
-      const listGroups = _.groupBy(schema, 'listType');
+      const listGroups = _.chain(schema)
+        .sortBy((o) => o.listOrder)
+        .groupBy('listType')
+        .value();
 
       return {
         isSchemaFetching,

--- a/frontend/src/Settings/ImportLists/ImportLists/EditImportListModalContent.js
+++ b/frontend/src/Settings/ImportLists/ImportLists/EditImportListModalContent.js
@@ -221,6 +221,7 @@ function EditImportListModalContent(props) {
                           advancedSettings={advancedSettings}
                           provider="importList"
                           providerData={item}
+                          section="settings.importLists"
                           {...field}
                           onChange={onFieldChange}
                         />

--- a/src/Lidarr.Api.V1/ImportLists/ImportListResource.cs
+++ b/src/Lidarr.Api.V1/ImportLists/ImportListResource.cs
@@ -11,6 +11,7 @@ namespace Lidarr.Api.V1.ImportLists
         public int LanguageProfileId { get; set; }
         public int MetadataProfileId { get; set; }
         public ImportListType ListType { get; set; }
+        public int ListOrder { get; set; }
     }
 
     public class ImportListResourceMapper : ProviderResourceMapper<ImportListResource, ImportListDefinition>
@@ -31,6 +32,7 @@ namespace Lidarr.Api.V1.ImportLists
             resource.LanguageProfileId = definition.LanguageProfileId;
             resource.MetadataProfileId = definition.MetadataProfileId;
             resource.ListType = definition.ListType;
+            resource.ListOrder = (int) definition.ListType;
 
             return resource;
         }

--- a/src/Lidarr.Api.V1/ImportLists/ImportListResource.cs
+++ b/src/Lidarr.Api.V1/ImportLists/ImportListResource.cs
@@ -10,6 +10,7 @@ namespace Lidarr.Api.V1.ImportLists
         public int QualityProfileId { get; set; }
         public int LanguageProfileId { get; set; }
         public int MetadataProfileId { get; set; }
+        public ImportListType ListType { get; set; }
     }
 
     public class ImportListResourceMapper : ProviderResourceMapper<ImportListResource, ImportListDefinition>
@@ -29,6 +30,7 @@ namespace Lidarr.Api.V1.ImportLists
             resource.QualityProfileId = definition.ProfileId;
             resource.LanguageProfileId = definition.LanguageProfileId;
             resource.MetadataProfileId = definition.MetadataProfileId;
+            resource.ListType = definition.ListType;
 
             return resource;
         }
@@ -48,6 +50,7 @@ namespace Lidarr.Api.V1.ImportLists
             definition.ProfileId = resource.QualityProfileId;
             definition.LanguageProfileId = resource.LanguageProfileId;
             definition.MetadataProfileId = resource.MetadataProfileId;
+            definition.ListType = resource.ListType;
 
             return definition;
         }

--- a/src/Lidarr.Api.V1/Lidarr.Api.V1.csproj
+++ b/src/Lidarr.Api.V1/Lidarr.Api.V1.csproj
@@ -231,7 +231,7 @@
       <Version>1.4.1</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>11.0.2</Version>
+      <Version>12.0.2</Version>
     </PackageReference>
     <PackageReference Include="NLog">
       <Version>4.5.4</Version>

--- a/src/Lidarr.Api.V1/app.config
+++ b/src/Lidarr.Api.V1/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="FluentMigrator" publicKeyToken="aacfc7de5acabf05" culture="neutral" />

--- a/src/Lidarr.Http/Lidarr.Http.csproj
+++ b/src/Lidarr.Http/Lidarr.Http.csproj
@@ -143,7 +143,7 @@
       <Version>1.4.1</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>11.0.2</Version>
+      <Version>12.0.2</Version>
     </PackageReference>
     <PackageReference Include="NLog">
       <Version>4.5.4</Version>

--- a/src/Lidarr.Http/app.config
+++ b/src/Lidarr.Http/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/src/NzbDrone.Automation.Test/app.config
+++ b/src/NzbDrone.Automation.Test/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="FluentMigrator" publicKeyToken="aacfc7de5acabf05" culture="neutral" />

--- a/src/NzbDrone.Common/NzbDrone.Common.csproj
+++ b/src/NzbDrone.Common/NzbDrone.Common.csproj
@@ -249,7 +249,7 @@
       <Version>0.86.5</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>11.0.2</Version>
+      <Version>12.0.2</Version>
     </PackageReference>
     <PackageReference Include="NLog">
       <Version>4.5.4</Version>

--- a/src/NzbDrone.Common/app.config
+++ b/src/NzbDrone.Common/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/NzbDrone.Console/NzbDrone.Console.csproj
+++ b/src/NzbDrone.Console/NzbDrone.Console.csproj
@@ -122,7 +122,7 @@
       <Version>3.1.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>11.0.2</Version>
+      <Version>12.0.2</Version>
     </PackageReference>
     <PackageReference Include="NLog">
       <Version>4.5.4</Version>

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -605,7 +605,7 @@
       <Version>4.0.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>11.0.2</Version>
+      <Version>12.0.2</Version>
     </PackageReference>
     <PackageReference Include="NLog">
       <Version>4.5.4</Version>

--- a/src/NzbDrone.Core/Annotations/FieldDefinitionAttribute.cs
+++ b/src/NzbDrone.Core/Annotations/FieldDefinitionAttribute.cs
@@ -36,7 +36,8 @@ namespace NzbDrone.Core.Annotations
         Url,
         Captcha,
         OAuth,
-        Device
+        Device,
+        Playlist
     }
 
     public enum HiddenType

--- a/src/NzbDrone.Core/App.config
+++ b/src/NzbDrone.Core/App.config
@@ -5,7 +5,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="FluentMigrator" publicKeyToken="aacfc7de5acabf05" culture="neutral" />

--- a/src/NzbDrone.Core/Datastore/TableMapping.cs
+++ b/src/NzbDrone.Core/Datastore/TableMapping.cs
@@ -68,7 +68,8 @@ namespace NzbDrone.Core.Datastore
                   .Ignore(d => d.Tags);
 
             Mapper.Entity<ImportListDefinition>().RegisterDefinition("ImportLists")
-                .Ignore(i => i.Enable);
+                .Ignore(i => i.Enable)
+                .Ignore(i => i.ListType);
 
             Mapper.Entity<NotificationDefinition>().RegisterDefinition("Notifications")
                   .Ignore(i => i.SupportsOnGrab)

--- a/src/NzbDrone.Core/ImportLists/HeadphonesImport/HeadphonesImport.cs
+++ b/src/NzbDrone.Core/ImportLists/HeadphonesImport/HeadphonesImport.cs
@@ -9,6 +9,8 @@ namespace NzbDrone.Core.ImportLists.HeadphonesImport
     {
         public override string Name => "Headphones";
 
+        public override ImportListType ListType => ImportListType.Other;
+
         public override int PageSize => 1000;
 
         public HeadphonesImport(IHttpClient httpClient, IImportListStatusService importListStatusService, IConfigService configService, IParsingService parsingService, Logger logger)

--- a/src/NzbDrone.Core/ImportLists/IImportList.cs
+++ b/src/NzbDrone.Core/ImportLists/IImportList.cs
@@ -6,6 +6,7 @@ namespace NzbDrone.Core.ImportLists
 {
     public interface IImportList : IProvider
     {
+        ImportListType ListType { get; }
         IList<ImportListItemInfo> Fetch();
     }
 }

--- a/src/NzbDrone.Core/ImportLists/ImportListBase.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListBase.cs
@@ -21,6 +21,8 @@ namespace NzbDrone.Core.ImportLists
 
         public abstract string Name { get; }
 
+        public abstract ImportListType ListType {get; }
+
         public ImportListBase(IImportListStatusService importListStatusService, IConfigService configService, IParsingService parsingService, Logger logger)
         {
             _importListStatusService = importListStatusService;

--- a/src/NzbDrone.Core/ImportLists/ImportListDefinition.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListDefinition.cs
@@ -14,6 +14,7 @@ namespace NzbDrone.Core.ImportLists
         public override bool Enable => EnableAutomaticAdd;
 
         public ImportListStatus Status { get; set; }
+        public ImportListType ListType { get; set; }
     }
 
     public enum ImportListMonitorType

--- a/src/NzbDrone.Core/ImportLists/ImportListFactory.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListFactory.cs
@@ -35,6 +35,13 @@ namespace NzbDrone.Core.ImportLists
             return base.Active().Where(c => c.Enable).ToList();
         }
 
+        public override void SetProviderCharacteristics(IImportList provider, ImportListDefinition definition)
+        {
+            base.SetProviderCharacteristics(provider, definition);
+
+            definition.ListType = provider.ListType;
+        }
+
         public List<IImportList> AutomaticAddEnabled(bool filterBlockedImportLists = true)
         {
             var enabledImportLists = GetAvailableProviders().Where(n => ((ImportListDefinition)n.Definition).EnableAutomaticAdd);

--- a/src/NzbDrone.Core/ImportLists/ImportListRepository.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListRepository.cs
@@ -6,6 +6,7 @@ namespace NzbDrone.Core.ImportLists
 {
     public interface IImportListRepository : IProviderRepository<ImportListDefinition>
     {
+        void UpdateSettings(ImportListDefinition model);
     }
 
     public class ImportListRepository : ProviderRepository<ImportListDefinition>, IImportListRepository
@@ -13,6 +14,11 @@ namespace NzbDrone.Core.ImportLists
         public ImportListRepository(IMainDatabase database, IEventAggregator eventAggregator)
             : base(database, eventAggregator)
         {
+        }
+
+        public void UpdateSettings(ImportListDefinition model)
+        {
+            SetFields(model, m => m.Settings);
         }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/ImportListType.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListType.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NzbDrone.Core.ImportLists
+{
+    public enum ImportListType
+    {
+        Spotify,
+        LastFm,
+        Other
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/LastFm/LastFmTag.cs
+++ b/src/NzbDrone.Core/ImportLists/LastFm/LastFmTag.cs
@@ -9,6 +9,8 @@ namespace NzbDrone.Core.ImportLists.LastFm
     {
         public override string Name => "Last.fm Tag";
 
+        public override ImportListType ListType => ImportListType.LastFm;
+
         public override int PageSize => 1000;
 
         public LastFmTag(IHttpClient httpClient, IImportListStatusService importListStatusService, IConfigService configService, IParsingService parsingService, Logger logger)

--- a/src/NzbDrone.Core/ImportLists/LastFm/LastFmUser.cs
+++ b/src/NzbDrone.Core/ImportLists/LastFm/LastFmUser.cs
@@ -9,6 +9,8 @@ namespace NzbDrone.Core.ImportLists.LastFm
     {
         public override string Name => "Last.fm User";
 
+        public override ImportListType ListType => ImportListType.LastFm;
+
         public override int PageSize => 1000;
 
         public LastFmUser(IHttpClient httpClient, IImportListStatusService importListStatusService, IConfigService configService, IParsingService parsingService, Logger logger)

--- a/src/NzbDrone.Core/ImportLists/LidarrLists/LidarrLists.cs
+++ b/src/NzbDrone.Core/ImportLists/LidarrLists/LidarrLists.cs
@@ -12,6 +12,8 @@ namespace NzbDrone.Core.ImportLists.LidarrLists
     {
         public override string Name => "Lidarr Lists";
 
+        public override ImportListType ListType => ImportListType.Other;
+
         public override int PageSize => 10;
 
         private readonly IMetadataRequestBuilder _requestBuilder;

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyException.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyException.cs
@@ -1,0 +1,27 @@
+using System;
+using NzbDrone.Common.Exceptions;
+
+namespace NzbDrone.Core.ImportLists.Spotify
+{
+    public class SpotifyException : NzbDroneException
+    {
+        public SpotifyException(string message) : base(message)
+        {
+        }
+
+        public SpotifyException(string message, params object[] args) : base(message, args)
+        {
+        }
+
+        public SpotifyException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+
+    public class SpotifyAuthorizationException : SpotifyException
+    {
+        public SpotifyAuthorizationException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyFollowedArtists.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyFollowedArtists.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using NLog;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Parser;
+using NzbDrone.Core.Parser.Model;
+using SpotifyAPI.Web;
+using SpotifyAPI.Web.Enums;
+
+namespace NzbDrone.Core.ImportLists.Spotify
+{
+    public class SpotifyFollowedArtistsSettings : SpotifySettingsBase<SpotifyFollowedArtistsSettings>
+    {
+        public override string Scope => "user-follow-read";
+    }
+
+    public class SpotifyFollowedArtists : SpotifyImportListBase<SpotifyFollowedArtistsSettings>
+    {
+        public SpotifyFollowedArtists(IImportListStatusService importListStatusService,
+                                      IImportListRepository importListRepository,
+                                      IConfigService configService,
+                                      IParsingService parsingService,
+                                      HttpClient httpClient,
+                                      Logger logger)
+        : base(importListStatusService, importListRepository, configService, parsingService, httpClient, logger)
+        {
+        }
+
+        public override string Name => "Spotify Followed Artists";
+
+        public override IList<ImportListItemInfo> Fetch(SpotifyWebAPI api)
+        {
+            var result = new List<ImportListItemInfo>();
+            
+            var followed = Execute(api, (x) => x.GetFollowedArtists(FollowType.Artist, 50));
+            var artists = followed.Artists;
+            while (true)
+            {
+                foreach (var artist in artists.Items)
+                {
+                    if (artist.Name.IsNotNullOrWhiteSpace())
+                    {
+                        result.AddIfNotNull(new ImportListItemInfo
+                                            {
+                                                Artist = artist.Name,
+                                            });
+                    }
+                }
+                if (!artists.HasNext())
+                    break;
+                artists = Execute(api, (x) => x.GetNextPage(artists));
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyImportListBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyImportListBase.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using FluentValidation.Results;
+using NLog;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Parser;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Validation;
+using SpotifyAPI.Web;
+using SpotifyAPI.Web.Models;
+
+namespace NzbDrone.Core.ImportLists.Spotify
+{
+    public abstract class SpotifyImportListBase<TSettings> : ImportListBase<TSettings>
+        where TSettings : SpotifySettingsBase<TSettings>, new()
+    {
+        private IHttpClient _httpClient;
+        private IImportListRepository _importListRepository;
+
+        public SpotifyImportListBase(IImportListStatusService importListStatusService,
+                                     IImportListRepository importListRepository,
+                                     IConfigService configService,
+                                     IParsingService parsingService,
+                                     HttpClient httpClient,
+                                     Logger logger)
+        : base(importListStatusService, configService, parsingService, logger)
+        {
+            _httpClient = httpClient;
+            _importListRepository = importListRepository;
+        }
+
+        private void RefreshToken()
+        {
+            _logger.Trace("Refreshing Token");
+
+            Settings.Validate().Filter("RefreshToken").ThrowOnError();
+
+            var request = new HttpRequestBuilder(Settings.RenewUri)
+                .AddQueryParam("refresh_token", Settings.RefreshToken)
+                .Build();
+
+            try
+            {
+                var response = _httpClient.Get<Token>(request);
+
+                if (response != null && response.Resource != null)
+                {
+                    var token = response.Resource;
+                    Settings.AccessToken = token.AccessToken;
+                    Settings.Expires = DateTime.UtcNow.AddSeconds(token.ExpiresIn);
+                    Settings.RefreshToken = token.RefreshToken != null ? token.RefreshToken : Settings.RefreshToken;
+
+                    if (Definition.Id > 0)
+                    {
+                        _importListRepository.UpdateSettings((ImportListDefinition)Definition);
+                    }
+                }
+            }
+            catch (HttpException)
+            {
+                _logger.Warn($"Error refreshing spotify access token");
+            }
+
+        }
+        
+        protected SpotifyWebAPI GetApi()
+        {
+            Settings.Validate().Filter("AccessToken", "RefreshToken").ThrowOnError();
+            _logger.Trace($"Access token expires at {Settings.Expires}");
+
+            if (Settings.Expires < DateTime.UtcNow.AddMinutes(5))
+            {
+                RefreshToken();
+            }
+
+            return new SpotifyWebAPI
+            {
+                AccessToken = Settings.AccessToken,
+                TokenType = "Bearer"
+            };
+        }
+
+        protected T Execute<T>(SpotifyWebAPI api, Func<SpotifyWebAPI, T> method, bool allowReauth = true) where T : BasicModel
+        {
+            T result = method(api);
+            if (result.HasError())
+            {
+                // If unauthorized, refresh token and try again
+                if (result.Error.Status == 401)
+                {
+                    if (allowReauth)
+                    {
+                        _logger.Debug("Spotify authorization error, refreshing token and retrying");
+                        RefreshToken();
+                        api.AccessToken = Settings.AccessToken;
+                        return Execute(api, method, false);
+                    }
+                    else
+                    {
+                        throw new SpotifyAuthorizationException(result.Error.Message);
+                    }
+                }
+                else
+                {
+                    throw new SpotifyException("[{0}] {1}", result.Error.Status, result.Error.Message);
+                }
+            }
+
+            return result;
+        }
+
+        public override IList<ImportListItemInfo> Fetch()
+        {
+            using (var api = GetApi())
+            {
+                _logger.Debug("Starting spotify import list sync");
+                var releases = Fetch(api);
+                return CleanupListItems(releases);
+            }
+        }
+
+        public abstract IList<ImportListItemInfo> Fetch(SpotifyWebAPI api);
+
+        protected DateTime ParseSpotifyDate(string date, string precision)
+        {
+            if (date.IsNullOrWhiteSpace() || precision.IsNullOrWhiteSpace())
+            {
+                return default(DateTime);
+            }
+            
+            string format;
+            
+            switch (precision) {
+                case "year":
+                    format = "yyyy";
+                    break;
+                case "month":
+                    format = "yyyy-MM";
+                    break;
+                case "day":
+                default:
+                    format = "yyyy-MM-dd";
+                    break;
+            }
+
+            return DateTime.TryParseExact(date, format, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime result) ? result : default(DateTime);
+        }
+
+        protected override void Test(List<ValidationFailure> failures)
+        {
+            failures.AddIfNotNull(TestConnection());
+        }
+
+        private ValidationFailure TestConnection()
+        {
+            try
+            {
+                using (var api = GetApi())
+                {
+                    var profile = Execute(api, (x) => x.GetPrivateProfile());
+                    _logger.Debug($"Connected to spotify profile {profile.DisplayName} [{profile.Id}]");
+                    return null;
+                }
+            }
+            catch (SpotifyAuthorizationException ex)
+            {
+                _logger.Warn(ex, "Spotify Authentication Error");
+                return new ValidationFailure(string.Empty, $"Spotify authentication error: {ex.Message}");
+            }
+            catch (Exception ex)
+            {
+                _logger.Warn(ex, "Unable to connect to Spotify");
+
+                return new ValidationFailure(string.Empty, "Unable to connect to import list, check the log for more details");
+            }
+        }
+
+        public override object RequestAction(string action, IDictionary<string, string> query)
+        {
+            if (action == "startOAuth")
+            {
+                var request = new HttpRequestBuilder(Settings.OAuthUrl)
+                    .AddQueryParam("client_id", Settings.ClientId)
+                    .AddQueryParam("response_type", "code")
+                    .AddQueryParam("redirect_uri", Settings.RedirectUri)
+                    .AddQueryParam("scope", Settings.Scope)
+                    .AddQueryParam("state", query["callbackUrl"])
+                    .AddQueryParam("show_dialog", true)
+                    .Build();
+
+                return new {
+                    OauthUrl = request.Url.ToString()
+                };
+            }
+            else if (action == "getOAuthToken")
+            {
+                return new {
+                    accessToken = query["access_token"],
+                    expires = DateTime.UtcNow.AddSeconds(int.Parse(query["expires_in"])),
+                    refreshToken = query["refresh_token"],
+                };
+            }
+
+            return new { };
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyImportListBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyImportListBase.cs
@@ -32,6 +32,8 @@ namespace NzbDrone.Core.ImportLists.Spotify
             _importListRepository = importListRepository;
         }
 
+        public override ImportListType ListType => ImportListType.Spotify;
+
         private void RefreshToken()
         {
             _logger.Trace("Refreshing Token");

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyPlaylist.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyPlaylist.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NLog;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Parser;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Validation;
+using SpotifyAPI.Web;
+using SpotifyAPI.Web.Models;
+
+namespace NzbDrone.Core.ImportLists.Spotify
+{
+    public class SpotifyPlaylist : SpotifyImportListBase<SpotifyPlaylistSettings>
+    {
+        public SpotifyPlaylist(IImportListStatusService importListStatusService,
+                               IImportListRepository importListRepository,
+                               IConfigService configService,
+                               IParsingService parsingService,
+                               HttpClient httpClient,
+                               Logger logger)
+        : base(importListStatusService, importListRepository, configService, parsingService, httpClient, logger)
+        {
+        }
+
+        public override string Name => "Spotify Playlists";
+
+        public override IList<ImportListItemInfo> Fetch(SpotifyWebAPI api)
+        {
+            var result = new List<ImportListItemInfo>();
+
+            foreach (var id in Settings.PlaylistIds)
+            {
+                _logger.Trace($"Processing playlist {id}");
+
+                var playlistTracks = Execute(api, (x) => x.GetPlaylistTracks(id, fields: "next, items(track(name, album(name,artists)))"));
+                while (true)
+                {
+                    foreach (var track in playlistTracks.Items)
+                    {
+                        var fullTrack = track.Track;
+                        // From spotify docs: "Note, a track object may be null. This can happen if a track is no longer available."
+                        if (fullTrack != null)
+                        {
+                            var album = fullTrack.Album?.Name;
+                            var artist = fullTrack.Album?.Artists?.FirstOrDefault()?.Name ?? fullTrack.Artists.FirstOrDefault()?.Name;
+
+                            if (album.IsNotNullOrWhiteSpace() && artist.IsNotNullOrWhiteSpace())
+                            {
+                                result.AddIfNotNull(new ImportListItemInfo
+                                                    {
+                                                        Artist = artist,
+                                                        Album = album,
+                                                        ReleaseDate = ParseSpotifyDate(fullTrack.Album.ReleaseDate, fullTrack.Album.ReleaseDatePrecision)
+                                                    });
+                                
+                            }
+                        }
+                    }
+                        
+                    if (!playlistTracks.HasNextPage())
+                        break;
+                    playlistTracks = Execute(api, (x) => x.GetNextPage(playlistTracks));
+                }
+            }
+
+            return result;
+        }
+
+        public override object RequestAction(string action, IDictionary<string, string> query)
+        {
+            if (action == "getPlaylists")
+            {
+                if (Settings.AccessToken.IsNullOrWhiteSpace())
+                {
+                    return new
+                        {
+                            playlists = new List<object>()
+                        };
+                }
+
+                Settings.Validate().Filter("AccessToken").ThrowOnError();
+
+                using (var api = GetApi())
+                {
+                    try
+                    {
+                        var profile = Execute(api, (x) => x.GetPrivateProfile());
+                        var playlistPage = Execute(api, (x) => x.GetUserPlaylists(profile.Id));
+                        _logger.Trace($"Got {playlistPage.Total} playlists");
+
+                        var playlists = new List<SimplePlaylist>(playlistPage.Total);
+                        while (true)
+                        {
+                            playlists.AddRange(playlistPage.Items);
+
+                            if (!playlistPage.HasNextPage())
+                                break;
+                            playlistPage = Execute(api, (x) => x.GetNextPage(playlistPage));
+                        }
+
+                        return new
+                            {
+                                options = new {
+                                    user = profile.DisplayName,
+                                    playlists = playlists.OrderBy(p => p.Name)
+                                    .Select(p => new
+                                        {
+                                            id = p.Id,
+                                            name = p.Name
+                                        })
+                                }
+                            };
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.Warn(ex, "Error fetching playlists from Spotify");
+                        return new { };
+                    }
+                }
+            }
+            else
+            {
+                return base.RequestAction(action, query);
+            }
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyPlaylistSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyPlaylistSettings.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using FluentValidation;
+using NzbDrone.Core.Annotations;
+
+namespace NzbDrone.Core.ImportLists.Spotify
+{
+    public class SpotifyPlaylistSettingsValidator : SpotifySettingsBaseValidator<SpotifyPlaylistSettings>
+    {
+        public SpotifyPlaylistSettingsValidator()
+        : base()
+        {
+            RuleFor(c => c.PlaylistIds).NotEmpty();
+        }
+    }
+
+    public class SpotifyPlaylistSettings : SpotifySettingsBase<SpotifyPlaylistSettings>
+    {
+        protected override AbstractValidator<SpotifyPlaylistSettings> Validator => new SpotifyPlaylistSettingsValidator();
+
+        public SpotifyPlaylistSettings()
+        {
+            PlaylistIds = new string[] { };
+        }
+
+        public override string Scope => "playlist-read-private";
+
+        [FieldDefinition(1, Label = "Playlists", Type = FieldType.Playlist)]
+        public IEnumerable<string> PlaylistIds { get; set; }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifySavedAlbums.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifySavedAlbums.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using System.Linq;
+using NLog;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Parser;
+using NzbDrone.Core.Parser.Model;
+using SpotifyAPI.Web;
+
+namespace NzbDrone.Core.ImportLists.Spotify
+{
+    public class SpotifySavedAlbumsSettings : SpotifySettingsBase<SpotifySavedAlbumsSettings>
+    {
+        public override string Scope => "user-library-read";
+    }
+
+    public class SpotifySavedAlbums : SpotifyImportListBase<SpotifySavedAlbumsSettings>
+    {
+        public SpotifySavedAlbums(IImportListStatusService importListStatusService,
+                                  IImportListRepository importListRepository,
+                                  IConfigService configService,
+                                  IParsingService parsingService,
+                                  HttpClient httpClient,
+                                  Logger logger)
+        : base(importListStatusService, importListRepository, configService, parsingService, httpClient, logger)
+        {
+        }
+
+        public override string Name => "Spotify Saved Albums";
+
+        public override IList<ImportListItemInfo> Fetch(SpotifyWebAPI api)
+        {
+            var result = new List<ImportListItemInfo>();
+
+            var albums = Execute(api, (x) => x.GetSavedAlbums(50));
+            _logger.Trace($"Got {albums.Total} saved albums");
+
+            while (true)
+            {
+                foreach (var album in albums.Items)
+                {
+                    var artistName = album.Album.Artists.FirstOrDefault()?.Name;
+                    var albumName = album.Album.Name;
+                    _logger.Trace($"Adding {artistName} - {albumName}");
+
+                    if (artistName.IsNotNullOrWhiteSpace() && albumName.IsNotNullOrWhiteSpace())
+                    {
+                        result.AddIfNotNull(new ImportListItemInfo
+                                            {
+                                                Artist = artistName,
+                                                Album = albumName
+                                            });
+                    }
+                }
+                if (!albums.HasNextPage())
+                    break;
+                albums = Execute(api, (x) => x.GetNextPage(albums));
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifySettingsBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifySettingsBase.cs
@@ -1,0 +1,55 @@
+using System;
+using FluentValidation;
+using NzbDrone.Core.Annotations;
+using NzbDrone.Core.Validation;
+
+namespace NzbDrone.Core.ImportLists.Spotify
+{
+    public class SpotifySettingsBaseValidator<TSettings> : AbstractValidator<TSettings>
+        where TSettings : SpotifySettingsBase<TSettings>
+    {
+        public SpotifySettingsBaseValidator()
+        {
+            RuleFor(c => c.AccessToken).NotEmpty();
+            RuleFor(c => c.RefreshToken).NotEmpty();
+            RuleFor(c => c.Expires).NotEmpty();
+        }
+    }
+
+    public class SpotifySettingsBase<TSettings> : IImportListSettings
+        where TSettings : SpotifySettingsBase<TSettings>
+    {
+        protected virtual AbstractValidator<TSettings> Validator => new SpotifySettingsBaseValidator<TSettings>();
+
+        public SpotifySettingsBase()
+        {
+            BaseUrl = "https://api.spotify.com/v1";
+            SignIn = "startOAuth";
+        }
+
+        public string BaseUrl { get; set; }
+
+        public string OAuthUrl => "https://accounts.spotify.com/authorize";
+        public string RedirectUri => "https://spotify.lidarr.audio/auth";
+        public string RenewUri => "https://spotify.lidarr.audio/renew";
+        public string ClientId => "848082790c32436d8a0405fddca0aa18";
+        public virtual string Scope => "";
+
+        [FieldDefinition(0, Label = "Access Token", Type = FieldType.Textbox, Hidden = HiddenType.Hidden)]
+        public string AccessToken { get; set; }
+
+        [FieldDefinition(0, Label = "Refresh Token", Type = FieldType.Textbox, Hidden = HiddenType.Hidden)]
+        public string RefreshToken { get; set; }
+
+        [FieldDefinition(0, Label = "Expires", Type = FieldType.Textbox, Hidden = HiddenType.Hidden)]
+        public DateTime Expires { get; set; }
+
+        [FieldDefinition(99, Label = "Authenticate with Spotify", Type = FieldType.OAuth)]
+        public string SignIn { get; set; }
+
+        public NzbDroneValidationResult Validate()
+        {
+            return new NzbDroneValidationResult(Validator.Validate((TSettings)this));
+        }
+    }
+}

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -289,6 +289,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
                 artist.Metadata = MapArtistMetadata(resource.Artists.Single(x => x.Id == resource.ArtistId));
             }
             album.Artist = artist;
+            album.ArtistMetadata = artist.Metadata;
 
             return album;
         }

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -552,6 +552,7 @@
     <Compile Include="ImportLists\ImportListBase.cs" />
     <Compile Include="ImportLists\ImportListPageableRequestChain.cs" />
     <Compile Include="ImportLists\ImportListPageableRequest.cs" />
+    <Compile Include="ImportLists\ImportListType.cs" />
     <Compile Include="ImportLists\ImportListUpdatedHandler.cs" />
     <Compile Include="ImportLists\IProcessImportListResponse.cs" />
     <Compile Include="ImportLists\ImportListSyncService.cs" />

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -569,6 +569,13 @@
     <Compile Include="ImportLists\LidarrLists\LidarrListsParser.cs" />
     <Compile Include="ImportLists\LidarrLists\LidarrListsRequestGenerator.cs" />
     <Compile Include="ImportLists\LidarrLists\LidarrListsSettings.cs" />
+    <Compile Include="ImportLists\Spotify\SpotifyException.cs" />
+    <Compile Include="ImportLists\Spotify\SpotifySettingsBase.cs" />
+    <Compile Include="ImportLists\Spotify\SpotifyImportListBase.cs" />
+    <Compile Include="ImportLists\Spotify\SpotifyPlaylistSettings.cs" />
+    <Compile Include="ImportLists\Spotify\SpotifyPlaylist.cs" />
+    <Compile Include="ImportLists\Spotify\SpotifyFollowedArtists.cs" />
+    <Compile Include="ImportLists\Spotify\SpotifySavedAlbums.cs" />
     <Compile Include="IndexerSearch\AlbumSearchCommand.cs" />
     <Compile Include="IndexerSearch\AlbumSearchService.cs" />
     <Compile Include="IndexerSearch\ArtistSearchCommand.cs" />
@@ -1333,6 +1340,7 @@
     <PackageReference Include="xmlrpcnet">
       <Version>2.5.0</Version>
     </PackageReference>
+    <PackageReference Include="SpotifyAPI.Web" Version="4.2.0" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -1317,7 +1317,7 @@
       <Version>4.2.5</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>11.0.2</Version>
+      <Version>12.0.2</Version>
     </PackageReference>
     <PackageReference Include="NLog">
       <Version>4.5.4</Version>

--- a/src/NzbDrone.Host/NzbDrone.Host.csproj
+++ b/src/NzbDrone.Host/NzbDrone.Host.csproj
@@ -179,7 +179,7 @@
       <Version>1.4.1</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>11.0.2</Version>
+      <Version>12.0.2</Version>
     </PackageReference>
     <PackageReference Include="NLog">
       <Version>4.5.4</Version>

--- a/src/NzbDrone.Host/app.config
+++ b/src/NzbDrone.Host/app.config
@@ -14,7 +14,7 @@
       <probing privatePath="libs" />
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NLog" publicKeyToken="5120e14c03d0593c" culture="neutral" />

--- a/src/NzbDrone.Integration.Test/NzbDrone.Integration.Test.csproj
+++ b/src/NzbDrone.Integration.Test/NzbDrone.Integration.Test.csproj
@@ -160,7 +160,7 @@
       <Version>1.4.1</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>11.0.2</Version>
+      <Version>12.0.2</Version>
     </PackageReference>
     <PackageReference Include="NLog">
       <Version>4.5.4</Version>

--- a/src/NzbDrone.Libraries.Test/NzbDrone.Libraries.Test.csproj
+++ b/src/NzbDrone.Libraries.Test/NzbDrone.Libraries.Test.csproj
@@ -80,7 +80,7 @@
       <Version>4.19.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>11.0.2</Version>
+      <Version>12.0.2</Version>
     </PackageReference>
     <PackageReference Include="NUnit">
       <Version>3.11.0</Version>

--- a/src/NzbDrone.Libraries.Test/app.config
+++ b/src/NzbDrone.Libraries.Test/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="FluentMigrator" publicKeyToken="aacfc7de5acabf05" culture="neutral" />

--- a/src/NzbDrone.Mono.Test/app.config
+++ b/src/NzbDrone.Mono.Test/app.config
@@ -8,7 +8,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="FluentMigrator" publicKeyToken="aacfc7de5acabf05" culture="neutral" />

--- a/src/NzbDrone.Mono/app.config
+++ b/src/NzbDrone.Mono/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/NzbDrone.SignalR/NzbDrone.SignalR.csproj
+++ b/src/NzbDrone.SignalR/NzbDrone.SignalR.csproj
@@ -90,7 +90,7 @@
       <Version>3.1.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>11.0.2</Version>
+      <Version>12.0.2</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NzbDrone.SignalR/app.config
+++ b/src/NzbDrone.SignalR/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="FluentMigrator" publicKeyToken="aacfc7de5acabf05" culture="neutral" />

--- a/src/NzbDrone.Test.Common/App.config
+++ b/src/NzbDrone.Test.Common/App.config
@@ -7,7 +7,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NLog" publicKeyToken="5120e14c03d0593c" culture="neutral" />

--- a/src/NzbDrone.Test.Common/NzbDrone.Test.Common.csproj
+++ b/src/NzbDrone.Test.Common/NzbDrone.Test.Common.csproj
@@ -100,7 +100,7 @@
       <Version>4.12.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>11.0.2</Version>
+      <Version>12.0.2</Version>
     </PackageReference>
     <PackageReference Include="NLog">
       <Version>4.5.4</Version>

--- a/src/NzbDrone.Update/NzbDrone.Update.csproj
+++ b/src/NzbDrone.Update/NzbDrone.Update.csproj
@@ -74,7 +74,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>11.0.2</Version>
+      <Version>12.0.2</Version>
     </PackageReference>
     <PackageReference Include="NLog">
       <Version>4.5.4</Version>

--- a/src/NzbDrone.Update/app.config
+++ b/src/NzbDrone.Update/app.config
@@ -11,7 +11,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/NzbDrone.Windows.Test/app.config
+++ b/src/NzbDrone.Windows.Test/app.config
@@ -8,7 +8,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="FluentMigrator" publicKeyToken="aacfc7de5acabf05" culture="neutral" />

--- a/src/NzbDrone.Windows/app.config
+++ b/src/NzbDrone.Windows/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/NzbDrone/NzbDrone.csproj
+++ b/src/NzbDrone/NzbDrone.csproj
@@ -138,7 +138,7 @@
       <Version>3.1.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>11.0.2</Version>
+      <Version>12.0.2</Version>
     </PackageReference>
     <PackageReference Include="NLog">
       <Version>4.5.4</Version>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Import playlists, followed artists and saved albums from spotify.  Uses an applet on the metadata server to get a full refresh token without having to provide a client secret to users.

#### Issues Fixed or Closed by this PR

* Fixes #334 
