### PR TITLE
Fixed: Null Ref on Album Cache Update in TrackedDownloadService.cs

### DIFF
--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
@@ -51,7 +51,8 @@ namespace NzbDrone.Core.Download.TrackedDownloads
 
         public void UpdateAlbumCache(int albumId)
         {
-            var updateCacheItems = _cache.Values.Where(x => x.RemoteAlbum.Albums.Any(a => a.Id == albumId)).ToList();
+
+            var updateCacheItems = _cache.Values.Where(x => x.RemoteAlbum != null && x.RemoteAlbum.Albums.Any(a => a.Id == albumId)).ToList();
 
             foreach (var item in updateCacheItems)
             {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixes a Null Ref in UpdateAlbumCache


#### Issues Fixed or Closed by this PR
Fixes #886
