### PR TITLE
Fix mediacover existing check

### DIFF
--- a/src/NzbDrone.Common/Http/HttpResponse.cs
+++ b/src/NzbDrone.Common/Http/HttpResponse.cs
@@ -53,6 +53,7 @@ namespace NzbDrone.Common.Http
 
         public bool HasHttpRedirect => StatusCode == HttpStatusCode.Moved ||
                                        StatusCode == HttpStatusCode.MovedPermanently ||
+                                       StatusCode == HttpStatusCode.TemporaryRedirect ||
                                        StatusCode == HttpStatusCode.Found;
 
         public string[] GetCookieHeaders()

--- a/src/NzbDrone.Core.Test/MediaCoverTests/CoverExistsSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaCoverTests/CoverExistsSpecificationFixture.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.Test.MediaCoverTests
         }
 
         [Test]
-        public void should_return_false_if_file_exists_but_diffrent_date()
+        public void should_return_false_if_file_exists_but_different_date()
         {
             GivenFileExistsOnDisk(DateTime.Now);
 
@@ -35,7 +35,7 @@ namespace NzbDrone.Core.Test.MediaCoverTests
         }
 
         [Test]
-        public void should_return_ture_if_file_exists_and_same_date_but_no_length_header()
+        public void should_return_true_if_file_exists_and_same_date_but_no_length_header()
         {
             var givenDate = DateTime.Now;
 
@@ -45,12 +45,31 @@ namespace NzbDrone.Core.Test.MediaCoverTests
         }
 
         [Test]
-        public void should_return_ture_if_file_exists_and_date_header_is_null_but_has_length_header()
+        public void should_return_false_if_file_exists_and_same_date_but_length_header_different()
         {
+            var givenDate = DateTime.Now;
 
+            GivenFileExistsOnDisk(givenDate);
+
+            Subject.AlreadyExists(givenDate, 999, "c:\\file.exe").Should().BeFalse();
+        }
+
+
+        [Test]
+        public void should_return_true_if_file_exists_and_date_header_is_null_but_has_length_header()
+        {
             GivenFileExistsOnDisk(DateTime.Now);
 
             Subject.AlreadyExists(null, 1000, "c:\\file.exe").Should().BeTrue();
         }
+
+        [Test]
+        public void should_return_true_if_file_exists_and_date_header_is_different_but_length_header_the_same()
+        {
+            GivenFileExistsOnDisk(DateTime.Now.AddDays(-1));
+
+            Subject.AlreadyExists(DateTime.Now, 1000, "c:\\file.exe").Should().BeTrue();
+        }
+
     }
 }

