### PR TITLE
Fixed: Embedding album art on import

### DIFF
--- a/src/NzbDrone.Core.Test/MediaCoverTests/MediaCoverServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaCoverTests/MediaCoverServiceFixture.cs
@@ -68,6 +68,30 @@ namespace NzbDrone.Core.Test.MediaCoverTests
 
         [TestCase(".png")]
         [TestCase(".jpg")]
+        public void convert_to_local_url_should_not_change_extension(string extension)
+        {
+            var covers = new List<MediaCover.MediaCover>
+                {
+                    new MediaCover.MediaCover
+                    {
+                        Url = "http://dummy.com/test" + extension,
+                        CoverType = MediaCoverTypes.Banner
+                    }
+                };
+
+            Mocker.GetMock<IDiskProvider>().Setup(c => c.FileGetLastWrite(It.IsAny<string>()))
+                  .Returns(new DateTime(1234));
+
+            Mocker.GetMock<IDiskProvider>().Setup(c => c.FileExists(It.IsAny<string>()))
+                  .Returns(true);
+
+            Subject.ConvertToLocalUrls(12, MediaCoverEntity.Artist, covers);
+
+            covers.Single().Extension.Should().Be(extension);
+        }
+
+        [TestCase(".png")]
+        [TestCase(".jpg")]
         public void should_convert_album_cover_urls_to_local(string extension)
         {
             var covers = new List<MediaCover.MediaCover>

--- a/src/NzbDrone.Core/MediaCover/MediaCover.cs
+++ b/src/NzbDrone.Core/MediaCover/MediaCover.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Datastore;
 
 namespace NzbDrone.Core.MediaCover
@@ -25,9 +26,25 @@ namespace NzbDrone.Core.MediaCover
 
     public class MediaCover : IEmbeddedDocument
     {
+        private string _url;
+        public string Url
+        {
+            get
+            {
+                return _url;
+            }
+            set
+            {
+                _url = value;
+                if (Extension.IsNullOrWhiteSpace())
+                {
+                    Extension = Path.GetExtension(value);
+                }
+            }
+        }
+
         public MediaCoverTypes CoverType { get; set; }
-        public string Url { get; set; }
-        public string Extension => Path.GetExtension(Url);
+        public string Extension { get; private set; }
 
         public MediaCover()
         {

--- a/src/NzbDrone.Core/MediaFiles/AudioTagService.cs
+++ b/src/NzbDrone.Core/MediaFiles/AudioTagService.cs
@@ -86,6 +86,7 @@ namespace NzbDrone.Core.MediaFiles
             if (cover != null)
             {
                 imageFile = _mediaCoverService.GetCoverPath(album.Id, MediaCoverEntity.Album, cover.CoverType, cover.Extension, null);
+                _logger.Trace($"Embedding: {imageFile}");
                 var fileInfo = _diskProvider.GetFileInfo(imageFile);
                 if (fileInfo.Exists)
                 {


### PR DESCRIPTION
## Database Migration
NO

#### Description
On import the album release is adjusted, which triggers an AlbumEditedEvent which in turn converts media cover urls to local urls.  The addition of ?lastWrite=xxx broke the calculation of extensions from the URL.  To fix, only set the extension and don't update the extension if url is changed.

#### Todos
- [x] Tests


#### Issues Fixed or Closed by this PR

* Fixes issue reported on discord
