### PR TITLE
New: Cache spotify -> musicbrainz mapping

### DIFF
--- a/src/NzbDrone.Core.Test/ImportListTests/ImportListSyncServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/ImportListTests/ImportListSyncServiceFixture.cs
@@ -120,9 +120,19 @@ namespace NzbDrone.Core.Test.ImportListTests
         }
 
         [Test]
-        public void should_not_search_if_album_title_and_album_id()
+        public void should_search_with_lidarr_id_if_album_id_and_no_artist_id()
         {
-            WithAlbum();
+            WithAlbumId();
+            Subject.Execute(new ImportListSyncCommand());
+
+            Mocker.GetMock<ISearchForNewAlbum>()
+                .Verify(v => v.SearchForNewAlbum($"lidarr:{_importListReports.First().AlbumMusicBrainzId}", null), Times.Once());
+        }
+
+        [Test]
+        public void should_not_search_if_album_id_and_artist_id()
+        {
+            WithArtistId();
             WithAlbumId();
             Subject.Execute(new ImportListSyncCommand());
 

--- a/src/NzbDrone.Core.Test/ImportListTests/Spotify/SpotifyMappingFixture.cs
+++ b/src/NzbDrone.Core.Test/ImportListTests/Spotify/SpotifyMappingFixture.cs
@@ -1,0 +1,346 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Common.Cloud;
+using NzbDrone.Common.Http;
+using NzbDrone.Common.Serializer;
+using NzbDrone.Core.ImportLists.Spotify;
+using NzbDrone.Core.MetadataSource;
+using NzbDrone.Core.MetadataSource.SkyHook.Resource;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Test.Common;
+
+namespace NzbDrone.Core.Test.ImportListTests
+{
+    [TestFixture]
+    // the base import list class is abstract so use the followed artists one
+    public class SpotifyMappingFixture : CoreTest<SpotifyFollowedArtists>
+    {
+        [SetUp]
+        public void Setup()
+        {
+            Mocker.SetConstant<ILidarrCloudRequestBuilder>(new LidarrCloudRequestBuilder());
+            Mocker.SetConstant<IMetadataRequestBuilder>(Mocker.Resolve<MetadataRequestBuilder>());
+        }
+
+        [Test]
+        public void map_artist_should_return_name_if_id_null()
+        {
+            var data = new SpotifyImportListItemInfo
+            {
+                Artist = "Adele"
+            };
+
+            Subject.MapArtistItem(data);
+
+            data.Artist.Should().Be("Adele");
+            data.ArtistMusicBrainzId.Should().BeNull();
+            data.Album.Should().BeNull();
+            data.AlbumMusicBrainzId.Should().BeNull();
+        }
+
+        [Test]
+        public void map_artist_should_set_id_0_if_no_match()
+        {
+            Mocker.GetMock<IHttpClient>()
+                .Setup(x => x.Get<ArtistResource>(It.IsAny<HttpRequest>()))
+                .Returns<HttpRequest>((x) => new HttpResponse<ArtistResource>(new HttpResponse(x, new HttpHeader(), new byte[0], HttpStatusCode.NotFound)));
+
+            var data = new SpotifyImportListItemInfo
+            {
+                Artist = "Adele",
+                ArtistSpotifyId = "id"
+            };
+
+            Subject.MapArtistItem(data);
+            data.ArtistMusicBrainzId.Should().Be("0");
+        }
+
+        [Test]
+        public void map_artist_should_not_update_id_if_http_throws()
+        {
+            Mocker.GetMock<IHttpClient>()
+                .Setup(x => x.Get<ArtistResource>(It.IsAny<HttpRequest>()))
+                .Throws(new Exception("Dummy exception"));
+
+            var data = new SpotifyImportListItemInfo
+            {
+                Artist = "Adele",
+                ArtistSpotifyId = "id"
+            };
+
+            Subject.MapArtistItem(data);
+            data.ArtistMusicBrainzId.Should().BeNull();
+
+            ExceptionVerification.ExpectedErrors(1);
+        }
+
+        [Test]
+        public void map_artist_should_work()
+        {
+            UseRealHttp();
+
+            var data = new SpotifyImportListItemInfo
+            {
+                Artist = "Adele",
+                ArtistSpotifyId = "4dpARuHxo51G3z768sgnrY"
+            };
+
+            Subject.MapArtistItem(data);
+            data.Should().NotBeNull();
+            data.Artist.Should().Be("Adele");
+            data.ArtistMusicBrainzId.Should().Be("cc2c9c3c-b7bc-4b8b-84d8-4fbd8779e493");
+            data.Album.Should().BeNull();
+            data.AlbumMusicBrainzId.Should().BeNull();
+        }
+
+        [Test]
+        public void map_album_should_return_name_if_uri_null()
+        {
+            var data = new SpotifyImportListItemInfo
+            {
+                Album = "25",
+                Artist = "Adele"
+            };
+
+            Subject.MapAlbumItem(data);
+            data.Should().NotBeNull();
+            data.Artist.Should().Be("Adele");
+            data.ArtistMusicBrainzId.Should().BeNull();
+            data.Album.Should().Be("25");
+            data.AlbumMusicBrainzId.Should().BeNull();
+        }
+
+        [Test]
+        public void map_album_should_set_id_0_if_no_match()
+        {
+            Mocker.GetMock<IHttpClient>()
+                .Setup(x => x.Get<AlbumResource>(It.IsAny<HttpRequest>()))
+                .Returns<HttpRequest>((x) => new HttpResponse<AlbumResource>(new HttpResponse(x, new HttpHeader(), new byte[0], HttpStatusCode.NotFound)));
+
+            var data = new SpotifyImportListItemInfo
+            {
+                Album = "25",
+                AlbumSpotifyId = "id",
+                Artist = "Adele"
+            };
+
+            Subject.MapAlbumItem(data);
+            data.AlbumMusicBrainzId.Should().Be("0");
+        }
+
+        [Test]
+        public void map_album_should_not_update_id_if_http_throws()
+        {
+            Mocker.GetMock<IHttpClient>()
+                .Setup(x => x.Get<AlbumResource>(It.IsAny<HttpRequest>()))
+                .Throws(new Exception("Dummy exception"));
+
+            var data = new SpotifyImportListItemInfo
+            {
+                Album = "25",
+                AlbumSpotifyId = "id",
+                Artist = "Adele"
+            };
+
+
+            Subject.MapAlbumItem(data);
+            data.Should().NotBeNull();
+            data.Artist.Should().Be("Adele");
+            data.ArtistMusicBrainzId.Should().BeNull();
+            data.Album.Should().Be("25");
+            data.AlbumMusicBrainzId.Should().BeNull();
+
+            ExceptionVerification.ExpectedErrors(1);
+        }
+
+        [Test]
+        public void map_album_should_work()
+        {
+            UseRealHttp();
+
+            var data = new SpotifyImportListItemInfo
+            {
+                Album = "25",
+                AlbumSpotifyId = "7uwTHXmFa1Ebi5flqBosig",
+                Artist = "Adele"
+            };
+
+            Subject.MapAlbumItem(data);
+
+            data.Should().NotBeNull();
+            data.Artist.Should().Be("Adele");
+            data.Album.Should().Be("25");
+            data.AlbumMusicBrainzId.Should().Be("5537624c-3d2f-4f5c-8099-df916082c85c");
+        }
+
+        [Test]
+        public void map_spotify_releases_should_only_map_album_id_for_album()
+        {
+            var data = new List<SpotifyImportListItemInfo>
+            {
+                new SpotifyImportListItemInfo
+                {
+                    Album = "25",
+                    AlbumSpotifyId = "7uwTHXmFa1Ebi5flqBosig",
+                    Artist = "Adele",
+                    ArtistSpotifyId = "4dpARuHxo51G3z768sgnrY"
+                }
+            };
+
+            var map = new List<SpotifyMap>
+            {
+                new SpotifyMap
+                {
+                    SpotifyId = "7uwTHXmFa1Ebi5flqBosig",
+                    MusicbrainzId = "5537624c-3d2f-4f5c-8099-df916082c85c"
+                },
+                new SpotifyMap
+                {
+                    SpotifyId = "4dpARuHxo51G3z768sgnrY",
+                    MusicbrainzId = "cc2c9c3c-b7bc-4b8b-84d8-4fbd8779e493"
+                }
+            };
+
+            Mocker.GetMock<IHttpClient>()
+                .Setup(x => x.Post<List<SpotifyMap>>(It.IsAny<HttpRequest>()))
+                .Returns<HttpRequest>(r => new HttpResponse<List<SpotifyMap>>(new HttpResponse(r, new HttpHeader(), map.ToJson())));
+
+            var result = Subject.MapSpotifyReleases(data);
+            result[0].AlbumMusicBrainzId.Should().Be("5537624c-3d2f-4f5c-8099-df916082c85c");
+            result[0].ArtistMusicBrainzId.Should().BeNull();
+        }
+
+        [Test]
+        public void map_spotify_releases_should_map_artist_id_for_artist()
+        {
+            var data = new List<SpotifyImportListItemInfo>
+            {
+                new SpotifyImportListItemInfo
+                {
+                    Artist = "Adele",
+                    ArtistSpotifyId = "4dpARuHxo51G3z768sgnrY"
+                }
+            };
+
+            var map = new List<SpotifyMap>
+            {
+                new SpotifyMap
+                {
+                    SpotifyId = "7uwTHXmFa1Ebi5flqBosig",
+                    MusicbrainzId = "5537624c-3d2f-4f5c-8099-df916082c85c"
+                },
+                new SpotifyMap
+                {
+                    SpotifyId = "4dpARuHxo51G3z768sgnrY",
+                    MusicbrainzId = "cc2c9c3c-b7bc-4b8b-84d8-4fbd8779e493"
+                }
+            };
+
+            Mocker.GetMock<IHttpClient>()
+                .Setup(x => x.Post<List<SpotifyMap>>(It.IsAny<HttpRequest>()))
+                .Returns<HttpRequest>(r => new HttpResponse<List<SpotifyMap>>(new HttpResponse(r, new HttpHeader(), map.ToJson())));
+
+            var result = Subject.MapSpotifyReleases(data);
+            result[0].ArtistMusicBrainzId.Should().Be("cc2c9c3c-b7bc-4b8b-84d8-4fbd8779e493");
+        }
+
+        [Test]
+        public void map_spotify_releases_should_drop_not_found()
+        {
+            var data = new List<SpotifyImportListItemInfo>
+            {
+                new SpotifyImportListItemInfo
+                {
+                    Album = "25",
+                    AlbumSpotifyId = "7uwTHXmFa1Ebi5flqBosig",
+                    Artist = "Adele"
+                }
+            };
+
+            var map = new List<SpotifyMap>
+            {
+                new SpotifyMap
+                {
+                    SpotifyId = "7uwTHXmFa1Ebi5flqBosig",
+                    MusicbrainzId = "0"
+                }
+            };
+
+            Mocker.GetMock<IHttpClient>()
+                .Setup(x => x.Post<List<SpotifyMap>>(It.IsAny<HttpRequest>()))
+                .Returns<HttpRequest>(r => new HttpResponse<List<SpotifyMap>>(new HttpResponse(r, new HttpHeader(), map.ToJson())));
+
+            var result = Subject.MapSpotifyReleases(data);
+            result.Should().BeEmpty();
+        }
+
+        [Test]
+        public void map_spotify_releases_should_catch_exception_from_api()
+        {
+            var data = new List<SpotifyImportListItemInfo>
+            {
+                new SpotifyImportListItemInfo
+                {
+                    Album = "25",
+                    AlbumSpotifyId = "7uwTHXmFa1Ebi5flqBosig",
+                    Artist = "Adele"
+                }
+            };
+
+            Mocker.GetMock<IHttpClient>()
+                .Setup(x => x.Post<List<SpotifyMap>>(It.IsAny<HttpRequest>()))
+                .Throws(new Exception("Dummy exception"));
+
+            Mocker.GetMock<IHttpClient>()
+                .Setup(x => x.Get<AlbumResource>(It.IsAny<HttpRequest>()))
+                .Throws(new Exception("Dummy exception"));
+
+
+            var result = Subject.MapSpotifyReleases(data);
+            result.Should().NotBeNull();
+            ExceptionVerification.ExpectedErrors(2);
+        }
+
+        [Test]
+        public void map_spotify_releases_should_cope_with_duplicate_spotify_ids()
+        {
+            var data = new List<SpotifyImportListItemInfo>
+            {
+                new SpotifyImportListItemInfo
+                {
+                    Album = "25",
+                    AlbumSpotifyId = "7uwTHXmFa1Ebi5flqBosig",
+                    Artist = "Adele"
+                },
+                new SpotifyImportListItemInfo
+                {
+                    Album = "25",
+                    AlbumSpotifyId = "7uwTHXmFa1Ebi5flqBosig",
+                    Artist = "Adele"
+                }
+            };
+
+            var map = new List<SpotifyMap>
+            {
+                new SpotifyMap
+                {
+                    SpotifyId = "7uwTHXmFa1Ebi5flqBosig",
+                    MusicbrainzId = "5537624c-3d2f-4f5c-8099-df916082c85c"
+                }
+            };
+
+            Mocker.GetMock<IHttpClient>()
+                .Setup(x => x.Post<List<SpotifyMap>>(It.IsAny<HttpRequest>()))
+                .Returns<HttpRequest>(r => new HttpResponse<List<SpotifyMap>>(new HttpResponse(r, new HttpHeader(), map.ToJson())));
+
+            var result = Subject.MapSpotifyReleases(data);
+            result.Should().HaveCount(2);
+            result[0].AlbumMusicBrainzId.Should().Be("5537624c-3d2f-4f5c-8099-df916082c85c");
+            result[1].AlbumMusicBrainzId.Should().Be("5537624c-3d2f-4f5c-8099-df916082c85c");
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
@@ -104,6 +104,18 @@ namespace NzbDrone.Core.ImportLists
 
                 }
 
+                // Map artist ID if we only have album ID
+                if  (report.AlbumMusicBrainzId.IsNotNullOrWhiteSpace() && report.ArtistMusicBrainzId.IsNullOrWhiteSpace())
+                {
+                    var mappedAlbum = _albumSearchService.SearchForNewAlbum($"lidarr:{report.AlbumMusicBrainzId}", null)
+                        .FirstOrDefault();
+
+                    if (mappedAlbum == null) continue;
+
+                    report.Artist = mappedAlbum.ArtistMetadata?.Value?.Name;
+                    report.ArtistMusicBrainzId = mappedAlbum?.ArtistMetadata?.Value?.ForeignArtistId;
+                }
+
                 // Map MBid if we only have a artist name
                 if (report.ArtistMusicBrainzId.IsNullOrWhiteSpace() && report.Artist.IsNotNullOrWhiteSpace())
                 {

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyFollowedArtists.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyFollowedArtists.cs
@@ -3,6 +3,7 @@ using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
+using NzbDrone.Core.MetadataSource;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Parser.Model;
 using SpotifyAPI.Web;
@@ -18,21 +19,22 @@ namespace NzbDrone.Core.ImportLists.Spotify
     public class SpotifyFollowedArtists : SpotifyImportListBase<SpotifyFollowedArtistsSettings>
     {
         public SpotifyFollowedArtists(ISpotifyProxy spotifyProxy,
+                                      IMetadataRequestBuilder requestBuilder,
                                       IImportListStatusService importListStatusService,
                                       IImportListRepository importListRepository,
                                       IConfigService configService,
                                       IParsingService parsingService,
                                       IHttpClient httpClient,
                                       Logger logger)
-        : base(spotifyProxy, importListStatusService, importListRepository, configService, parsingService, httpClient, logger)
+        : base(spotifyProxy, requestBuilder, importListStatusService, importListRepository, configService, parsingService, httpClient, logger)
         {
         }
 
         public override string Name => "Spotify Followed Artists";
 
-        public override IList<ImportListItemInfo> Fetch(SpotifyWebAPI api)
+        public override IList<SpotifyImportListItemInfo> Fetch(SpotifyWebAPI api)
         {
-            var result = new List<ImportListItemInfo>();
+            var result = new List<SpotifyImportListItemInfo>();
 
             var followedArtists = _spotifyProxy.GetFollowedArtists(this, api);
             var artists = followedArtists?.Artists;
@@ -61,12 +63,14 @@ namespace NzbDrone.Core.ImportLists.Spotify
             return result;
         }
 
-        private ImportListItemInfo ParseFullArtist(FullArtist artist)
+        private SpotifyImportListItemInfo ParseFullArtist(FullArtist artist)
         {
             if (artist?.Name.IsNotNullOrWhiteSpace() ?? false)
             {
-                return new ImportListItemInfo {
+                return new SpotifyImportListItemInfo
+                {
                     Artist = artist.Name,
+                    ArtistSpotifyId = artist.Id
                 };
             }
 

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyImportListItemInfo.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyImportListItemInfo.cs
@@ -1,0 +1,15 @@
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.ImportLists.Spotify
+{
+    public class SpotifyImportListItemInfo : ImportListItemInfo
+    {
+        public string ArtistSpotifyId { get; set; }
+        public string AlbumSpotifyId { get; set; }
+
+        public override string ToString()
+        {
+            return string.Format("[{0}] {1}", ArtistSpotifyId, AlbumSpotifyId);
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyMap.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyMap.cs
@@ -1,0 +1,8 @@
+namespace NzbDrone.Core.ImportLists.Spotify
+{
+    public class SpotifyMap
+    {
+        public string SpotifyId { get; set; }
+        public string MusicbrainzId { get; set; }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifySavedAlbums.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifySavedAlbums.cs
@@ -4,6 +4,7 @@ using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
+using NzbDrone.Core.MetadataSource;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Parser.Model;
 using SpotifyAPI.Web;
@@ -19,21 +20,22 @@ namespace NzbDrone.Core.ImportLists.Spotify
     public class SpotifySavedAlbums : SpotifyImportListBase<SpotifySavedAlbumsSettings>
     {
         public SpotifySavedAlbums(ISpotifyProxy spotifyProxy,
+                                  IMetadataRequestBuilder requestBuilder,
                                   IImportListStatusService importListStatusService,
                                   IImportListRepository importListRepository,
                                   IConfigService configService,
                                   IParsingService parsingService,
                                   IHttpClient httpClient,
                                   Logger logger)
-        : base(spotifyProxy, importListStatusService, importListRepository, configService, parsingService, httpClient, logger)
+        : base(spotifyProxy, requestBuilder, importListStatusService, importListRepository, configService, parsingService, httpClient, logger)
         {
         }
 
         public override string Name => "Spotify Saved Albums";
 
-        public override IList<ImportListItemInfo> Fetch(SpotifyWebAPI api)
+        public override IList<SpotifyImportListItemInfo> Fetch(SpotifyWebAPI api)
         {
-            var result = new List<ImportListItemInfo>();
+            var result = new List<SpotifyImportListItemInfo>();
 
             var savedAlbums = _spotifyProxy.GetSavedAlbums(this, api);
 
@@ -62,7 +64,7 @@ namespace NzbDrone.Core.ImportLists.Spotify
             return result;
         }
 
-        private ImportListItemInfo ParseSavedAlbum(SavedAlbum savedAlbum)
+        private SpotifyImportListItemInfo ParseSavedAlbum(SavedAlbum savedAlbum)
         {
             var artistName = savedAlbum?.Album?.Artists?.FirstOrDefault()?.Name;
             var albumName = savedAlbum?.Album?.Name;
@@ -70,9 +72,11 @@ namespace NzbDrone.Core.ImportLists.Spotify
 
             if (artistName.IsNotNullOrWhiteSpace() && albumName.IsNotNullOrWhiteSpace())
             {
-                return new ImportListItemInfo {
+                return new SpotifyImportListItemInfo
+                {
                     Artist = artistName,
                     Album = albumName,
+                    AlbumSpotifyId = savedAlbum?.Album?.Id,
                     ReleaseDate = ParseSpotifyDate(savedAlbum?.Album?.ReleaseDate, savedAlbum?.Album?.ReleaseDatePrecision)
                 };
             }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The metadata server has a new endpoint for the mapping from Spotify to musicbrainz.  If no mapping already found, it does a search, takes the best result and caches this for next time.

This commit edits the Spotify import lists to use the new endpoint instead of letting `ImportListSyncService` do a search.

#### Todos
- [x] Tests
