### PR TITLE
Fixed: Don't corrupt OPUS files when tagging them

### DIFF
--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -2,6 +2,7 @@
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="Taglib" value="https://pkgs.dev.azure.com/Lidarr/Lidarr/_packaging/Taglib/nuget/v3/index.json" />
     <add key="MyFeed" value="https://pkgs.dev.azure.com/Servarr/Servarr/_packaging/SQLite/nuget/v3/index.json" />
     <add key="FluentMigrator" value="https://www.myget.org/F/fluent-migrator/api/v3/index.json" />
   </packageSources>

--- a/src/NzbDrone.Core/Lidarr.Core.csproj
+++ b/src/NzbDrone.Core/Lidarr.Core.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="NLog" Version="4.6.8" />
     <PackageReference Include="RestSharp" Version="106.10.1" />
     <PackageReference Include="System.IO.Abstractions" Version="7.0.15" />
-    <PackageReference Include="TagLibSharp-Lidarr" Version="2.2.0.19" />
+    <PackageReference Include="TagLibSharp-Lidarr" Version="2.2.0.25" />
     <PackageReference Include="Kveer.XmlRPC" Version="1.1.1" />
     <PackageReference Include="SpotifyAPI.Web" Version="4.2.2" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0007" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Update taglib to fix opus corruption bug

#### Todos
- [x] Tests


#### Issues Fixed or Closed by this PR

* Fixes #841 
