### PR TITLE
Fixed: Use correct ID to search for Albums

### DIFF
--- a/src/NzbDrone.Core/Music/AlbumService.cs
+++ b/src/NzbDrone.Core/Music/AlbumService.cs
@@ -19,8 +19,8 @@ namespace NzbDrone.Core.Music
         List<Album> GetAlbumsForRefresh(int artistMetadataId, IEnumerable<string> foreignIds);
         Album AddAlbum(Album newAlbum);
         Album FindById(string foreignId);
-        Album FindByTitle(int artistId, string title);
-        Album FindByTitleInexact(int artistId, string title);
+        Album FindByTitle(int artistMetadataId, string title);
+        Album FindByTitleInexact(int artistMetadataId, string title);
         List<Album> GetCandidates(int artistId, string title);
         void DeleteAlbum(int albumId, bool deleteFiles);
         List<Album> GetAllAlbums();
@@ -76,9 +76,9 @@ namespace NzbDrone.Core.Music
             return _albumRepository.FindById(lidarrId);
         }
 
-        public Album FindByTitle(int artistId, string title)
+        public Album FindByTitle(int artistMetadataId, string title)
         {
-            return _albumRepository.FindByTitle(artistId, title);
+            return _albumRepository.FindByTitle(artistMetadataId, title);
         }
 
         private List<Tuple<Func<Album, string, double>, string>> AlbumScoringFunctions(string title, string cleanTitle)

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -161,7 +161,7 @@ namespace NzbDrone.Core.Parser
             if (albumInfo == null)
             {
                 _logger.Debug("Trying inexact album match for {0}", parsedAlbumInfo.AlbumTitle);
-                albumInfo = _albumService.FindByTitleInexact(artist.Id, parsedAlbumInfo.AlbumTitle);
+                albumInfo = _albumService.FindByTitleInexact(artist.ArtistMetadataId, parsedAlbumInfo.AlbumTitle);
             }
 
             if (albumInfo != null)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The parser was giving the artist id not the artist metadata id.  It should definitely be using the metadata id: https://github.com/lidarr/Lidarr/blob/9ccef35f8f20746e0fee50564f7686c984372549/src/NzbDrone.Core/Music/AlbumService.cs#L102