### PR TITLE
New: Allow monitoring all albums for import list artist

### DIFF
--- a/frontend/src/Settings/ImportLists/ImportLists/EditImportListModalContent.css
+++ b/frontend/src/Settings/ImportLists/ImportLists/EditImportListModalContent.css
@@ -10,3 +10,7 @@
 
   display: none;
 }
+
+.labelIcon {
+  margin-left: 8px;
+}

--- a/frontend/src/Settings/ImportLists/ImportLists/EditImportListModalContent.js
+++ b/frontend/src/Settings/ImportLists/ImportLists/EditImportListModalContent.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { inputTypes, kinds } from 'Helpers/Props';
+import { icons, inputTypes, kinds, tooltipPositions } from 'Helpers/Props';
+import Icon from 'Components/Icon';
 import Button from 'Components/Link/Button';
 import SpinnerErrorButton from 'Components/Link/SpinnerErrorButton';
 import LoadingIndicator from 'Components/Loading/LoadingIndicator';
@@ -12,10 +13,41 @@ import Form from 'Components/Form/Form';
 import FormGroup from 'Components/Form/FormGroup';
 import FormLabel from 'Components/Form/FormLabel';
 import FormInputGroup from 'Components/Form/FormInputGroup';
+import Popover from 'Components/Tooltip/Popover';
 import ProviderFieldFormGroup from 'Components/Form/ProviderFieldFormGroup';
+import DescriptionList from 'Components/DescriptionList/DescriptionList';
+import DescriptionListItem from 'Components/DescriptionList/DescriptionListItem';
 import styles from './EditImportListModalContent.css';
 
