### PR TITLE
Fixed: Don't refresh and rescan artist when new album added

### DIFF
--- a/src/NzbDrone.Core.Test/ImportListTests/ImportListSyncServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/ImportListTests/ImportListSyncServiceFixture.cs
@@ -54,8 +54,8 @@ namespace NzbDrone.Core.Test.ImportListTests
                 .Returns((List<Artist> artists, bool doRefresh) => artists);
 
             Mocker.GetMock<IAddAlbumService>()
-                .Setup(v => v.AddAlbums(It.IsAny<List<Album>>()))
-                .Returns((List<Album> albums) => albums);
+                .Setup(v => v.AddAlbums(It.IsAny<List<Album>>(), false))
+                .Returns((List<Album> albums, bool doRefresh) => albums);
         }
 
         private void WithAlbum()
@@ -208,7 +208,7 @@ namespace NzbDrone.Core.Test.ImportListTests
             Subject.Execute(new ImportListSyncCommand());
 
             Mocker.GetMock<IAddAlbumService>()
-                .Verify(v => v.AddAlbums(It.Is<List<Album>>(t => t.Count == 1)));
+                .Verify(v => v.AddAlbums(It.Is<List<Album>>(t => t.Count == 1), false));
         }
 
         [TestCase(ImportListMonitorType.None, false)]
@@ -236,7 +236,7 @@ namespace NzbDrone.Core.Test.ImportListTests
             Subject.Execute(new ImportListSyncCommand());
 
             Mocker.GetMock<IAddAlbumService>()
-                .Verify(v => v.AddAlbums(It.Is<List<Album>>(t => t.Count == 1 && t.First().Monitored == expectedAlbumMonitored)));
+                .Verify(v => v.AddAlbums(It.Is<List<Album>>(t => t.Count == 1 && t.First().Monitored == expectedAlbumMonitored), false));
         }
 
         [Test]
@@ -260,7 +260,7 @@ namespace NzbDrone.Core.Test.ImportListTests
             Subject.Execute(new ImportListSyncCommand());
 
             Mocker.GetMock<IAddAlbumService>()
-                .Verify(v => v.AddAlbums(It.Is<List<Album>>(t => t.Count == 0)));
+                .Verify(v => v.AddAlbums(It.Is<List<Album>>(t => t.Count == 0), false));
         }
 
         [Test]
@@ -273,7 +273,7 @@ namespace NzbDrone.Core.Test.ImportListTests
             Subject.Execute(new ImportListSyncCommand());
 
             Mocker.GetMock<IAddAlbumService>()
-                .Verify(v => v.AddAlbums(It.Is<List<Album>>(t => t.Count == 0)));
+                .Verify(v => v.AddAlbums(It.Is<List<Album>>(t => t.Count == 0), false));
         }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
@@ -118,7 +118,7 @@ namespace NzbDrone.Core.ImportLists
             }
 
             var addedArtists = _addArtistService.AddArtists(artistsToAdd, false);
-            var addedAlbums = _addAlbumService.AddAlbums(albumsToAdd);
+            var addedAlbums = _addAlbumService.AddAlbums(albumsToAdd, false);
 
             var message = string.Format($"Import List Sync Completed. Items found: {reports.Count}, Artists added: {addedArtists.Count}, Albums added: {addedAlbums.Count}");
 

--- a/src/NzbDrone.Core/MediaCover/MediaCoverService.cs
+++ b/src/NzbDrone.Core/MediaCover/MediaCoverService.cs
@@ -26,6 +26,7 @@ namespace NzbDrone.Core.MediaCover
     public class MediaCoverService :
         IHandleAsync<ArtistRefreshCompleteEvent>,
         IHandleAsync<ArtistDeletedEvent>,
+        IHandleAsync<AlbumAddedEvent>,
         IHandleAsync<AlbumDeletedEvent>,
         IMapCoversToLocal
     {
@@ -289,6 +290,14 @@ namespace NzbDrone.Core.MediaCover
             if (_diskProvider.FolderExists(path))
             {
                 _diskProvider.DeleteFolder(path, true);
+            }
+        }
+
+        public void HandleAsync(AlbumAddedEvent message)
+        {
+            if (message.DoRefresh)
+            {
+                EnsureAlbumCovers(message.Album);
             }
         }
 

