### PR TITLE
Azure yarn cache

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,7 @@ variables:
   macOsTar: 'Lidarr.$(buildName).osx.tar.gz'
   linuxTar: 'Lidarr.$(buildName).linux.tar.gz'
   sentryOrg: 'lidarr'
+  yarnCacheFolder: $(Pipeline.Workspace)/.yarn
 
 trigger:
   branches:
@@ -91,6 +92,11 @@ stages:
       - checkout: self
         submodules: true
         fetchDepth: 1
+      - task: CacheBeta@0
+        inputs:
+          key: yarn | $(Agent.OS) | yarn.lock
+          path: $(yarnCacheFolder)
+        displayName: Cache Yarn packages
       - bash: ./build.sh --only-frontend
         displayName: Build Lidarr Frontend
         env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,7 +145,7 @@ stages:
       pool:
         vmImage: 'ubuntu-16.04'
       steps:
-      - bash: sudo apt install dos2unix
+      - bash: sudo apt-get install dos2unix
       - checkout: self
         fetchDepth: 1
       - task: DownloadPipelineArtifact@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ variables:
   macOsTar: 'Lidarr.$(buildName).osx.tar.gz'
   linuxTar: 'Lidarr.$(buildName).linux.tar.gz'
   sentryOrg: 'lidarr'
-  yarnCacheFolder: $(Pipeline.Workspace)/.yarn
+  YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
 
 trigger:
   branches:
@@ -95,7 +95,7 @@ stages:
       - task: CacheBeta@0
         inputs:
           key: yarn | $(Agent.OS) | yarn.lock
-          path: $(yarnCacheFolder)
+          path: $(YARN_CACHE_FOLDER)
         displayName: Cache Yarn packages
       - bash: ./build.sh --only-frontend
         displayName: Build Lidarr Frontend

--- a/build.sh
+++ b/build.sh
@@ -143,8 +143,7 @@ Build()
 RunGulp()
 {
     ProgressStart 'yarn install'
-    yarn install
-    #npm-cache install npm || CheckExitCode npm install --no-optional --no-bin-links
+    yarn install --frozen-lockfile
     ProgressEnd 'yarn install'
 
     LintUI


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Ensure that lock file doesn't get updated or re-generated during build leading to different packages than in repo. 

Cache yarn packages, seems build process has overtaken Analyze in recent builds (mostly from Windows frontend build) 
