### PR TITLE
Allow ImportFailed Downloads to be scanned

### DIFF
--- a/src/NzbDrone.Core/Download/TrackedDownloads/DownloadMonitoringService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/DownloadMonitoringService.cs
@@ -127,7 +127,7 @@ namespace NzbDrone.Core.Download.TrackedDownloads
             try
             {
                 var trackedDownload = _trackedDownloadService.TrackDownload((DownloadClientDefinition)downloadClient.Definition, downloadItem);
-                if (trackedDownload != null && trackedDownload.State == TrackedDownloadStage.Downloading)
+                if (trackedDownload != null && trackedDownload.State == TrackedDownloadStage.Downloading || trackedDownload.State == TrackedDownloadStage.ImportFailed)
                 {
                     _failedDownloadService.Process(trackedDownload);
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This is a simple PR to fix a problem Lidarr will not rescan albums that has been marked as `ImportFailed`. Please refer to the following issue for further #945 information.

#### Issues Fixed or Closed by this PR
#945 