--- a/src/NzbDrone.Core.Test/MediaCoverTests/MediaCoverServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaCoverTests/MediaCoverServiceFixture.cs
@@ -100,7 +100,7 @@ namespace NzbDrone.Core.Test.MediaCoverTests
         public void should_resize_covers_if_main_downloaded()
         {
             Mocker.GetMock<ICoverExistsSpecification>()
-                  .Setup(v => v.AlreadyExists(It.IsAny<DateTime>(), It.IsAny<string>()))
+                  .Setup(v => v.AlreadyExists(It.IsAny<DateTime?>(), It.IsAny<long?>(), It.IsAny<string>()))
                   .Returns(false);
 
             Mocker.GetMock<IAlbumService>()
@@ -121,7 +121,7 @@ namespace NzbDrone.Core.Test.MediaCoverTests
         public void should_resize_covers_if_missing()
         {
             Mocker.GetMock<ICoverExistsSpecification>()
-                  .Setup(v => v.AlreadyExists(It.IsAny<DateTime>(), It.IsAny<string>()))
+                  .Setup(v => v.AlreadyExists(It.IsAny<DateTime?>(), It.IsAny<long?>(), It.IsAny<string>()))
                   .Returns(true);
 
             Mocker.GetMock<IAlbumService>()
@@ -142,7 +142,7 @@ namespace NzbDrone.Core.Test.MediaCoverTests
         public void should_not_resize_covers_if_exists()
         {
             Mocker.GetMock<ICoverExistsSpecification>()
-                  .Setup(v => v.AlreadyExists(It.IsAny<DateTime>(), It.IsAny<string>()))
+                  .Setup(v => v.AlreadyExists(It.IsAny<DateTime?>(), It.IsAny<long?>(), It.IsAny<string>()))
                   .Returns(true);
 
             Mocker.GetMock<IDiskProvider>()
@@ -167,7 +167,7 @@ namespace NzbDrone.Core.Test.MediaCoverTests
         public void should_resize_covers_if_existing_is_empty()
         {
             Mocker.GetMock<ICoverExistsSpecification>()
-                  .Setup(v => v.AlreadyExists(It.IsAny<DateTime>(), It.IsAny<string>()))
+                  .Setup(v => v.AlreadyExists(It.IsAny<DateTime?>(), It.IsAny<long?>(), It.IsAny<string>()))
                   .Returns(true);
 
             Mocker.GetMock<IDiskProvider>()
@@ -192,7 +192,7 @@ namespace NzbDrone.Core.Test.MediaCoverTests
         public void should_log_error_if_resize_failed()
         {
             Mocker.GetMock<ICoverExistsSpecification>()
-                  .Setup(v => v.AlreadyExists(It.IsAny<DateTime>(), It.IsAny<string>()))
+                  .Setup(v => v.AlreadyExists(It.IsAny<DateTime?>(), It.IsAny<long?>(), It.IsAny<string>()))
                   .Returns(true);
 
             Mocker.GetMock<IDiskProvider>()

--- a/src/NzbDrone.Core/MediaCover/CoverAlreadyExistsSpecification.cs
+++ b/src/NzbDrone.Core/MediaCover/CoverAlreadyExistsSpecification.cs
@@ -1,11 +1,12 @@
-﻿using System;
+using System;
 using NzbDrone.Common.Disk;
+using NzbDrone.Common.Http;
 
 namespace NzbDrone.Core.MediaCover
 {
     public interface ICoverExistsSpecification
     {
-        bool AlreadyExists(DateTime serverModifiedDate, string localPath);
+        bool AlreadyExists(DateTime? serverModifiedDate, long? serverContentLength, string localPath);
     }
 
     public class CoverAlreadyExistsSpecification : ICoverExistsSpecification
@@ -17,16 +18,28 @@ namespace NzbDrone.Core.MediaCover
             _diskProvider = diskProvider;
         }
 
-        public bool AlreadyExists(DateTime lastModifiedDateServer, string localPath)
+        public bool AlreadyExists(DateTime? serverModifiedDate, long? serverContentLength, string localPath)
         {
             if (!_diskProvider.FileExists(localPath))
             {
                 return false;
             }
 
-            DateTime? lastModifiedLocal = _diskProvider.FileGetLastWrite(localPath);
+            if (serverModifiedDate.HasValue)
+            {
+                DateTime? lastModifiedLocal = _diskProvider.FileGetLastWrite(localPath);
 
-            return lastModifiedLocal.Value.ToUniversalTime() == lastModifiedDateServer.ToUniversalTime();
+                return lastModifiedLocal.Value.ToUniversalTime() == serverModifiedDate.Value.ToUniversalTime();
+            }
+
+            if (serverContentLength.HasValue && serverContentLength.Value > 0)
+            {
+                var fileSize = _diskProvider.GetFileSize(localPath);
+
+                return fileSize == serverContentLength;
+            }
+
+            return false;
         }
     }
 }

--- a/src/NzbDrone.Core/MediaCover/CoverAlreadyExistsSpecification.cs
+++ b/src/NzbDrone.Core/MediaCover/CoverAlreadyExistsSpecification.cs
@@ -1,6 +1,5 @@
 using System;
 using NzbDrone.Common.Disk;
-using NzbDrone.Common.Http;
 
 namespace NzbDrone.Core.MediaCover
 {
@@ -25,18 +24,18 @@ namespace NzbDrone.Core.MediaCover
                 return false;
             }
 
-            if (serverModifiedDate.HasValue)
-            {
-                DateTime? lastModifiedLocal = _diskProvider.FileGetLastWrite(localPath);
-
-                return lastModifiedLocal.Value.ToUniversalTime() == serverModifiedDate.Value.ToUniversalTime();
-            }
-
             if (serverContentLength.HasValue && serverContentLength.Value > 0)
             {
                 var fileSize = _diskProvider.GetFileSize(localPath);
 
                 return fileSize == serverContentLength;
+            }
+
+            if (serverModifiedDate.HasValue)
+            {
+                DateTime? lastModifiedLocal = _diskProvider.FileGetLastWrite(localPath);
+
+                return lastModifiedLocal.Value.ToUniversalTime() == serverModifiedDate.Value.ToUniversalTime();
             }
 
             return false;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This implements 2 things:
- Follow 307 Temp Redirects when we allow redirect in httpClient
- Look for ContentLength Headers as a backup if Last Modified does not exist. (maybe we want to change this to check if the last modify check fails?)

#### Todos
- [x] Tests
- [ ] Documentation

#### Issues Fixed or Closed by this PR

* Fixes #850 