+function ImportListMonitoringOptionsPopoverContent() {
+  return (
+    <DescriptionList>
+      <DescriptionListItem
+        title="None"
+        data="Do not monitor artists or albums"
+      />
+
+      <DescriptionListItem
+        title="Specific Album"
+        data="Monitor artists but only monitor albums explicitly included in the list"
+      />
+
+      <DescriptionListItem
+        title="All Artist Albums"
+        data="Monitor artists and all albums for each artist included on the import list"
+      />
+    </DescriptionList>
+  );
+}
+
 function EditImportListModalContent(props) {
+
+  const monitorOptions = [
+    { key: 'none', value: 'None' },
+    { key: 'specificAlbum', value: 'Specific Album' },
+    { key: 'entireArtist', value: 'All Artist Albums' }
+  ];
+
   const {
     advancedSettings,
     isFetching,
@@ -92,11 +124,26 @@ function EditImportListModalContent(props) {
               </FormGroup>
 
               <FormGroup>
-                <FormLabel>Monitor</FormLabel>
+                <FormLabel>
+                  Monitor
+
+                  <Popover
+                    anchor={
+                      <Icon
+                        className={styles.labelIcon}
+                        name={icons.INFO}
+                      />
+                    }
+                    title="Monitoring Options"
+                    body={<ImportListMonitoringOptionsPopoverContent />}
+                    position={tooltipPositions.RIGHT}
+                  />
+                </FormLabel>
 
                 <FormInputGroup
-                  type={inputTypes.CHECK}
+                  type={inputTypes.SELECT}
                   name="shouldMonitor"
+                  values={monitorOptions}
                   helpText={'Monitor artists and albums added from this list'}
                   {...shouldMonitor}
                   onChange={onInputChange}

--- a/frontend/src/Store/Actions/Settings/importLists.js
+++ b/frontend/src/Store/Actions/Settings/importLists.js
@@ -107,8 +107,8 @@ export default {
 
     [SELECT_IMPORT_LIST_SCHEMA]: (state, { payload }) => {
       return selectProviderSchema(state, section, payload, (selectedSchema) => {
-        selectedSchema.enableRss = selectedSchema.supportsRss;
-        selectedSchema.enableSearch = selectedSchema.supportsSearch;
+        selectedSchema.enableAutomaticAdd = true;
+        selectedSchema.shouldMonitor = 'entireArtist';
 
         return selectedSchema;
       });

--- a/src/Lidarr.Api.V1/ImportLists/ImportListResource.cs
+++ b/src/Lidarr.Api.V1/ImportLists/ImportListResource.cs
@@ -5,7 +5,7 @@ namespace Lidarr.Api.V1.ImportLists
     public class ImportListResource : ProviderResource
     {
         public bool EnableAutomaticAdd { get; set; }
-        public bool ShouldMonitor { get; set; }
+        public ImportListMonitorType ShouldMonitor { get; set; }
         public string RootFolderPath { get; set; }
         public int QualityProfileId { get; set; }
         public int LanguageProfileId { get; set; }

--- a/src/NzbDrone.Core.Test/ImportListTests/ImportListSyncServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/ImportListTests/ImportListSyncServiceFixture.cs
@@ -39,7 +39,7 @@ namespace NzbDrone.Core.Test.ImportListTests
 
             Mocker.GetMock<IImportListFactory>()
                 .Setup(v => v.Get(It.IsAny<int>()))
-                .Returns(new ImportListDefinition{ ShouldMonitor = true });
+                .Returns(new ImportListDefinition{ ShouldMonitor = ImportListMonitorType.SpecificAlbum });
 
             Mocker.GetMock<IFetchAndParseImportList>()
                 .Setup(v => v.Fetch())
@@ -81,6 +81,13 @@ namespace NzbDrone.Core.Test.ImportListTests
                         ForeignId = "f59c5520-5f46-4d2c-b2c4-822eabf53419"
                     }
                 });
+        }
+
+        private void WithMonitorType(ImportListMonitorType monitor)
+        {
+            Mocker.GetMock<IImportListFactory>()
+                .Setup(v => v.Get(It.IsAny<int>()))
+                .Returns(new ImportListDefinition{ ShouldMonitor = monitor });
         }
 
         [Test]
@@ -152,17 +159,20 @@ namespace NzbDrone.Core.Test.ImportListTests
                 .Verify(v => v.AddArtists(It.Is<List<Artist>>(t=>t.Count == 0)));
         }
 
-        [Test]
-        public void should_add_if_not_existing_artist()
+        [TestCase(ImportListMonitorType.None, false)]
+        [TestCase(ImportListMonitorType.SpecificAlbum, true)]
+        [TestCase(ImportListMonitorType.EntireArtist, true)]
+        public void should_add_if_not_existing_artist(ImportListMonitorType monitor, bool expectedArtistMonitored)
         {
             WithArtistId();
             WithAlbum();
             WithAlbumId();
+            WithMonitorType(monitor);
 
             Subject.Execute(new ImportListSyncCommand());
 
             Mocker.GetMock<IAddArtistService>()
-                .Verify(v => v.AddArtists(It.Is<List<Artist>>(t => t.Count == 1)));
+                .Verify(v => v.AddArtists(It.Is<List<Artist>>(t => t.Count == 1 && t.First().Monitored == expectedArtistMonitored)));
         }
 
         [Test]
@@ -180,16 +190,31 @@ namespace NzbDrone.Core.Test.ImportListTests
         }
 
         [Test]
-        public void should_mark_album_for_monitor_if_album_id()
+        public void should_mark_album_for_monitor_if_album_id_and_specific_monitor_selected()
         {
             WithArtistId();
             WithAlbum();
             WithAlbumId();
+            WithMonitorType(ImportListMonitorType.SpecificAlbum);
 
             Subject.Execute(new ImportListSyncCommand());
 
             Mocker.GetMock<IAddArtistService>()
                 .Verify(v => v.AddArtists(It.Is<List<Artist>>(t => t.Count == 1 && t.First().AddOptions.AlbumsToMonitor.Contains("09474d62-17dd-3a4f-98fb-04c65f38a479"))));
+        }
+
+        [Test]
+        public void should_not_mark_album_for_monitor_if_album_id_and_monitor_all_selected()
+        {
+            WithArtistId();
+            WithAlbum();
+            WithAlbumId();
+            WithMonitorType(ImportListMonitorType.EntireArtist);
+
+            Subject.Execute(new ImportListSyncCommand());
+
+            Mocker.GetMock<IAddArtistService>()
+                .Verify(v => v.AddArtists(It.Is<List<Artist>>(t => t.Count == 1 && !t.First().AddOptions.AlbumsToMonitor.Any())));
         }
 
         [Test]
