### PR TITLE
Some fixes from #838

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/TrackImport/Identification/IdentificationServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/TrackImport/Identification/IdentificationServiceFixture.cs
@@ -50,6 +50,7 @@ namespace NzbDrone.Core.Test.MediaFiles.TrackImport.Identification
 
             _artistService = Mocker.Resolve<ArtistService>();
             Mocker.SetConstant<IArtistService>(_artistService);
+            Mocker.SetConstant<IArtistMetadataService>(Mocker.Resolve<ArtistMetadataService>());
             Mocker.SetConstant<IAlbumService>(Mocker.Resolve<AlbumService>());
             Mocker.SetConstant<IReleaseService>(Mocker.Resolve<ReleaseService>());
             Mocker.SetConstant<ITrackService>(Mocker.Resolve<TrackService>());

--- a/src/NzbDrone.Core.Test/MusicTests/ArtistMetadataRepositoryTests/ArtistMetadataRepositoryFixture.cs
+++ b/src/NzbDrone.Core.Test/MusicTests/ArtistMetadataRepositoryTests/ArtistMetadataRepositoryFixture.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Music;
+using NzbDrone.Common.Extensions;
+using System.Linq;
+
+namespace NzbDrone.Core.Test.MusicTests.ArtistRepositoryTests
+{
+    [TestFixture]
+
+    public class ArtistMetadataRepositoryFixture : DbTest<ArtistMetadataRepository, ArtistMetadata>
+    {
+        private ArtistMetadataRepository _artistMetadataRepo;
+        private List<ArtistMetadata> _metadataList;
+
+        [SetUp]
+        public void Setup()
+        {
+            _artistMetadataRepo = Mocker.Resolve<ArtistMetadataRepository>();
+            _metadataList = Builder<ArtistMetadata>.CreateListOfSize(10).BuildList();
+        }
+                 
+        [Test]
+        public void upsert_many_should_insert_list_of_new()
+        {
+            var updated = _artistMetadataRepo.UpsertMany(_metadataList);
+            AllStoredModels.Should().HaveCount(_metadataList.Count);
+            updated.Should().BeTrue();
+        }
+                 
+        [Test]
+        public void upsert_many_should_upsert_existing_with_id_0()
+        {
+            var _clone = _metadataList.JsonClone();
+            var updated = _artistMetadataRepo.UpsertMany(_clone);
+
+            updated.Should().BeTrue();
+            AllStoredModels.Should().HaveCount(_metadataList.Count);
+
+            updated = _artistMetadataRepo.UpsertMany(_metadataList);
+            updated.Should().BeFalse();
+            AllStoredModels.Should().HaveCount(_metadataList.Count);
+        }
+
+        [Test]
+        public void upsert_many_should_upsert_mixed_list_of_old_and_new()
+        {
+            var _clone = _metadataList.Take(5).ToList().JsonClone();
+            var updated = _artistMetadataRepo.UpsertMany(_clone);
+
+            updated.Should().BeTrue();
+            AllStoredModels.Should().HaveCount(_clone.Count);
+
+            updated = _artistMetadataRepo.UpsertMany(_metadataList);
+            updated.Should().BeTrue();
+            AllStoredModels.Should().HaveCount(_metadataList.Count);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/MusicTests/RefreshAlbumServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MusicTests/RefreshAlbumServiceFixture.cs
@@ -62,11 +62,7 @@ namespace NzbDrone.Core.Test.MusicTests
                 .Setup(s => s.GetReleasesForRefresh(album1.Id, It.IsAny<IEnumerable<string>>()))
                 .Returns(new List<AlbumRelease> { release });
 
-            Mocker.GetMock<IArtistMetadataRepository>()
-                .Setup(s => s.FindById(It.IsAny<List<string>>()))
-                .Returns(new List<ArtistMetadata>());
-
-            Mocker.GetMock<IArtistMetadataRepository>()
+            Mocker.GetMock<IArtistMetadataService>()
                 .Setup(s => s.UpsertMany(It.IsAny<List<ArtistMetadata> >()))
                 .Returns(true);
 

--- a/src/NzbDrone.Core.Test/MusicTests/RefreshArtistServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MusicTests/RefreshArtistServiceFixture.cs
@@ -106,6 +106,7 @@ namespace NzbDrone.Core.Test.MusicTests
             Subject.Execute(new RefreshArtistCommand(_artist.Id));
 
             VerifyEventNotPublished<ArtistUpdatedEvent>();
+            VerifyEventPublished<ArtistRefreshCompleteEvent>();
         }
 
         [Test]
@@ -125,6 +126,7 @@ namespace NzbDrone.Core.Test.MusicTests
             Subject.Execute(new RefreshArtistCommand(_artist.Id));
 
             VerifyEventPublished<ArtistUpdatedEvent>();
+            VerifyEventPublished<ArtistRefreshCompleteEvent>();
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -280,6 +280,7 @@
     <Compile Include="MusicTests\AlbumMonitoredServiceTests\AlbumMonitoredServiceFixture.cs" />
     <Compile Include="MusicTests\AlbumRepositoryTests\AlbumRepositoryFixture.cs" />
     <Compile Include="MusicTests\ArtistRepositoryTests\ArtistRepositoryFixture.cs" />
+    <Compile Include="MusicTests\ArtistMetadataRepositoryTests\ArtistMetadataRepositoryFixture.cs" />
     <Compile Include="MusicTests\ArtistServiceTests\UpdateMultipleArtistFixture.cs" />
     <Compile Include="MusicTests\ArtistServiceTests\FindByNameInexactFixture.cs" />
     <Compile Include="MusicTests\RefreshAlbumServiceFixture.cs" />

--- a/src/NzbDrone.Core/Music/AddArtistService.cs
+++ b/src/NzbDrone.Core/Music/AddArtistService.cs
@@ -10,7 +10,6 @@ using NzbDrone.Core.Exceptions;
 using NzbDrone.Core.MetadataSource;
 using NzbDrone.Core.Organizer;
 using NzbDrone.Core.Parser;
-using NzbDrone.Core.MetadataSource.SkyHook;
 
 namespace NzbDrone.Core.Music
 {
@@ -23,21 +22,21 @@ namespace NzbDrone.Core.Music
     public class AddArtistService : IAddArtistService
     {
         private readonly IArtistService _artistService;
-        private readonly IArtistMetadataRepository _artistMetadataRepository;
+        private readonly IArtistMetadataService _artistMetadataService;
         private readonly IProvideArtistInfo _artistInfo;
         private readonly IBuildFileNames _fileNameBuilder;
         private readonly IAddArtistValidator _addArtistValidator;
         private readonly Logger _logger;
 
         public AddArtistService(IArtistService artistService,
-                                IArtistMetadataRepository artistMetadataRepository,
+                                IArtistMetadataService artistMetadataService,
                                 IProvideArtistInfo artistInfo,
                                 IBuildFileNames fileNameBuilder,
                                 IAddArtistValidator addArtistValidator,
                                 Logger logger)
         {
             _artistService = artistService;
-            _artistMetadataRepository = artistMetadataRepository;
+            _artistMetadataService = artistMetadataService;
             _artistInfo = artistInfo;
             _fileNameBuilder = fileNameBuilder;
             _addArtistValidator = addArtistValidator;
@@ -54,7 +53,7 @@ namespace NzbDrone.Core.Music
             _logger.Info("Adding Artist {0} Path: [{1}]", newArtist, newArtist.Path);
 
             // add metadata
-            _artistMetadataRepository.Upsert(newArtist.Metadata.Value);
+            _artistMetadataService.Upsert(newArtist.Metadata.Value);
             newArtist.ArtistMetadataId = newArtist.Metadata.Value.Id;
 
             // add the artist itself
@@ -87,7 +86,7 @@ namespace NzbDrone.Core.Music
             }
 
             // add metadata
-            _artistMetadataRepository.UpsertMany(artistsToAdd.Select(x => x.Metadata.Value).ToList());
+            _artistMetadataService.UpsertMany(artistsToAdd.Select(x => x.Metadata.Value).ToList());
             artistsToAdd.ForEach(x => x.ArtistMetadataId = x.Metadata.Value.Id);
             
             return _artistService.AddArtists(artistsToAdd);

--- a/src/NzbDrone.Core/Music/ArtistMetadataService.cs
+++ b/src/NzbDrone.Core/Music/ArtistMetadataService.cs
@@ -1,0 +1,34 @@
+using NLog;
+using System.Collections.Generic;
+
+namespace NzbDrone.Core.Music
+{
+    public interface IArtistMetadataService
+    {
+        bool Upsert(ArtistMetadata artist);
+        bool UpsertMany(List<ArtistMetadata> artists);
+    }
+
+    public class ArtistMetadataService : IArtistMetadataService
+    {
+        private readonly IArtistMetadataRepository _artistMetadataRepository;
+        private readonly Logger _logger;
+
+        public ArtistMetadataService(IArtistMetadataRepository artistMetadataRepository,
+                                     Logger logger)
+        {
+            _artistMetadataRepository = artistMetadataRepository;
+            _logger = logger;
+        }
+
+        public bool Upsert(ArtistMetadata artist)
+        {
+            return _artistMetadataRepository.UpsertMany(new List<ArtistMetadata> { artist });
+        }
+
+        public bool UpsertMany(List<ArtistMetadata> artists)
+        {
+            return _artistMetadataRepository.UpsertMany(artists);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Music/RefreshAlbumReleaseService.cs
+++ b/src/NzbDrone.Core/Music/RefreshAlbumReleaseService.cs
@@ -22,12 +22,12 @@ namespace NzbDrone.Core.Music
         private readonly Logger _logger;
 
         public RefreshAlbumReleaseService(IReleaseService releaseService,
-                                          IArtistMetadataRepository artistMetadataRepository,
+                                          IArtistMetadataService artistMetadataService,
                                           IRefreshTrackService refreshTrackService,
                                           ITrackService trackService,
                                           IMediaFileService mediaFileService,
                                           Logger logger)
-        : base(logger, artistMetadataRepository)
+        : base(logger, artistMetadataService)
         {
             _releaseService = releaseService;
             _trackService = trackService;

--- a/src/NzbDrone.Core/Music/RefreshAlbumService.cs
+++ b/src/NzbDrone.Core/Music/RefreshAlbumService.cs
@@ -38,7 +38,7 @@ namespace NzbDrone.Core.Music
         public RefreshAlbumService(IAlbumService albumService,
                                    IArtistService artistService,
                                    IAddArtistService addArtistService,
-                                   IArtistMetadataRepository artistMetadataRepository,
+                                   IArtistMetadataService artistMetadataService,
                                    IReleaseService releaseService,
                                    IProvideAlbumInfo albumInfo,
                                    IRefreshAlbumReleaseService refreshAlbumReleaseService,
@@ -47,7 +47,7 @@ namespace NzbDrone.Core.Music
                                    IEventAggregator eventAggregator,
                                    ICheckIfAlbumShouldBeRefreshed checkIfAlbumShouldBeRefreshed,
                                    Logger logger)
-        : base(logger, artistMetadataRepository)
+        : base(logger, artistMetadataService)
         {
             _albumService = albumService;
             _artistService = artistService;

--- a/src/NzbDrone.Core/Music/RefreshArtistService.cs
+++ b/src/NzbDrone.Core/Music/RefreshArtistService.cs
@@ -23,7 +23,6 @@ namespace NzbDrone.Core.Music
     {
         private readonly IProvideArtistInfo _artistInfo;
         private readonly IArtistService _artistService;
-        private readonly IArtistMetadataRepository _artistMetadataRepository;
         private readonly IAlbumService _albumService;
         private readonly IRefreshAlbumService _refreshAlbumService;
         private readonly IEventAggregator _eventAggregator;
@@ -37,7 +36,7 @@ namespace NzbDrone.Core.Music
 
         public RefreshArtistService(IProvideArtistInfo artistInfo,
                                     IArtistService artistService,
-                                    IArtistMetadataRepository artistMetadataRepository,
+                                    IArtistMetadataService artistMetadataService,
                                     IAlbumService albumService,
                                     IRefreshAlbumService refreshAlbumService,
                                     IEventAggregator eventAggregator,
@@ -48,11 +47,10 @@ namespace NzbDrone.Core.Music
                                     IConfigService configService,
                                     IImportListExclusionService importListExclusionService,
                                     Logger logger)
-        : base(logger, artistMetadataRepository)
+        : base(logger, artistMetadataService)
         {
             _artistInfo = artistInfo;
             _artistService = artistService;
-            _artistMetadataRepository = artistMetadataRepository;
             _albumService = albumService;
             _refreshAlbumService = refreshAlbumService;
             _eventAggregator = eventAggregator;

--- a/src/NzbDrone.Core/Music/RefreshArtistService.cs
+++ b/src/NzbDrone.Core/Music/RefreshArtistService.cs
@@ -245,7 +245,7 @@ namespace NzbDrone.Core.Music
             _eventAggregator.PublishEvent(new ArtistUpdatedEvent(entity));
         }
 
-        protected virtual void PublishRefreshCompleteEvent(Artist entity)
+        protected override void PublishRefreshCompleteEvent(Artist entity)
         {
             _eventAggregator.PublishEvent(new ArtistRefreshCompleteEvent(entity));
         }

--- a/src/NzbDrone.Core/Music/RefreshEntityServiceBase.cs
+++ b/src/NzbDrone.Core/Music/RefreshEntityServiceBase.cs
@@ -9,13 +9,13 @@ namespace NzbDrone.Core.Music
     public abstract class RefreshEntityServiceBase<Entity, Child>
     {
         private readonly Logger _logger;
-        private readonly IArtistMetadataRepository _artistMetadataRepository;
+        private readonly IArtistMetadataService _artistMetadataService;
 
         public RefreshEntityServiceBase(Logger logger,
-                                        IArtistMetadataRepository artistMetadataRepository)
+                                        IArtistMetadataService artistMetadataService)
         {
             _logger = logger;
-            _artistMetadataRepository = artistMetadataRepository;
+            _artistMetadataService = artistMetadataService;
         }
         
         public enum UpdateResult
@@ -199,7 +199,7 @@ namespace NzbDrone.Core.Music
         public UpdateResult UpdateArtistMetadata(List<ArtistMetadata> data)
         {
             var remoteMetadata = data.DistinctBy(x => x.ForeignArtistId).ToList();
-            var updated = _artistMetadataRepository.UpsertMany(data);
+            var updated = _artistMetadataService.UpsertMany(data);
             return updated ? UpdateResult.UpdateTags : UpdateResult.None;
         }
 

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -884,6 +884,7 @@
     <Compile Include="Music\AlbumService.cs" />
     <Compile Include="Music\ArtistRepository.cs" />
     <Compile Include="Music\ArtistMetadataRepository.cs" />
+    <Compile Include="Music\ArtistMetadataService.cs" />
     <Compile Include="Music\ArtistService.cs" />
     <Compile Include="Music\Commands\RefreshArtistCommand.cs" />
     <Compile Include="Music\Events\AlbumAddedEvent.cs" />

--- a/src/NzbDrone.Core/Parser/FingerprintingService.cs
+++ b/src/NzbDrone.Core/Parser/FingerprintingService.cs
@@ -362,6 +362,7 @@ namespace NzbDrone.Core.Parser
             httpRequest.Headers.Add("Content-Encoding", "gzip");
             httpRequest.Headers.ContentType = "application/x-www-form-urlencoded";
             httpRequest.SuppressHttpError = true;
+            httpRequest.RequestTimeout = TimeSpan.FromSeconds(5);
 
             HttpResponse<LookupResponse> httpResponse;
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
#838 introduced two issues:
1. Removing an artist and adding again caused an error.
1. Media covers weren't refreshing.

The first is fixed by introducing an `ArtistMetadataService` to prevent using inappropriate methods from `BasicRepository` (needed to use `UpsertMany` and not `Upsert`).  Also added tests for ArtistMetadataRepository to make sure that works properly.

The second is fixed by `virtual -> override`.

Also, add a timeout to AcoustID API - it was hanging earlier making tests really slow to run.

#### Todos
- [x] Tests
