### PR TITLE
Fixed: Artist FindById Should Find OldIds

### DIFF
--- a/src/NzbDrone.Core/Music/ArtistRepository.cs
+++ b/src/NzbDrone.Core/Music/ArtistRepository.cs
@@ -31,7 +31,16 @@ namespace NzbDrone.Core.Music
 
         public Artist FindById(string foreignArtistId)
         {
-            return Query.Where<ArtistMetadata>(m => m.ForeignArtistId == foreignArtistId).SingleOrDefault();
+            var artist = Query.Where<ArtistMetadata>(m => m.ForeignArtistId == foreignArtistId).SingleOrDefault();
+
+            if (artist == null)
+            {
+                var id = "\"" + foreignArtistId + "\"";
+                artist = Query.Where<ArtistMetadata>(x => x.OldForeignArtistIds.Contains(id))
+                               .SingleOrDefault();
+            }
+
+            return artist;
         }
 
         public Artist FindByName(string cleanName)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When using FindById, check oldIds column as well. This ensures we don't accidentally try and add an artist from a list if the list gives an old Id.

Also, break and log to next report in list processing if artist is existing. Save some processing for now until album add is added

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR
Fixes #970 
Fixes LIDARR-3FY
* 
