### PR TITLE
Fixed: Don't force images to JPG and fix Kodi album art filenames

### DIFF
--- a/src/NzbDrone.Core.Test/MediaCoverTests/MediaCoverServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaCoverTests/MediaCoverServiceFixture.cs
@@ -41,12 +41,17 @@ namespace NzbDrone.Core.Test.MediaCoverTests
             Mocker.GetMock<IHttpClient>().Setup(c => c.Head(It.IsAny<HttpRequest>())).Returns(_httpResponse);
         }
 
-        [Test]
-        public void should_convert_cover_urls_to_local()
+        [TestCase(".png")]
+        [TestCase(".jpg")]
+        public void should_convert_cover_urls_to_local(string extension)
         {
             var covers = new List<MediaCover.MediaCover>
                 {
-                    new MediaCover.MediaCover {CoverType = MediaCoverTypes.Banner}
+                    new MediaCover.MediaCover
+                    {
+                        Url = "http://dummy.com/test" + extension,
+                        CoverType = MediaCoverTypes.Banner
+                    }
                 };
 
             Mocker.GetMock<IDiskProvider>().Setup(c => c.FileGetLastWrite(It.IsAny<string>()))
@@ -58,15 +63,20 @@ namespace NzbDrone.Core.Test.MediaCoverTests
             Subject.ConvertToLocalUrls(12, MediaCoverEntity.Artist, covers);
 
 
-            covers.Single().Url.Should().Be("/MediaCover/12/banner.jpg?lastWrite=1234");
+            covers.Single().Url.Should().Be("/MediaCover/12/banner" + extension + "?lastWrite=1234");
         }
 
-        [Test]
-        public void should_convert_album_cover_urls_to_local()
+        [TestCase(".png")]
+        [TestCase(".jpg")]
+        public void should_convert_album_cover_urls_to_local(string extension)
         {
             var covers = new List<MediaCover.MediaCover>
                 {
-                    new MediaCover.MediaCover {CoverType = MediaCoverTypes.Disc}
+                    new MediaCover.MediaCover
+                    {
+                        Url = "http://dummy.com/test" + extension,
+                        CoverType = MediaCoverTypes.Disc
+                    }
                 };
 
             Mocker.GetMock<IDiskProvider>().Setup(c => c.FileGetLastWrite(It.IsAny<string>()))
@@ -78,22 +88,27 @@ namespace NzbDrone.Core.Test.MediaCoverTests
             Subject.ConvertToLocalUrls(6, MediaCoverEntity.Album, covers);
 
 
-            covers.Single().Url.Should().Be("/MediaCover/Albums/6/disc.jpg?lastWrite=1234");
+            covers.Single().Url.Should().Be("/MediaCover/Albums/6/disc" + extension + "?lastWrite=1234");
         }
 
-        [Test]
-        public void should_convert_media_urls_to_local_without_time_if_file_doesnt_exist()
+        [TestCase(".png")]
+        [TestCase(".jpg")]
+        public void should_convert_media_urls_to_local_without_time_if_file_doesnt_exist(string extension)
         {
             var covers = new List<MediaCover.MediaCover>
                 {
-                    new MediaCover.MediaCover {CoverType = MediaCoverTypes.Banner}
+                    new MediaCover.MediaCover
+                    {
+                        Url = "http://dummy.com/test" + extension,
+                        CoverType = MediaCoverTypes.Banner
+                    }
                 };
 
 
             Subject.ConvertToLocalUrls(12, MediaCoverEntity.Artist, covers);
 
 
-            covers.Single().Url.Should().Be("/MediaCover/12/banner.jpg");
+            covers.Single().Url.Should().Be("/MediaCover/12/banner" + extension);
         }
 
         [Test]

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Roksbox/RoksboxMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Roksbox/RoksboxMetadata.cs
@@ -165,7 +165,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Roksbox
                 return new List<ImageFileResult>(); ;
             }
 
-            var source = _mediaCoverService.GetCoverPath(artist.Id, MediaCoverEntity.Artist, image.CoverType);
+            var source = _mediaCoverService.GetCoverPath(artist.Id, MediaCoverEntity.Artist, image.CoverType, image.Extension);
             var destination = Path.GetFileName(artist.Path) + Path.GetExtension(source);
 
             return new List<ImageFileResult>{ new ImageFileResult(destination, source) };

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -205,11 +205,11 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
         {
             foreach (var image in artist.Metadata.Value.Images)
             {
-                var source = _mediaCoverService.GetCoverPath(artist.Id, MediaCoverEntity.Artist, image.CoverType);
-                var destination = image.CoverType.ToString().ToLowerInvariant() + Path.GetExtension(image.Url);
+                var source = _mediaCoverService.GetCoverPath(artist.Id, MediaCoverEntity.Artist, image.CoverType, image.Extension);
+                var destination = image.CoverType.ToString().ToLowerInvariant() + image.Extension;
                 if (image.CoverType == MediaCoverTypes.Poster)
                 {
-                    destination = "folder" + Path.GetExtension(image.Url);
+                    destination = "folder" + image.Extension;
                 }
 
                 yield return new ImageFileResult(destination, source);
@@ -222,7 +222,21 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
             {
                 // TODO: Make Source fallback to URL if local does not exist
                 // var source = _mediaCoverService.GetCoverPath(album.ArtistId, image.CoverType, null, album.Id);
-                var destination = Path.Combine(albumPath, image.CoverType.ToString().ToLowerInvariant() + Path.GetExtension(image.Url));
+                string filename;
+
+                switch(image.CoverType)
+                {
+                    case MediaCoverTypes.Cover:
+                        filename = "folder";
+                        break;
+                    case MediaCoverTypes.Disc:
+                        filename = "discart";
+                        break;
+                    default:
+                        continue;
+                }
+
+                var destination = Path.Combine(albumPath, filename + image.Extension);
 
                 yield return new ImageFileResult(destination, image.Url);
             }

--- a/src/NzbDrone.Core/MediaCover/MediaCover.cs
+++ b/src/NzbDrone.Core/MediaCover/MediaCover.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using NzbDrone.Core.Datastore;
 
 namespace NzbDrone.Core.MediaCover
@@ -26,6 +27,7 @@ namespace NzbDrone.Core.MediaCover
     {
         public MediaCoverTypes CoverType { get; set; }
         public string Url { get; set; }
+        public string Extension => Path.GetExtension(Url);
 
         public MediaCover()
         {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- Maintain original image format when downloading/resizing - don't force to `.jpg`
- Fix KODI album art names (`folder.jpg` and `discart.jpg`)

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR

* Fixes #872 
