### PR TITLE
Fixed: Don't rescan folders for each artist added via a list

### DIFF
--- a/src/NzbDrone.Core.Test/ImportListTests/ImportListSyncServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/ImportListTests/ImportListSyncServiceFixture.cs
@@ -48,6 +48,14 @@ namespace NzbDrone.Core.Test.ImportListTests
             Mocker.GetMock<IImportListExclusionService>()
                 .Setup(v => v.All())
                 .Returns(new List<ImportListExclusion>());
+
+            Mocker.GetMock<IAddArtistService>()
+                .Setup(v => v.AddArtists(It.IsAny<List<Artist>>(), false))
+                .Returns((List<Artist> artists, bool doRefresh) => artists);
+
+            Mocker.GetMock<IAddAlbumService>()
+                .Setup(v => v.AddAlbums(It.IsAny<List<Album>>()))
+                .Returns((List<Album> albums) => albums);
         }
 
         private void WithAlbum()
@@ -176,7 +184,7 @@ namespace NzbDrone.Core.Test.ImportListTests
             Subject.Execute(new ImportListSyncCommand());
 
             Mocker.GetMock<IAddArtistService>()
-                .Verify(v => v.AddArtists(It.Is<List<Artist>>(t => t.Count == 0)));
+                .Verify(v => v.AddArtists(It.Is<List<Artist>>(t => t.Count == 0), false));
         }
 
         [Test]
@@ -188,7 +196,7 @@ namespace NzbDrone.Core.Test.ImportListTests
             Subject.Execute(new ImportListSyncCommand());
 
             Mocker.GetMock<IAddArtistService>()
-                .Verify(v => v.AddArtists(It.Is<List<Artist>>(t => t.Count == 0)));
+                .Verify(v => v.AddArtists(It.Is<List<Artist>>(t => t.Count == 0), false));
         }
 
         [Test]
@@ -214,7 +222,7 @@ namespace NzbDrone.Core.Test.ImportListTests
             Subject.Execute(new ImportListSyncCommand());
 
             Mocker.GetMock<IAddArtistService>()
-                .Verify(v => v.AddArtists(It.Is<List<Artist>>(t => t.Count == 1 && t.First().Monitored == expectedArtistMonitored)));
+                .Verify(v => v.AddArtists(It.Is<List<Artist>>(t => t.Count == 1 && t.First().Monitored == expectedArtistMonitored), false));
         }
 
         [TestCase(ImportListMonitorType.None, false)]
@@ -240,7 +248,7 @@ namespace NzbDrone.Core.Test.ImportListTests
             Subject.Execute(new ImportListSyncCommand());
 
             Mocker.GetMock<IAddArtistService>()
-                .Verify(v => v.AddArtists(It.Is<List<Artist>>(t => t.Count == 0)));
+                .Verify(v => v.AddArtists(It.Is<List<Artist>>(t => t.Count == 0), false));
         }
 
         [Test]

--- a/src/NzbDrone.Core/Music/Events/ArtistsImportedEvent.cs
+++ b/src/NzbDrone.Core/Music/Events/ArtistsImportedEvent.cs
@@ -6,10 +6,12 @@ namespace NzbDrone.Core.Music.Events
     public class ArtistsImportedEvent : IEvent
     {
         public List<int> ArtistIds { get; private set; }
+        public bool DoRefresh { get; private set; }
 
-        public ArtistsImportedEvent(List<int> artistIds)
+        public ArtistsImportedEvent(List<int> artistIds, bool doRefresh = true)
         {
             ArtistIds = artistIds;
+            DoRefresh = doRefresh;
         }
     }
 }

--- a/src/NzbDrone.Core/Music/Handlers/ArtistAddedHandler.cs
+++ b/src/NzbDrone.Core/Music/Handlers/ArtistAddedHandler.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using NzbDrone.Core.Messaging.Commands;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Music.Commands;
@@ -26,7 +25,10 @@ namespace NzbDrone.Core.Music
 
         public void Handle(ArtistsImportedEvent message)
         {
-            _commandQueueManager.PushMany(message.ArtistIds.Select(s => new RefreshArtistCommand(s, true)).ToList());
+            if (message.DoRefresh)
+            {
+                _commandQueueManager.Push(new BulkRefreshArtistCommand(message.ArtistIds, true));
+            }
         }
     }
 }

--- a/src/NzbDrone.Core/Music/Services/AddArtistService.cs
+++ b/src/NzbDrone.Core/Music/Services/AddArtistService.cs
@@ -17,7 +17,7 @@ namespace NzbDrone.Core.Music
     public interface IAddArtistService
     {
         Artist AddArtist(Artist newArtist, bool doRefresh = true);
-        List<Artist> AddArtists(List<Artist> newArtists);
+        List<Artist> AddArtists(List<Artist> newArtists, bool doRefresh = true);
     }
 
     public class AddArtistService : IAddArtistService
@@ -63,7 +63,7 @@ namespace NzbDrone.Core.Music
             return newArtist;
         }
 
-        public List<Artist> AddArtists(List<Artist> newArtists)
+        public List<Artist> AddArtists(List<Artist> newArtists, bool doRefresh = true)
         {
             var added = DateTime.UtcNow;
             var artistsToAdd = new List<Artist>();
@@ -88,7 +88,7 @@ namespace NzbDrone.Core.Music
             _artistMetadataService.UpsertMany(artistsToAdd.Select(x => x.Metadata.Value).ToList());
             artistsToAdd.ForEach(x => x.ArtistMetadataId = x.Metadata.Value.Id);
 
-            return _artistService.AddArtists(artistsToAdd);
+            return _artistService.AddArtists(artistsToAdd, doRefresh);
         }
 
         private Artist AddSkyhookData(Artist newArtist)

--- a/src/NzbDrone.Core/Music/Services/ArtistService.cs
+++ b/src/NzbDrone.Core/Music/Services/ArtistService.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.Music
         Artist GetArtistByMetadataId(int artistMetadataId);
         List<Artist> GetArtists(IEnumerable<int> artistIds);
         Artist AddArtist(Artist newArtist, bool doRefresh);
-        List<Artist> AddArtists(List<Artist> newArtists);
+        List<Artist> AddArtists(List<Artist> newArtists, bool doRefresh);
         Artist FindById(string foreignArtistId);
         Artist FindByName(string title);
         Artist FindByNameInexact(string title);
@@ -60,11 +60,11 @@ namespace NzbDrone.Core.Music
             return newArtist;
         }
 
-        public List<Artist> AddArtists(List<Artist> newArtists)
+        public List<Artist> AddArtists(List<Artist> newArtists, bool doRefresh)
         {
             _cache.Clear();
             _artistRepository.InsertMany(newArtists);
-            _eventAggregator.PublishEvent(new ArtistsImportedEvent(newArtists.Select(s => s.Id).ToList()));
+            _eventAggregator.PublishEvent(new ArtistsImportedEvent(newArtists.Select(s => s.Id).ToList(), doRefresh));
 
             return newArtists;
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Make sure we only trigger one folder scan when adding multiple artists via a list

#### Issues Fixed or Closed by this PR

* Fixes #1186 
