### PR TITLE
Fix incorrect deletion of cached object

### DIFF
--- a/src/NzbDrone.Common.Test/CacheTests/CachedFixture.cs
+++ b/src/NzbDrone.Common.Test/CacheTests/CachedFixture.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using FluentAssertions;
 using NUnit.Framework;
@@ -127,6 +127,18 @@ namespace NzbDrone.Common.Test.CacheTests
 
             hitCount.Should().BeInRange(3, 7);
             _cachedString.Values.Should().HaveCount(0);
+        }
+
+        [Test]
+        [Retry(3)]
+        public void should_not_clear_when_superseded()
+        {
+            _cachedString.Set("key", "A", TimeSpan.FromMilliseconds(100));
+            _cachedString.Set("key", "B", TimeSpan.FromMilliseconds(10000));
+
+            Thread.Sleep(1000);
+
+            _cachedString.Values.Should().HaveCount(1);
         }
     }
 

--- a/src/NzbDrone.Common/Cache/Cached.cs
+++ b/src/NzbDrone.Common/Cache/Cached.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using NzbDrone.Common.EnsureThat;
 
@@ -42,7 +43,13 @@ namespace NzbDrone.Common.Cache
 
             if (lifetime != null)
             {
-                System.Threading.Tasks.Task.Delay(lifetime.Value).ContinueWith(t => _store.TryRemove(key, out var temp));
+                System.Threading.Tasks.Task.Delay(lifetime.Value).ContinueWith(t =>
+                {
+                    if (_store.TryRemove(key, out var temp2) && !temp2.IsExpired())
+                    {
+                        _store.TryAdd(key, temp2);
+                    }
+                });
             }
         }
 


### PR DESCRIPTION
The Set method in Cached.cs schedules a deletion of the item that was added by key at a point in the future.  If a different item is added with the same key, it will be deleted at the time scheduled in the first.

#### Issues Fixed or Closed by this PR

#1159
 
