### PR TITLE
Fixed: NRE importing Spotify saved albums / followed artists

### DIFF
--- a/src/NzbDrone.Core.Test/ImportListTests/Spotify/SpotifyFollowedArtistsFixture.cs
+++ b/src/NzbDrone.Core.Test/ImportListTests/Spotify/SpotifyFollowedArtistsFixture.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Core.ImportLists.Spotify;
+using NzbDrone.Core.Test.Framework;
+using SpotifyAPI.Web;
+using SpotifyAPI.Web.Models;
+
+namespace NzbDrone.Core.Test.ImportListTests
+{
+    [TestFixture]
+    public class SpotifyFollowedArtistsFixture : CoreTest<SpotifyFollowedArtists>
+    {
+        // placeholder, we don't use real API
+        private readonly SpotifyWebAPI api = null;
+
+        [Test]
+        public void should_not_throw_if_followed_is_null()
+        {
+            Mocker.GetMock<ISpotifyProxy>().
+                Setup(x => x.GetFollowedArtists(It.IsAny<SpotifyFollowedArtists>(),
+                                                It.IsAny<SpotifyWebAPI>()))
+                .Returns(default(FollowedArtists));
+
+            var result = Subject.Fetch(api);
+
+            result.Should().BeEmpty();
+        }
+
+        [Test]
+        public void should_not_throw_if_followed_artists_is_null()
+        {
+            var followed = new FollowedArtists {
+                Artists = null
+            };
+
+            Mocker.GetMock<ISpotifyProxy>().
+                Setup(x => x.GetFollowedArtists(It.IsAny<SpotifyFollowedArtists>(),
+                                                It.IsAny<SpotifyWebAPI>()))
+                .Returns(followed);
+
+            var result = Subject.Fetch(api);
+
+            result.Should().BeEmpty();
+        }
+
+        [Test]
+        public void should_not_throw_if_followed_artist_items_is_null()
+        {
+            var followed = new FollowedArtists {
+                Artists = new CursorPaging<FullArtist> {
+                    Items = null
+                }
+            };
+
+            Mocker.GetMock<ISpotifyProxy>().
+                Setup(x => x.GetFollowedArtists(It.IsAny<SpotifyFollowedArtists>(),
+                                                It.IsAny<SpotifyWebAPI>()))
+                .Returns(followed);
+
+            var result = Subject.Fetch(api);
+
+            result.Should().BeEmpty();
+            Subject.Fetch(api);
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        public void should_skip_bad_artist_names(string name)
+        {
+            var followed = new FollowedArtists {
+                Artists = new CursorPaging<FullArtist> {
+                    Items = new List<FullArtist> {
+                        new FullArtist {
+                            Name = name
+                        }
+                    }
+                }
+            };
+
+            Mocker.GetMock<ISpotifyProxy>().
+                Setup(x => x.GetFollowedArtists(It.IsAny<SpotifyFollowedArtists>(),
+                                                It.IsAny<SpotifyWebAPI>()))
+                .Returns(followed);
+
+            var result = Subject.Fetch(api);
+
+            result.Should().BeEmpty();
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/ImportListTests/Spotify/SpotifyFollowedArtistsFixture.cs
+++ b/src/NzbDrone.Core.Test/ImportListTests/Spotify/SpotifyFollowedArtistsFixture.cs
@@ -66,6 +66,28 @@ namespace NzbDrone.Core.Test.ImportListTests
         }
 
         [Test]
+        public void should_not_throw_if_artist_is_null()
+        {
+            var followed = new FollowedArtists {
+                Artists = new CursorPaging<FullArtist> {
+                    Items = new List<FullArtist> {
+                        null
+                    }
+                }
+            };
+
+            Mocker.GetMock<ISpotifyProxy>().
+                Setup(x => x.GetFollowedArtists(It.IsAny<SpotifyFollowedArtists>(),
+                                                It.IsAny<SpotifyWebAPI>()))
+                .Returns(followed);
+
+            var result = Subject.Fetch(api);
+
+            result.Should().BeEmpty();
+            Subject.Fetch(api);
+        }
+
+        [Test]
         public void should_parse_followed_artist()
         {
             var followed = new FollowedArtists {

--- a/src/NzbDrone.Core.Test/ImportListTests/Spotify/SpotifyPlaylistFixture.cs
+++ b/src/NzbDrone.Core.Test/ImportListTests/Spotify/SpotifyPlaylistFixture.cs
@@ -1,0 +1,218 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Core.ImportLists.Spotify;
+using NzbDrone.Core.Test.Framework;
+using SpotifyAPI.Web;
+using SpotifyAPI.Web.Models;
+
+namespace NzbDrone.Core.Test.ImportListTests
+{
+    [TestFixture]
+    public class SpotifyPlaylistFixture : CoreTest<SpotifyPlaylist>
+    {
+        // placeholder, we don't use real API
+        private readonly SpotifyWebAPI api = null;
+
+        [Test]
+        public void should_not_throw_if_playlist_tracks_is_null()
+        {
+            Mocker.GetMock<ISpotifyProxy>().
+                Setup(x => x.GetPlaylistTracks(It.IsAny<SpotifyPlaylist>(),
+                                               It.IsAny<SpotifyWebAPI>(),
+                                               It.IsAny<string>(),
+                                               It.IsAny<string>()))
+                .Returns(default(Paging<PlaylistTrack>));
+
+            var result = Subject.Fetch(api, "playlistid");
+
+            result.Should().BeEmpty();
+        }
+
+        [Test]
+        public void should_not_throw_if_playlist_tracks_items_is_null()
+        {
+            var playlistTracks = new Paging<PlaylistTrack> {
+                Items = null
+            };
+
+            Mocker.GetMock<ISpotifyProxy>().
+                Setup(x => x.GetPlaylistTracks(It.IsAny<SpotifyPlaylist>(),
+                                               It.IsAny<SpotifyWebAPI>(),
+                                               It.IsAny<string>(),
+                                               It.IsAny<string>()))
+                .Returns(playlistTracks);
+
+            var result = Subject.Fetch(api, "playlistid");
+
+            result.Should().BeEmpty();
+        }
+
+        [Test]
+        public void should_use_album_artist_when_it_exists()
+        {
+            var playlistTracks = new Paging<PlaylistTrack> {
+                Items = new List<PlaylistTrack> {
+                    new PlaylistTrack {
+                        Track = new FullTrack {
+                            Album = new SimpleAlbum {
+                                Name = "Album",
+                                Artists = new List<SimpleArtist> {
+                                    new SimpleArtist {
+                                        Name = "AlbumArtist"
+                                    }
+                                }
+                            },
+                            Artists = new List<SimpleArtist> {
+                                new SimpleArtist {
+                                    Name = "TrackArtist"
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            Mocker.GetMock<ISpotifyProxy>().
+                Setup(x => x.GetPlaylistTracks(It.IsAny<SpotifyPlaylist>(),
+                                               It.IsAny<SpotifyWebAPI>(),
+                                               It.IsAny<string>(),
+                                               It.IsAny<string>()))
+                .Returns(playlistTracks);
+
+            var result = Subject.Fetch(api, "playlistid");
+
+            result.Should().HaveCount(1);
+            result[0].Artist.Should().Be("AlbumArtist");
+        }
+
+        [Test]
+        public void should_fall_back_to_track_artist_if_album_artist_missing()
+        {
+            var playlistTracks = new Paging<PlaylistTrack> {
+                Items = new List<PlaylistTrack> {
+                    new PlaylistTrack {
+                        Track = new FullTrack {
+                            Album = new SimpleAlbum {
+                                Name = "Album",
+                                Artists = new List<SimpleArtist> {
+                                    new SimpleArtist {
+                                        Name = null
+                                    }
+                                }
+                            },
+                            Artists = new List<SimpleArtist> {
+                                new SimpleArtist {
+                                    Name = "TrackArtist"
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            Mocker.GetMock<ISpotifyProxy>().
+                Setup(x => x.GetPlaylistTracks(It.IsAny<SpotifyPlaylist>(),
+                                               It.IsAny<SpotifyWebAPI>(),
+                                               It.IsAny<string>(),
+                                               It.IsAny<string>()))
+                .Returns(playlistTracks);
+
+            var result = Subject.Fetch(api, "playlistid");
+
+            result.Should().HaveCount(1);
+            result[0].Artist.Should().Be("TrackArtist");
+        }
+
+
+        [TestCase(null, null, "Album")]
+        [TestCase("AlbumArtist", null, null)]
+        [TestCase(null, "TrackArtist", null)]
+        public void should_skip_bad_artist_or_album_names(string albumArtistName, string trackArtistName, string albumName)
+        {
+            var playlistTracks = new Paging<PlaylistTrack> {
+                Items = new List<PlaylistTrack> {
+                    new PlaylistTrack {
+                        Track = new FullTrack {
+                            Album = new SimpleAlbum {
+                                Name = albumName,
+                                Artists = new List<SimpleArtist> {
+                                    new SimpleArtist {
+                                        Name = albumArtistName
+                                    }
+                                }
+                            },
+                            Artists = new List<SimpleArtist> {
+                                new SimpleArtist {
+                                    Name = trackArtistName
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            Mocker.GetMock<ISpotifyProxy>().
+                Setup(x => x.GetPlaylistTracks(It.IsAny<SpotifyPlaylist>(),
+                                               It.IsAny<SpotifyWebAPI>(),
+                                               It.IsAny<string>(),
+                                               It.IsAny<string>()))
+                .Returns(playlistTracks);
+
+            var result = Subject.Fetch(api, "playlistid");
+
+            result.Should().BeEmpty();
+        }
+
+        [Test]
+        public void should_not_throw_if_get_next_page_returns_null()
+        {
+            var playlistTracks = new Paging<PlaylistTrack> {
+                Items = new List<PlaylistTrack> {
+                    new PlaylistTrack {
+                        Track = new FullTrack {
+                            Album = new SimpleAlbum {
+                                Name = "Album",
+                                Artists = new List<SimpleArtist> {
+                                    new SimpleArtist {
+                                        Name = null
+                                    }
+                                }
+                            },
+                            Artists = new List<SimpleArtist> {
+                                new SimpleArtist {
+                                    Name = "TrackArtist"
+                                }
+                            }
+                        }
+                    }
+                },
+                Next = "DummyToMakeHasNextTrue"
+            };
+
+            Mocker.GetMock<ISpotifyProxy>().
+                Setup(x => x.GetPlaylistTracks(It.IsAny<SpotifyPlaylist>(),
+                                               It.IsAny<SpotifyWebAPI>(),
+                                               It.IsAny<string>(),
+                                               It.IsAny<string>()))
+                .Returns(playlistTracks);
+
+            Mocker.GetMock<ISpotifyProxy>()
+                .Setup(x => x.GetNextPage(It.IsAny<SpotifyFollowedArtists>(),
+                                          It.IsAny<SpotifyWebAPI>(),
+                                          It.IsAny<Paging<PlaylistTrack>>()))
+                .Returns(default(Paging<PlaylistTrack>));
+
+            var result = Subject.Fetch(api, "playlistid");
+
+            result.Should().HaveCount(1);
+
+            Mocker.GetMock<ISpotifyProxy>()
+                .Verify(x => x.GetNextPage(It.IsAny<SpotifyPlaylist>(),
+                                           It.IsAny<SpotifyWebAPI>(),
+                                           It.IsAny<Paging<PlaylistTrack>>()),
+                        Times.Once());
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/ImportListTests/Spotify/SpotifyPlaylistFixture.cs
+++ b/src/NzbDrone.Core.Test/ImportListTests/Spotify/SpotifyPlaylistFixture.cs
@@ -50,6 +50,27 @@ namespace NzbDrone.Core.Test.ImportListTests
         }
 
         [Test]
+        public void should_not_throw_if_playlist_track_is_null()
+        {
+            var playlistTracks = new Paging<PlaylistTrack> {
+                Items = new List<PlaylistTrack> {
+                    null
+                }
+            };
+
+            Mocker.GetMock<ISpotifyProxy>().
+                Setup(x => x.GetPlaylistTracks(It.IsAny<SpotifyPlaylist>(),
+                                               It.IsAny<SpotifyWebAPI>(),
+                                               It.IsAny<string>(),
+                                               It.IsAny<string>()))
+                .Returns(playlistTracks);
+
+            var result = Subject.Fetch(api, "playlistid");
+
+            result.Should().BeEmpty();
+        }
+
+        [Test]
         public void should_use_album_artist_when_it_exists()
         {
             var playlistTracks = new Paging<PlaylistTrack> {

--- a/src/NzbDrone.Core.Test/ImportListTests/Spotify/SpotifySavedAlbumsFixture.cs
+++ b/src/NzbDrone.Core.Test/ImportListTests/Spotify/SpotifySavedAlbumsFixture.cs
@@ -1,0 +1,107 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Core.ImportLists.Spotify;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Test.Framework;
+using SpotifyAPI.Web;
+using SpotifyAPI.Web.Models;
+
+namespace NzbDrone.Core.Test.ImportListTests
+{
+    [TestFixture]
+    public class SpotifySavedAlbumsFixture : CoreTest<SpotifySavedAlbums>
+    {
+        // placeholder, we don't use real API
+        private readonly SpotifyWebAPI api = null;
+
+        [Test]
+        public void should_not_throw_if_saved_albums_is_null()
+        {
+            Mocker.GetMock<ISpotifyProxy>().
+                Setup(x => x.GetSavedAlbums(It.IsAny<SpotifySavedAlbums>(),
+                                                It.IsAny<SpotifyWebAPI>()))
+                .Returns(default(Paging<SavedAlbum>));
+
+            var result = Subject.Fetch(api);
+
+            result.Should().BeEmpty();
+        }
+
+        [Test]
+        public void should_not_throw_if_saved_album_items_is_null()
+        {
+            var savedAlbums = new Paging<SavedAlbum> {
+                Items = null
+            };
+
+            Mocker.GetMock<ISpotifyProxy>().
+                Setup(x => x.GetSavedAlbums(It.IsAny<SpotifySavedAlbums>(),
+                                                It.IsAny<SpotifyWebAPI>()))
+                .Returns(savedAlbums);
+
+            var result = Subject.Fetch(api);
+
+            result.Should().BeEmpty();
+        }
+
+        [TestCase("Artist", "Album")]
+        public void should_parse_saved_album(string artistName, string albumName)
+        {
+            var savedAlbums = new Paging<SavedAlbum> {
+                Items = new List<SavedAlbum> {
+                    new SavedAlbum {
+                        Album = new FullAlbum {
+                            Name = albumName,
+                            Artists = new List<SimpleArtist> {
+                                new SimpleArtist {
+                                    Name = artistName
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            Mocker.GetMock<ISpotifyProxy>().
+                Setup(x => x.GetSavedAlbums(It.IsAny<SpotifySavedAlbums>(),
+                                                It.IsAny<SpotifyWebAPI>()))
+                .Returns(savedAlbums);
+
+            var result = Subject.Fetch(api);
+
+            result.Should().HaveCount(1);
+        }
+
+        [TestCase(null, "Album")]
+        [TestCase("Artist", null)]
+        [TestCase(null, null)]
+        public void should_skip_bad_artist_names(string artistName, string albumName)
+        {
+            var savedAlbums = new Paging<SavedAlbum> {
+                Items = new List<SavedAlbum> {
+                    new SavedAlbum {
+                        Album = new FullAlbum {
+                            Name = albumName,
+                            Artists = new List<SimpleArtist> {
+                                new SimpleArtist {
+                                    Name = artistName
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            Mocker.GetMock<ISpotifyProxy>().
+                Setup(x => x.GetSavedAlbums(It.IsAny<SpotifySavedAlbums>(),
+                                                It.IsAny<SpotifyWebAPI>()))
+                .Returns(savedAlbums);
+
+            var result = Subject.Fetch(api);
+
+            result.Should().BeEmpty();
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/ImportListTests/Spotify/SpotifySavedAlbumsFixture.cs
+++ b/src/NzbDrone.Core.Test/ImportListTests/Spotify/SpotifySavedAlbumsFixture.cs
@@ -45,6 +45,25 @@ namespace NzbDrone.Core.Test.ImportListTests
             result.Should().BeEmpty();
         }
 
+        [Test]
+        public void should_not_throw_if_saved_album_is_null()
+        {
+            var savedAlbums = new Paging<SavedAlbum> {
+                Items = new List<SavedAlbum> {
+                    null
+                }
+            };
+
+            Mocker.GetMock<ISpotifyProxy>().
+                Setup(x => x.GetSavedAlbums(It.IsAny<SpotifySavedAlbums>(),
+                                                It.IsAny<SpotifyWebAPI>()))
+                .Returns(savedAlbums);
+
+            var result = Subject.Fetch(api);
+
+            result.Should().BeEmpty();
+        }
+
         [TestCase("Artist", "Album")]
         public void should_parse_saved_album(string artistName, string albumName)
         {

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyFollowedArtists.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyFollowedArtists.cs
@@ -34,8 +34,8 @@ namespace NzbDrone.Core.ImportLists.Spotify
         {
             var result = new List<ImportListItemInfo>();
 
-            var followed = _spotifyProxy.GetFollowedArtists(this, api);
-            var artists = followed?.Artists;
+            var followedArtists = _spotifyProxy.GetFollowedArtists(this, api);
+            var artists = followedArtists?.Artists;
 
             while (true)
             {
@@ -56,7 +56,9 @@ namespace NzbDrone.Core.ImportLists.Spotify
                 }
 
                 if (!artists.HasNext())
+                {
                     break;
+                }
 
                 artists = _spotifyProxy.GetNextPage(this, api, artists);
             }

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyFollowedArtists.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyFollowedArtists.cs
@@ -46,13 +46,7 @@ namespace NzbDrone.Core.ImportLists.Spotify
 
                 foreach (var artist in artists?.Items ?? new List<FullArtist>())
                 {
-                    if (artist.Name.IsNotNullOrWhiteSpace())
-                    {
-                        result.AddIfNotNull(new ImportListItemInfo
-                                            {
-                                                Artist = artist.Name,
-                                            });
-                    }
+                    result.AddIfNotNull(ParseFullArtist(artist));
                 }
 
                 if (!artists.HasNext())
@@ -64,6 +58,18 @@ namespace NzbDrone.Core.ImportLists.Spotify
             }
 
             return result;
+        }
+
+        private ImportListItemInfo ParseFullArtist(FullArtist artist)
+        {
+            if (artist.Name.IsNotNullOrWhiteSpace())
+            {
+                return new ImportListItemInfo {
+                    Artist = artist.Name,
+                };
+            }
+
+            return null;
         }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyFollowedArtists.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyFollowedArtists.cs
@@ -39,12 +39,12 @@ namespace NzbDrone.Core.ImportLists.Spotify
 
             while (true)
             {
-                if (artists == null)
+                if (artists?.Items == null)
                 {
                     return result;
                 }
 
-                foreach (var artist in artists?.Items ?? new List<FullArtist>())
+                foreach (var artist in artists.Items)
                 {
                     result.AddIfNotNull(ParseFullArtist(artist));
                 }
@@ -62,7 +62,7 @@ namespace NzbDrone.Core.ImportLists.Spotify
 
         private ImportListItemInfo ParseFullArtist(FullArtist artist)
         {
-            if (artist.Name.IsNotNullOrWhiteSpace())
+            if (artist?.Name.IsNotNullOrWhiteSpace() ?? false)
             {
                 return new ImportListItemInfo {
                     Artist = artist.Name,

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyFollowedArtists.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyFollowedArtists.cs
@@ -35,15 +35,15 @@ namespace NzbDrone.Core.ImportLists.Spotify
             var result = new List<ImportListItemInfo>();
 
             var followed = _spotifyProxy.GetFollowedArtists(this, api);
+            var artists = followed?.Artists;
 
-            if (followed == null || followed.Artists == null)
-            {
-                return result;
-            }
-
-            var artists = followed.Artists;
             while (true)
             {
+                if (artists == null)
+                {
+                    return result;
+                }
+
                 foreach (var artist in artists?.Items ?? new List<FullArtist>())
                 {
                     if (artist.Name.IsNotNullOrWhiteSpace())
@@ -54,8 +54,10 @@ namespace NzbDrone.Core.ImportLists.Spotify
                                             });
                     }
                 }
+
                 if (!artists.HasNext())
                     break;
+
                 artists = _spotifyProxy.GetNextPage(this, api, artists);
             }
 

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyImportListBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyImportListBase.cs
@@ -22,13 +22,13 @@ namespace NzbDrone.Core.ImportLists.Spotify
 
         protected ISpotifyProxy _spotifyProxy;
 
-        public SpotifyImportListBase(ISpotifyProxy spotifyProxy,
-                                     IImportListStatusService importListStatusService,
-                                     IImportListRepository importListRepository,
-                                     IConfigService configService,
-                                     IParsingService parsingService,
-                                     IHttpClient httpClient,
-                                     Logger logger)
+        protected SpotifyImportListBase(ISpotifyProxy spotifyProxy,
+                                        IImportListStatusService importListStatusService,
+                                        IImportListRepository importListRepository,
+                                        IConfigService configService,
+                                        IParsingService parsingService,
+                                        IHttpClient httpClient,
+                                        Logger logger)
         : base(importListStatusService, configService, parsingService, logger)
         {
             _httpClient = httpClient;

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyImportListBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyImportListBase.cs
@@ -20,21 +20,27 @@ namespace NzbDrone.Core.ImportLists.Spotify
         private IHttpClient _httpClient;
         private IImportListRepository _importListRepository;
 
-        public SpotifyImportListBase(IImportListStatusService importListStatusService,
+        protected ISpotifyProxy _spotifyProxy;
+
+        public SpotifyImportListBase(ISpotifyProxy spotifyProxy,
+                                     IImportListStatusService importListStatusService,
                                      IImportListRepository importListRepository,
                                      IConfigService configService,
                                      IParsingService parsingService,
-                                     HttpClient httpClient,
+                                     IHttpClient httpClient,
                                      Logger logger)
         : base(importListStatusService, configService, parsingService, logger)
         {
             _httpClient = httpClient;
             _importListRepository = importListRepository;
+            _spotifyProxy = spotifyProxy;
         }
 
         public override ImportListType ListType => ImportListType.Spotify;
 
-        private void RefreshToken()
+        public string AccessToken => Settings.AccessToken;
+
+        public void RefreshToken()
         {
             _logger.Trace("Refreshing Token");
 
@@ -68,7 +74,7 @@ namespace NzbDrone.Core.ImportLists.Spotify
 
         }
         
-        protected SpotifyWebAPI GetApi()
+        public SpotifyWebAPI GetApi()
         {
             Settings.Validate().Filter("AccessToken", "RefreshToken").ThrowOnError();
             _logger.Trace($"Access token expires at {Settings.Expires}");
@@ -83,35 +89,6 @@ namespace NzbDrone.Core.ImportLists.Spotify
                 AccessToken = Settings.AccessToken,
                 TokenType = "Bearer"
             };
-        }
-
-        protected T Execute<T>(SpotifyWebAPI api, Func<SpotifyWebAPI, T> method, bool allowReauth = true) where T : BasicModel
-        {
-            T result = method(api);
-            if (result.HasError())
-            {
-                // If unauthorized, refresh token and try again
-                if (result.Error.Status == 401)
-                {
-                    if (allowReauth)
-                    {
-                        _logger.Debug("Spotify authorization error, refreshing token and retrying");
-                        RefreshToken();
-                        api.AccessToken = Settings.AccessToken;
-                        return Execute(api, method, false);
-                    }
-                    else
-                    {
-                        throw new SpotifyAuthorizationException(result.Error.Message);
-                    }
-                }
-                else
-                {
-                    throw new SpotifyException("[{0}] {1}", result.Error.Status, result.Error.Message);
-                }
-            }
-
-            return result;
         }
 
         public override IList<ImportListItemInfo> Fetch()
@@ -162,7 +139,7 @@ namespace NzbDrone.Core.ImportLists.Spotify
             {
                 using (var api = GetApi())
                 {
-                    var profile = Execute(api, (x) => x.GetPrivateProfile());
+                    var profile = _spotifyProxy.GetPrivateProfile(this, api);
                     _logger.Debug($"Connected to spotify profile {profile.DisplayName} [{profile.Id}]");
                     return null;
                 }

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyPlaylist.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyPlaylist.cs
@@ -49,25 +49,7 @@ namespace NzbDrone.Core.ImportLists.Spotify
 
                 foreach (var playlistTrack in playlistTracks.Items ?? new List<PlaylistTrack>())
                 {
-                    var track = playlistTrack.Track;
-
-                    // From spotify docs: "Note, a track object may be null. This can happen if a track is no longer available."
-                    if (track != null && track.Album != null)
-                    {
-                        var albumName = track.Album.Name;
-                        var artistName = track.Album.Artists?.FirstOrDefault()?.Name ?? track.Artists?.FirstOrDefault()?.Name;
-
-                        if (albumName.IsNotNullOrWhiteSpace() && artistName.IsNotNullOrWhiteSpace())
-                        {
-                            result.AddIfNotNull(new ImportListItemInfo
-                                {
-                                    Artist = artistName,
-                                    Album = albumName,
-                                    ReleaseDate = ParseSpotifyDate(track.Album.ReleaseDate, track.Album.ReleaseDatePrecision)
-                                });
-                                
-                        }
-                    }
+                    result.AddIfNotNull(ParseTrack(playlistTrack.Track));
                 }
                         
                 if (!playlistTracks.HasNextPage())
@@ -79,6 +61,27 @@ namespace NzbDrone.Core.ImportLists.Spotify
             }
 
             return result;
+        }
+
+        private ImportListItemInfo ParseTrack(FullTrack track)
+        {
+            // From spotify docs: "Note, a track object may be null. This can happen if a track is no longer available."
+            if (track != null && track.Album != null)
+            {
+                var albumName = track.Album.Name;
+                var artistName = track.Album.Artists?.FirstOrDefault()?.Name ?? track.Artists?.FirstOrDefault()?.Name;
+
+                if (albumName.IsNotNullOrWhiteSpace() && artistName.IsNotNullOrWhiteSpace())
+                {
+                    return new ImportListItemInfo {
+                        Artist = artistName,
+                        Album = albumName,
+                        ReleaseDate = ParseSpotifyDate(track.Album.ReleaseDate, track.Album.ReleaseDatePrecision)
+                    };
+                }
+            }
+
+            return null;
         }
 
         public override object RequestAction(string action, IDictionary<string, string> query)

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyPlaylist.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyPlaylist.cs
@@ -39,9 +39,15 @@ namespace NzbDrone.Core.ImportLists.Spotify
                 var playlistTracks = _spotifyProxy.GetPlaylistTracks(this, api, id, "next, items(track(name, album(name,artists)))");
                 while (true)
                 {
-                    foreach (var track in playlistTracks.Items)
+                    if (playlistTracks == null)
+                    {
+                        return result;
+                    }
+
+                    foreach (var track in playlistTracks.Items ?? new List<PlaylistTrack>())
                     {
                         var fullTrack = track.Track;
+
                         // From spotify docs: "Note, a track object may be null. This can happen if a track is no longer available."
                         if (fullTrack != null)
                         {
@@ -63,6 +69,7 @@ namespace NzbDrone.Core.ImportLists.Spotify
                         
                     if (!playlistTracks.HasNextPage())
                         break;
+
                     playlistTracks = _spotifyProxy.GetNextPage(this, api, playlistTracks);
                 }
             }

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyProxy.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyProxy.cs
@@ -1,0 +1,109 @@
+using System;
+using NLog;
+using SpotifyAPI.Web;
+using SpotifyAPI.Web.Enums;
+using SpotifyAPI.Web.Models;
+
+namespace NzbDrone.Core.ImportLists.Spotify
+{
+    public interface ISpotifyProxy
+    {
+        PrivateProfile GetPrivateProfile<TSettings>(SpotifyImportListBase<TSettings> list, SpotifyWebAPI api)
+            where TSettings : SpotifySettingsBase<TSettings>, new();
+        Paging<SimplePlaylist> GetUserPlaylists<TSettings>(SpotifyImportListBase<TSettings> list, SpotifyWebAPI api, string id)
+            where TSettings : SpotifySettingsBase<TSettings>, new();
+        FollowedArtists GetFollowedArtists<TSettings>(SpotifyImportListBase<TSettings> list, SpotifyWebAPI api)
+            where TSettings : SpotifySettingsBase<TSettings>, new();
+        Paging<SavedAlbum> GetSavedAlbums<TSettings>(SpotifyImportListBase<TSettings> list, SpotifyWebAPI api)
+            where TSettings : SpotifySettingsBase<TSettings>, new();
+        Paging<PlaylistTrack> GetPlaylistTracks<TSettings>(SpotifyImportListBase<TSettings> list, SpotifyWebAPI api, string id, string fields)
+            where TSettings : SpotifySettingsBase<TSettings>, new();
+        Paging<T> GetNextPage<T, TSettings>(SpotifyImportListBase<TSettings> list, SpotifyWebAPI api, Paging<T> item)
+            where TSettings : SpotifySettingsBase<TSettings>, new();
+        CursorPaging<T> GetNextPage<T, TSettings>(SpotifyImportListBase<TSettings> list, SpotifyWebAPI api, CursorPaging<T> item)
+            where TSettings : SpotifySettingsBase<TSettings>, new();
+    }
+
+    public class SpotifyProxy : ISpotifyProxy
+    {
+        private readonly Logger _logger;
+
+        public SpotifyProxy(Logger logger)
+        {
+            _logger = logger;
+        }
+
+        public PrivateProfile GetPrivateProfile<TSettings>(SpotifyImportListBase<TSettings> list, SpotifyWebAPI api)
+            where TSettings : SpotifySettingsBase<TSettings>, new()
+        {
+            return Execute(list, api, x => x.GetPrivateProfile());
+        }
+
+        public Paging<SimplePlaylist> GetUserPlaylists<TSettings>(SpotifyImportListBase<TSettings> list, SpotifyWebAPI api, string id)
+            where TSettings : SpotifySettingsBase<TSettings>, new()
+        {
+            return Execute(list, api, x => x.GetUserPlaylists(id));
+        }
+
+        public FollowedArtists GetFollowedArtists<TSettings>(SpotifyImportListBase<TSettings> list, SpotifyWebAPI api)
+            where TSettings : SpotifySettingsBase<TSettings>, new()
+        {
+            return Execute(list, api, x => x.GetFollowedArtists(FollowType.Artist));
+        }
+
+        public Paging<SavedAlbum> GetSavedAlbums<TSettings>(SpotifyImportListBase<TSettings> list, SpotifyWebAPI api)
+            where TSettings : SpotifySettingsBase<TSettings>, new()
+        {
+            return Execute(list, api, x => x.GetSavedAlbums(50));
+        }
+
+        public Paging<PlaylistTrack> GetPlaylistTracks<TSettings>(SpotifyImportListBase<TSettings> list, SpotifyWebAPI api, string id, string fields)
+            where TSettings : SpotifySettingsBase<TSettings>, new()
+        {
+            return Execute(list, api, x => x.GetPlaylistTracks(id, fields: fields));
+        }
+
+        public Paging<T> GetNextPage<T, TSettings>(SpotifyImportListBase<TSettings> list, SpotifyWebAPI api, Paging<T> item)
+            where TSettings : SpotifySettingsBase<TSettings>, new()
+        {
+            return Execute(list, api, (x) => x.GetNextPage(item));
+        }
+
+        public CursorPaging<T> GetNextPage<T, TSettings>(SpotifyImportListBase<TSettings> list, SpotifyWebAPI api, CursorPaging<T> item)
+            where TSettings : SpotifySettingsBase<TSettings>, new()
+        {
+            return Execute(list, api, (x) => x.GetNextPage(item));
+        }
+
+        public T Execute<T, TSettings>(SpotifyImportListBase<TSettings> list, SpotifyWebAPI api, Func<SpotifyWebAPI, T> method, bool allowReauth = true)
+            where T : BasicModel
+            where TSettings : SpotifySettingsBase<TSettings>, new()
+        {
+            T result = method(api);
+            if (result.HasError())
+            {
+                // If unauthorized, refresh token and try again
+                if (result.Error.Status == 401)
+                {
+                    if (allowReauth)
+                    {
+                        _logger.Debug("Spotify authorization error, refreshing token and retrying");
+                        list.RefreshToken();
+                        api.AccessToken = list.AccessToken;
+                        return Execute(list, api, method, false);
+                    }
+                    else
+                    {
+                        throw new SpotifyAuthorizationException(result.Error.Message);
+                    }
+                }
+                else
+                {
+                    throw new SpotifyException("[{0}] {1}", result.Error.Status, result.Error.Message);
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifySavedAlbums.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifySavedAlbums.cs
@@ -36,15 +36,16 @@ namespace NzbDrone.Core.ImportLists.Spotify
             var result = new List<ImportListItemInfo>();
 
             var albums = _spotifyProxy.GetSavedAlbums(this, api);
-            if (albums == null)
-            {
-                return result;
-            }
 
-            _logger.Trace($"Got {albums.Total} saved albums");
+            _logger.Trace($"Got {albums?.Total ?? 0} saved albums");
 
             while (true)
             {
+                if (albums == null)
+                {
+                    return result;
+                }
+
                 foreach (var album in albums?.Items ?? new List<SavedAlbum>())
                 {
                     var artistName = album?.Album?.Artists?.FirstOrDefault()?.Name;
@@ -60,8 +61,10 @@ namespace NzbDrone.Core.ImportLists.Spotify
                                             });
                     }
                 }
+
                 if (!albums.HasNextPage())
                     break;
+
                 albums = _spotifyProxy.GetNextPage(this, api, albums);
             }
 

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifySavedAlbums.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifySavedAlbums.cs
@@ -35,21 +35,21 @@ namespace NzbDrone.Core.ImportLists.Spotify
         {
             var result = new List<ImportListItemInfo>();
 
-            var albums = _spotifyProxy.GetSavedAlbums(this, api);
+            var savedAlbums = _spotifyProxy.GetSavedAlbums(this, api);
 
-            _logger.Trace($"Got {albums?.Total ?? 0} saved albums");
+            _logger.Trace($"Got {savedAlbums?.Total ?? 0} saved albums");
 
             while (true)
             {
-                if (albums == null)
+                if (savedAlbums == null)
                 {
                     return result;
                 }
 
-                foreach (var album in albums?.Items ?? new List<SavedAlbum>())
+                foreach (var savedAlbum in savedAlbums?.Items ?? new List<SavedAlbum>())
                 {
-                    var artistName = album?.Album?.Artists?.FirstOrDefault()?.Name;
-                    var albumName = album?.Album?.Name;
+                    var artistName = savedAlbum?.Album?.Artists?.FirstOrDefault()?.Name;
+                    var albumName = savedAlbum?.Album?.Name;
                     _logger.Trace($"Adding {artistName} - {albumName}");
 
                     if (artistName.IsNotNullOrWhiteSpace() && albumName.IsNotNullOrWhiteSpace())
@@ -57,15 +57,18 @@ namespace NzbDrone.Core.ImportLists.Spotify
                         result.AddIfNotNull(new ImportListItemInfo
                                             {
                                                 Artist = artistName,
-                                                Album = albumName
+                                                Album = albumName,
+                                                ReleaseDate = ParseSpotifyDate(savedAlbum?.Album?.ReleaseDate, savedAlbum?.Album?.ReleaseDatePrecision)
                                             });
                     }
                 }
 
-                if (!albums.HasNextPage())
+                if (!savedAlbums.HasNextPage())
+                {
                     break;
+                }
 
-                albums = _spotifyProxy.GetNextPage(this, api, albums);
+                savedAlbums = _spotifyProxy.GetNextPage(this, api, savedAlbums);
             }
 
             return result;

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifySavedAlbums.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifySavedAlbums.cs
@@ -41,12 +41,12 @@ namespace NzbDrone.Core.ImportLists.Spotify
 
             while (true)
             {
-                if (savedAlbums == null)
+                if (savedAlbums?.Items == null)
                 {
                     return result;
                 }
 
-                foreach (var savedAlbum in savedAlbums?.Items ?? new List<SavedAlbum>())
+                foreach (var savedAlbum in savedAlbums.Items)
                 {
                     result.AddIfNotNull(ParseSavedAlbum(savedAlbum));
                 }

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifySavedAlbums.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifySavedAlbums.cs
@@ -48,19 +48,7 @@ namespace NzbDrone.Core.ImportLists.Spotify
 
                 foreach (var savedAlbum in savedAlbums?.Items ?? new List<SavedAlbum>())
                 {
-                    var artistName = savedAlbum?.Album?.Artists?.FirstOrDefault()?.Name;
-                    var albumName = savedAlbum?.Album?.Name;
-                    _logger.Trace($"Adding {artistName} - {albumName}");
-
-                    if (artistName.IsNotNullOrWhiteSpace() && albumName.IsNotNullOrWhiteSpace())
-                    {
-                        result.AddIfNotNull(new ImportListItemInfo
-                                            {
-                                                Artist = artistName,
-                                                Album = albumName,
-                                                ReleaseDate = ParseSpotifyDate(savedAlbum?.Album?.ReleaseDate, savedAlbum?.Album?.ReleaseDatePrecision)
-                                            });
-                    }
+                    result.AddIfNotNull(ParseSavedAlbum(savedAlbum));
                 }
 
                 if (!savedAlbums.HasNextPage())
@@ -72,6 +60,24 @@ namespace NzbDrone.Core.ImportLists.Spotify
             }
 
             return result;
+        }
+
+        private ImportListItemInfo ParseSavedAlbum(SavedAlbum savedAlbum)
+        {
+            var artistName = savedAlbum?.Album?.Artists?.FirstOrDefault()?.Name;
+            var albumName = savedAlbum?.Album?.Name;
+            _logger.Trace($"Adding {artistName} - {albumName}");
+
+            if (artistName.IsNotNullOrWhiteSpace() && albumName.IsNotNullOrWhiteSpace())
+            {
+                return new ImportListItemInfo {
+                    Artist = artistName,
+                    Album = albumName,
+                    ReleaseDate = ParseSpotifyDate(savedAlbum?.Album?.ReleaseDate, savedAlbum?.Album?.ReleaseDatePrecision)
+                };
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Rework spotify import lists to use a `ISpotifyProxy` interface so we can test.  Add tests

#### Todos
- [x] Tests for playlists


#### Issues Fixed or Closed by this PR

* Fixes #957 
