### PR TITLE
Fixed: Don't mark downloads as failed if no files found

### DIFF
--- a/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceFixture.cs
@@ -284,6 +284,19 @@ namespace NzbDrone.Core.Test.Download
         }
 
         [Test]
+        public void should_not_mark_as_failed_if_nothing_found_to_import()
+        {
+            Mocker.GetMock<IDownloadedTracksImportService>()
+                  .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<ImportMode>(), It.IsAny<Artist>(), It.IsAny<DownloadClientItem>()))
+                  .Returns(new List<ImportResult>());
+
+            Subject.Process(_trackedDownload);
+
+            AssertNoCompletedDownload();
+            _trackedDownload.State.Should().NotBe(TrackedDownloadStage.ImportFailed);
+        }
+
+        [Test]
         public void should_not_mark_as_imported_if_all_files_were_skipped()
         {
             Mocker.GetMock<IDownloadedTracksImportService>()

--- a/src/NzbDrone.Core/Download/CompletedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/CompletedDownloadService.cs
@@ -108,9 +108,7 @@ namespace NzbDrone.Core.Download
 
             if (importResults.Empty())
             {
-                trackedDownload.State = TrackedDownloadStage.ImportFailed;
                 trackedDownload.Warn("No files found are eligible for import in {0}", outputPath);
-                _eventAggregator.PublishEvent(new AlbumImportIncompleteEvent(trackedDownload));
                 return;
             }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Restores Sonarr/Radarr behaviour where a download is retried until the files become available.  Restores compatibility with seedboxes.

The downside is that if the path doesn't exist (e.g. due to a bad/missing remote path mapping) it'll just sit in the queue indefinitely instead of failing with a warning.

#### Todos
- [] Tests



#### Issues Fixed or Closed by this PR

* #945 
