### PR TITLE
Fixed: Directory not empty exception deleting nested empty subdirectories

### DIFF
--- a/src/NzbDrone.Common.Test/DiskTests/DiskProviderFixtureBase.cs
+++ b/src/NzbDrone.Common.Test/DiskTests/DiskProviderFixtureBase.cs
@@ -123,6 +123,21 @@ namespace NzbDrone.Common.Test.DiskTests
         }
 
         [Test]
+        public void should_be_able_to_delete_nested_empty_subdirs()
+        {
+            var artistDir = Path.Combine(GetTempFilePath(), "Artist");
+            var albumDir = Path.Combine(artistDir, "Album");
+
+            Directory.CreateDirectory(Path.Combine(albumDir));
+            Directory.CreateDirectory(Path.Combine(albumDir, "Album"));
+            Directory.CreateDirectory(Path.Combine(albumDir, "Album", "CD1"));
+            Directory.CreateDirectory(Path.Combine(albumDir, "Album", "CD2"));
+
+            Subject.RemoveEmptySubfolders(artistDir);
+            Directory.Exists(albumDir).Should().BeFalse();
+        }
+
+        [Test]
         public void empty_folder_should_return_folder_modified_date()
         {
             var tempfolder = new DirectoryInfo(TempFolder);

--- a/src/NzbDrone.Common/Disk/DiskProviderBase.cs
+++ b/src/NzbDrone.Common/Disk/DiskProviderBase.cs
@@ -154,6 +154,13 @@ namespace NzbDrone.Common.Disk
             return _fileSystem.Directory.GetDirectories(path);
         }
 
+        public string[] GetDirectories(string path, SearchOption searchOption)
+        {
+            Ensure.That(path, () => path).IsValidPath();
+
+            return _fileSystem.Directory.GetDirectories(path, "*", searchOption);
+        }
+
         public string[] GetFiles(string path, SearchOption searchOption)
         {
             Ensure.That(path, () => path).IsValidPath();
@@ -500,10 +507,11 @@ namespace NzbDrone.Common.Disk
 
         public void RemoveEmptySubfolders(string path)
         {
-            var subfolders = GetDirectories(path);
+            var subfolders = GetDirectories(path, SearchOption.AllDirectories);
             var files = GetFiles(path, SearchOption.AllDirectories);
 
-            foreach (var subfolder in subfolders)
+            // By sorting by length descending we ensure we always delete children before parents
+            foreach (var subfolder in subfolders.OrderByDescending(x => x.Length))
             {
                 if (files.None(f => subfolder.IsParentPath(f)))
                 {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
`RemoveEmptySubfolders` fails with nested empty subfolders.  It needs to search for directories recursively and delete empty children before trying to delete empty parents.

#### Todos
- [x] Tests


#### Issues Fixed or Closed by this PR

* Fixes Sentry Lidarr-1qj
* Fixes Sentry Lidarr-1qz
* Fixes Sentry Lidarr-24a
* Fixes Sentry Lidarr-3T8
* Fixes Sentry Lidarr-25R