@@ -202,6 +227,5 @@ namespace NzbDrone.Core.Test.ImportListTests
             Mocker.GetMock<IAddArtistService>()
                 .Verify(v => v.AddArtists(It.Is<List<Artist>>(t => t.Count == 1 && t.First().AddOptions.AlbumsToMonitor.Count == 0)));
         }
-
     }
 }

--- a/src/NzbDrone.Core/ImportLists/ImportListDefinition.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListDefinition.cs
@@ -5,7 +5,7 @@ namespace NzbDrone.Core.ImportLists
     public class ImportListDefinition : ProviderDefinition
     {
         public bool EnableAutomaticAdd { get; set; }
-        public bool ShouldMonitor { get; set; }
+        public ImportListMonitorType ShouldMonitor { get; set; }
         public int ProfileId { get; set; }
         public int LanguageProfileId { get; set; }
         public int MetadataProfileId { get; set; }
@@ -14,5 +14,12 @@ namespace NzbDrone.Core.ImportLists
         public override bool Enable => EnableAutomaticAdd;
 
         public ImportListStatus Status { get; set; }
+    }
+
+    public enum ImportListMonitorType
+    {
+        None,
+        SpecificAlbum,
+        EntireArtist
     }
 }

--- a/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
@@ -130,13 +130,14 @@ namespace NzbDrone.Core.ImportLists
                 // Append Artist if not already in DB or already on add list
                 if (existingArtist == null && excludedArtist == null && artistsToAdd.All(s => s.Metadata.Value.ForeignArtistId != report.ArtistMusicBrainzId))
                 {
+                    var monitored = importList.ShouldMonitor != ImportListMonitorType.None;
                     artistsToAdd.Add(new Artist
                     {
                         Metadata = new ArtistMetadata {
                             ForeignArtistId = report.ArtistMusicBrainzId,
                             Name = report.Artist
                         },
-                        Monitored = importList.ShouldMonitor,
+                        Monitored = monitored,
                         RootFolderPath = importList.RootFolderPath,
                         QualityProfileId = importList.ProfileId,
                         LanguageProfileId = importList.LanguageProfileId,
@@ -144,15 +145,15 @@ namespace NzbDrone.Core.ImportLists
                         Tags = importList.Tags,
                         AlbumFolder = true,
                         AddOptions = new AddArtistOptions {
-                            SearchForMissingAlbums = importList.ShouldMonitor,
-                            Monitored = importList.ShouldMonitor,
-                            Monitor = importList.ShouldMonitor ? MonitorTypes.All : MonitorTypes.None
+                            SearchForMissingAlbums = monitored,
+                            Monitored = monitored,
+                            Monitor = monitored ? MonitorTypes.All : MonitorTypes.None
                         }
                     });
                 }
 
                 // Add Album so we know what to monitor
-                if (report.AlbumMusicBrainzId.IsNotNullOrWhiteSpace() && artistsToAdd.Any(s => s.Metadata.Value.ForeignArtistId == report.ArtistMusicBrainzId) && importList.ShouldMonitor)
+                if (report.AlbumMusicBrainzId.IsNotNullOrWhiteSpace() && artistsToAdd.Any(s => s.Metadata.Value.ForeignArtistId == report.ArtistMusicBrainzId) && importList.ShouldMonitor == ImportListMonitorType.SpecificAlbum)
                 {
                     artistsToAdd.Find(s => s.Metadata.Value.ForeignArtistId == report.ArtistMusicBrainzId).AddOptions.AlbumsToMonitor.Add(report.AlbumMusicBrainzId);
                 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Currently when an import list returns albums (instead of artists) and "monitor" is selected in the import list, only the albums actually in the import list are monitored.  Other albums that match the metadata profile for the same artist are not monitored.

As requested by a user on Discord (and seems like a good idea to me) this allows you to choose whether to monitor just the album in the import list or every album by an artist appearing on the list.

#### Todos
- [x] Tests
