### PR TITLE
Fixed: NRE when tagging an album with omitted media

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/AudioTagService.cs
+++ b/src/NzbDrone.Core/MediaFiles/AudioTagService.cs
@@ -107,7 +107,8 @@ namespace NzbDrone.Core.MediaFiles
                 Album = album.Title,
                 Disc = (uint)track.MediumNumber,
                 DiscCount = (uint)release.Media.Count,
-                Media = release.Media[track.MediumNumber - 1].Format,
+                // We may have omitted media so index in the list isn't the same as medium number
+                Media = release.Media.SingleOrDefault(x => x.Number == track.MediumNumber).Format,
                 Date = release.ReleaseDate,
                 Year = (uint)album.ReleaseDate?.Year,
                 OriginalReleaseDate = album.ReleaseDate,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixes NRE if album has a media omitted so index in the list isn't the same as the medium number.

#### Todos
- [x] Tests


#### Issues Fixed or Closed by this PR
* Fixes #958 
