### PR TITLE
Fixed: Change UI Genre Tag Separator from ", " to " / "

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/AudioTag.cs
+++ b/src/NzbDrone.Core/MediaFiles/AudioTag.cs
@@ -538,7 +538,7 @@ namespace NzbDrone.Core.MediaFiles
 
             if (!Genres.SequenceEqual(other.Genres))
             {
-                output.Add("Genres", Tuple.Create(string.Join(", ", Genres), string.Join(", ", other.Genres)));
+                output.Add("Genres", Tuple.Create(string.Join(" / ", Genres), string.Join(" / ", other.Genres)));
             }
 
             if (ImageSize != other.ImageSize)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
For MP3's, the official separator is " / " and this also works for FLAC.  Change the UI separator to match the way the tags are written.