--- a/src/NzbDrone.Core/Music/Commands/RefreshAlbumCommand.cs
+++ b/src/NzbDrone.Core/Music/Commands/RefreshAlbumCommand.cs
@@ -5,14 +5,16 @@ namespace NzbDrone.Core.Music.Commands
     public class RefreshAlbumCommand : Command
     {
         public int? AlbumId { get; set; }
+        public bool IsNewAlbum { get; set; }
 
         public RefreshAlbumCommand()
         {
         }
 
-        public RefreshAlbumCommand(int? albumId)
+        public RefreshAlbumCommand(int? albumId, bool isNewAlbum = false)
         {
             AlbumId = albumId;
+            IsNewAlbum = isNewAlbum;
         }
 
         public override bool SendUpdatesToClient => true;

--- a/src/NzbDrone.Core/Music/Events/AlbumAddedEvent.cs
+++ b/src/NzbDrone.Core/Music/Events/AlbumAddedEvent.cs
@@ -5,10 +5,12 @@ namespace NzbDrone.Core.Music.Events
     public class AlbumAddedEvent : IEvent
     {
         public Album Album { get; private set; }
+        public bool DoRefresh { get; private set; }
 
-        public AlbumAddedEvent(Album album)
+        public AlbumAddedEvent(Album album, bool doRefresh = true)
         {
             Album = album;
+            DoRefresh = doRefresh;
         }
     }
 }

--- a/src/NzbDrone.Core/Music/Services/AddAlbumService.cs
+++ b/src/NzbDrone.Core/Music/Services/AddAlbumService.cs
@@ -12,8 +12,8 @@ namespace NzbDrone.Core.Music
 {
     public interface IAddAlbumService
     {
-        Album AddAlbum(Album album);
-        List<Album> AddAlbums(List<Album> albums);
+        Album AddAlbum(Album album, bool doRefresh = true);
+        List<Album> AddAlbums(List<Album> albums, bool doRefresh = true);
     }
 
     public class AddAlbumService : IAddAlbumService
@@ -40,7 +40,7 @@ namespace NzbDrone.Core.Music
             _logger = logger;
         }
 
-        public Album AddAlbum(Album album)
+        public Album AddAlbum(Album album, bool doRefresh = true)
         {
             _logger.Debug($"Adding album {album}");
 
@@ -65,12 +65,12 @@ namespace NzbDrone.Core.Music
             }
 
             album.ArtistMetadataId = dbArtist.ArtistMetadataId;
-            _albumService.AddAlbum(album);
+            _albumService.AddAlbum(album, doRefresh);
 
             return album;
         }
 
-        public List<Album> AddAlbums(List<Album> albums)
+        public List<Album> AddAlbums(List<Album> albums, bool doRefresh = true)
         {
             var added = DateTime.UtcNow;
             var addedAlbums = new List<Album>();
@@ -78,7 +78,7 @@ namespace NzbDrone.Core.Music
             foreach (var a in albums)
             {
                 a.Added = added;
-                addedAlbums.Add(AddAlbum(a));
+                addedAlbums.Add(AddAlbum(a, doRefresh));
             }
 
             return addedAlbums;

--- a/src/NzbDrone.Core/Music/Services/AlbumService.cs
+++ b/src/NzbDrone.Core/Music/Services/AlbumService.cs
@@ -19,7 +19,7 @@ namespace NzbDrone.Core.Music
         List<Album> GetLastAlbumsByArtistMetadataId(IEnumerable<int> artistMetadataIds);
         List<Album> GetAlbumsByArtistMetadataId(int artistMetadataId);
         List<Album> GetAlbumsForRefresh(int artistMetadataId, IEnumerable<string> foreignIds);
-        Album AddAlbum(Album newAlbum);
+        Album AddAlbum(Album newAlbum, bool doRefresh);
         Album FindById(string foreignId);
         Album FindByTitle(int artistMetadataId, string title);
         Album FindByTitleInexact(int artistMetadataId, string title);
@@ -57,11 +57,11 @@ namespace NzbDrone.Core.Music
             _logger = logger;
         }
 
-        public Album AddAlbum(Album newAlbum)
+        public Album AddAlbum(Album newAlbum, bool doRefresh)
         {
             _albumRepository.Insert(newAlbum);
 
-            _eventAggregator.PublishEvent(new AlbumAddedEvent(GetAlbum(newAlbum.Id)));
+            _eventAggregator.PublishEvent(new AlbumAddedEvent(GetAlbum(newAlbum.Id), doRefresh));
 
             return newAlbum;
         }


### PR DESCRIPTION
#### Database Migration`
NO

#### Description
Speeds up adding a single album to an existing artist.  Should help
reduce the number of full rescans being triggered also - an added
album was triggering one.

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR

* More improvements for #1186 
