### PR TITLE
Fixed: Correctly page through Spotify followed artists

### DIFF
--- a/src/NzbDrone.Core.Test/ImportListTests/Spotify/SpotifyFollowedArtistsFixture.cs
+++ b/src/NzbDrone.Core.Test/ImportListTests/Spotify/SpotifyFollowedArtistsFixture.cs
@@ -132,8 +132,8 @@ namespace NzbDrone.Core.Test.ImportListTests
             Mocker.GetMock<ISpotifyProxy>()
                 .Setup(x => x.GetNextPage(It.IsAny<SpotifyFollowedArtists>(),
                                           It.IsAny<SpotifyWebAPI>(),
-                                          It.IsAny<CursorPaging<FullArtist>>()))
-                .Returns(default(CursorPaging<FullArtist>));
+                                          It.IsAny<FollowedArtists>()))
+                .Returns(default(FollowedArtists));
 
             var result = Subject.Fetch(api);
 
@@ -142,7 +142,7 @@ namespace NzbDrone.Core.Test.ImportListTests
             Mocker.GetMock<ISpotifyProxy>()
                 .Verify(v => v.GetNextPage(It.IsAny<SpotifyFollowedArtists>(),
                                            It.IsAny<SpotifyWebAPI>(),
-                                           It.IsAny<CursorPaging<FullArtist>>()),
+                                           It.IsAny<FollowedArtists>()),
                         Times.Once());
         }
 

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyFollowedArtists.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyFollowedArtists.cs
@@ -54,7 +54,8 @@ namespace NzbDrone.Core.ImportLists.Spotify
                     break;
                 }
 
-                artists = _spotifyProxy.GetNextPage(this, api, artists);
+                followedArtists = _spotifyProxy.GetNextPage(this, api, followedArtists);
+                artists = followedArtists?.Artists;
             }
 
             return result;

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyProxy.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyProxy.cs
@@ -20,7 +20,7 @@ namespace NzbDrone.Core.ImportLists.Spotify
             where TSettings : SpotifySettingsBase<TSettings>, new();
         Paging<T> GetNextPage<T, TSettings>(SpotifyImportListBase<TSettings> list, SpotifyWebAPI api, Paging<T> item)
             where TSettings : SpotifySettingsBase<TSettings>, new();
-        CursorPaging<T> GetNextPage<T, TSettings>(SpotifyImportListBase<TSettings> list, SpotifyWebAPI api, CursorPaging<T> item)
+        FollowedArtists GetNextPage<TSettings>(SpotifyImportListBase<TSettings> list, SpotifyWebAPI api, FollowedArtists item)
             where TSettings : SpotifySettingsBase<TSettings>, new();
     }
 
@@ -48,7 +48,7 @@ namespace NzbDrone.Core.ImportLists.Spotify
         public FollowedArtists GetFollowedArtists<TSettings>(SpotifyImportListBase<TSettings> list, SpotifyWebAPI api)
             where TSettings : SpotifySettingsBase<TSettings>, new()
         {
-            return Execute(list, api, x => x.GetFollowedArtists(FollowType.Artist));
+            return Execute(list, api, x => x.GetFollowedArtists(FollowType.Artist, 50));
         }
 
         public Paging<SavedAlbum> GetSavedAlbums<TSettings>(SpotifyImportListBase<TSettings> list, SpotifyWebAPI api)
@@ -69,10 +69,10 @@ namespace NzbDrone.Core.ImportLists.Spotify
             return Execute(list, api, (x) => x.GetNextPage(item));
         }
 
-        public CursorPaging<T> GetNextPage<T, TSettings>(SpotifyImportListBase<TSettings> list, SpotifyWebAPI api, CursorPaging<T> item)
+        public FollowedArtists GetNextPage<TSettings>(SpotifyImportListBase<TSettings> list, SpotifyWebAPI api, FollowedArtists item)
             where TSettings : SpotifySettingsBase<TSettings>, new()
         {
-            return Execute(list, api, (x) => x.GetNextPage(item));
+            return Execute(list, api, (x) => x.GetNextPage<FollowedArtists, FullArtist>(item.Artists));
         }
 
         public T Execute<T, TSettings>(SpotifyImportListBase<TSettings> list, SpotifyWebAPI api, Func<SpotifyWebAPI, T> method, bool allowReauth = true)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fix the Spotify followed artist import list so that it imports more than 20 artists.  The paging was set up incorrectly for following artists, making the wrong API call.  Tested by setting limit to 1 and verifying all artists appear.

Page size increased to 50 (the max) to minimize number of pages required.

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR

* User on discord reported followed artists limited to 20 (the default page size).
