### PR TITLE
Fixed: Pseudo Release Incorrect Enum Name

### DIFF
--- a/src/NzbDrone.Core/Music/ReleaseStatus.cs
+++ b/src/NzbDrone.Core/Music/ReleaseStatus.cs
@@ -65,7 +65,7 @@ namespace NzbDrone.Core.Music
         public static ReleaseStatus Official => new ReleaseStatus(0, "Official");
         public static ReleaseStatus Promotion => new ReleaseStatus(1, "Promotion");
         public static ReleaseStatus Bootleg => new ReleaseStatus(2, "Bootleg");
-        public static ReleaseStatus Pseudo => new ReleaseStatus(3, "Pseudo");
+        public static ReleaseStatus Pseudo => new ReleaseStatus(3, "Pseudo-Release");
 
 
         public static readonly List<ReleaseStatus> All = new List<ReleaseStatus>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixes name of pseudo release to match metadata server/mb naming

#### Issues Fixed or Closed by this PR
Fixes #987
