### PR TITLE
Fixed: Refreshing artist/album details shows 404 until store loads

### DIFF
--- a/frontend/src/Artist/Details/ArtistDetails.css
+++ b/frontend/src/Artist/Details/ArtistDetails.css
@@ -8,6 +8,12 @@
   height: 310px;
 }
 
+.errorMessage {
+  margin-top: 20px;
+  text-align: center;
+  font-size: 20px;
+}
+
 .backdrop {
   position: absolute;
   z-index: -1;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fix up #874 - check that artist store is loaded when loading album/artist details page. 

#### Issues Fixed or Closed by this PR

* Fixes temporary 404 on refreshing artist details page
* Fixes error and failed render refreshing album details page
* Fixes #631  
