### PR TITLE
Fixed: Write the correct album/releasegroup ids for XBMC/Emby

### DIFF
--- a/src/Lidarr.Api.V1/Artist/ArtistModule.cs
+++ b/src/Lidarr.Api.V1/Artist/ArtistModule.cs
@@ -290,7 +290,10 @@ namespace Lidarr.Api.V1.Artist
 
         public void Handle(MediaCoversUpdatedEvent message)
         {
-            BroadcastResourceChange(ModelAction.Updated, GetArtistResource(message.Artist));
+            if (message.Updated)
+            {
+                BroadcastResourceChange(ModelAction.Updated, GetArtistResource(message.Artist));
+            }
         }
     }
 }

--- a/src/NzbDrone.Core.Test/MusicTests/AlbumMonitoredServiceTests/AlbumMonitoredServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MusicTests/AlbumMonitoredServiceTests/AlbumMonitoredServiceFixture.cs
@@ -58,7 +58,7 @@ namespace NzbDrone.Core.Test.MusicTests.AlbumMonitoredServiceTests
             Subject.SetAlbumMonitoredStatus(_artist, null);
 
             Mocker.GetMock<IArtistService>()
-                  .Verify(v => v.UpdateArtist(It.IsAny<Artist>()), Times.Once());
+                .Verify(v => v.UpdateArtist(It.IsAny<Artist>(), It.IsAny<bool>()), Times.Once());
 
             Mocker.GetMock<IAlbumService>()
                   .Verify(v => v.UpdateMany(It.IsAny<List<Album>>()), Times.Never());
@@ -72,7 +72,7 @@ namespace NzbDrone.Core.Test.MusicTests.AlbumMonitoredServiceTests
             Subject.SetAlbumMonitoredStatus(_artist, new MonitoringOptions { Monitored = true, AlbumsToMonitor = albumsToMonitor });
 
             Mocker.GetMock<IArtistService>()
-                .Verify(v => v.UpdateArtist(It.IsAny<Artist>()), Times.Once());
+                .Verify(v => v.UpdateArtist(It.IsAny<Artist>(), It.IsAny<bool>()), Times.Once());
 
             VerifyMonitored(e => e.ForeignAlbumId == _albums.First().ForeignAlbumId);
             VerifyNotMonitored(e => e.ForeignAlbumId != _albums.First().ForeignAlbumId);

--- a/src/NzbDrone.Core.Test/MusicTests/MoveArtistServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MusicTests/MoveArtistServiceFixture.cs
@@ -87,7 +87,7 @@ namespace NzbDrone.Core.Test.MusicTests
             ExceptionVerification.ExpectedErrors(1);
 
             Mocker.GetMock<IArtistService>()
-                .Verify(v => v.UpdateArtist(It.IsAny<Artist>()), Times.Once());
+                .Verify(v => v.UpdateArtist(It.IsAny<Artist>(), It.IsAny<bool>()), Times.Once());
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/MusicTests/RefreshArtistServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MusicTests/RefreshArtistServiceFixture.cs
@@ -100,8 +100,8 @@ namespace NzbDrone.Core.Test.MusicTests
         private void AllowArtistUpdate()
         {
             Mocker.GetMock<IArtistService>(MockBehavior.Strict)
-                .Setup(x => x.UpdateArtist(It.IsAny<Artist>()))
-                .Returns((Artist a) => a);
+                .Setup(x => x.UpdateArtist(It.IsAny<Artist>(), It.IsAny<bool>()))
+                .Returns((Artist a, bool updated) => a);
         }
 
         [Test]
@@ -151,7 +151,7 @@ namespace NzbDrone.Core.Test.MusicTests
             Subject.Execute(new RefreshArtistCommand(_artist.Id));
 
             Mocker.GetMock<IArtistService>()
-                .Verify(v => v.UpdateArtist(It.IsAny<Artist>()), Times.Never());
+                .Verify(v => v.UpdateArtist(It.IsAny<Artist>(), It.IsAny<bool>()), Times.Never());
 
             Mocker.GetMock<IArtistService>()
                 .Verify(v => v.DeleteArtist(It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Once());
@@ -169,7 +169,7 @@ namespace NzbDrone.Core.Test.MusicTests
             Subject.Execute(new RefreshArtistCommand(_artist.Id));
 
             Mocker.GetMock<IArtistService>()
-                .Verify(v => v.UpdateArtist(It.IsAny<Artist>()), Times.Never());
+                .Verify(v => v.UpdateArtist(It.IsAny<Artist>(), It.IsAny<bool>()), Times.Never());
 
             Mocker.GetMock<IArtistService>()
                 .Verify(v => v.DeleteArtist(It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Never());
@@ -197,8 +197,8 @@ namespace NzbDrone.Core.Test.MusicTests
             // Make sure that the artist is updated before we refresh the albums
             Mocker.GetMock<IArtistService>(MockBehavior.Strict)
                 .InSequence(seq)
-                .Setup(x => x.UpdateArtist(It.IsAny<Artist>()))
-                .Returns((Artist a) => a);
+                .Setup(x => x.UpdateArtist(It.IsAny<Artist>(), It.IsAny<bool>()))
+                .Returns((Artist a, bool updated) => a);
 
             Mocker.GetMock<IAlbumService>(MockBehavior.Strict)
                 .InSequence(seq)
@@ -208,13 +208,13 @@ namespace NzbDrone.Core.Test.MusicTests
             // Update called twice for a move/merge
             Mocker.GetMock<IArtistService>(MockBehavior.Strict)
                 .InSequence(seq)
-                .Setup(x => x.UpdateArtist(It.IsAny<Artist>()))
-                .Returns((Artist a) => a);
+                .Setup(x => x.UpdateArtist(It.IsAny<Artist>(), It.IsAny<bool>()))
+                .Returns((Artist a, bool updated) => a);
 
             Subject.Execute(new RefreshArtistCommand(_artist.Id));
 
             Mocker.GetMock<IArtistService>()
-                .Verify(v => v.UpdateArtist(It.Is<Artist>(s => s.ArtistMetadataId == 100 && s.ForeignArtistId == newArtistInfo.ForeignArtistId)),
+                .Verify(v => v.UpdateArtist(It.Is<Artist>(s => s.ArtistMetadataId == 100 && s.ForeignArtistId == newArtistInfo.ForeignArtistId), It.IsAny<bool>()),
                         Times.Exactly(2));
         }
 
@@ -257,8 +257,8 @@ namespace NzbDrone.Core.Test.MusicTests
 
             Mocker.GetMock<IArtistService>(MockBehavior.Strict)
                 .InSequence(seq)
-                .Setup(x => x.UpdateArtist(It.Is<Artist>(a => a.Id == clash.Id)))
-                .Returns((Artist a) => a);
+                .Setup(x => x.UpdateArtist(It.Is<Artist>(a => a.Id == clash.Id), It.IsAny<bool>()))
+                .Returns((Artist a, bool updated) => a);
 
             Mocker.GetMock<IAlbumService>(MockBehavior.Strict)
                 .InSequence(seq)
@@ -268,14 +268,14 @@ namespace NzbDrone.Core.Test.MusicTests
             // Update called twice for a move/merge
             Mocker.GetMock<IArtistService>(MockBehavior.Strict)
                 .InSequence(seq)
-                .Setup(x => x.UpdateArtist(It.IsAny<Artist>()))
-                .Returns((Artist a) => a);
+                .Setup(x => x.UpdateArtist(It.IsAny<Artist>(), It.IsAny<bool>()))
+                .Returns((Artist a, bool updated) => a);
 
             Subject.Execute(new RefreshArtistCommand(_artist.Id));
 
             // the retained artist gets updated
             Mocker.GetMock<IArtistService>()
-                .Verify(v => v.UpdateArtist(It.Is<Artist>(s => s.Id == clash.Id)), Times.Exactly(2));
+                .Verify(v => v.UpdateArtist(It.Is<Artist>(s => s.Id == clash.Id), It.IsAny<bool>()), Times.Exactly(2));
 
             // the old one gets removed
             Mocker.GetMock<IArtistService>()

--- a/src/NzbDrone.Core/Extras/ExtraService.cs
+++ b/src/NzbDrone.Core/Extras/ExtraService.cs
@@ -24,6 +24,7 @@ namespace NzbDrone.Core.Extras
     public class ExtraService : IExtraService,
                                 IHandle<MediaCoversUpdatedEvent>,
                                 IHandle<TrackFolderCreatedEvent>,
+                                IHandle<ArtistScannedEvent>,
                                 IHandle<ArtistRenamedEvent>
     {
         private readonly IMediaFileService _mediaFileService;
@@ -55,7 +56,7 @@ namespace NzbDrone.Core.Extras
         {
             ImportExtraFiles(localTrack, trackFile, isReadOnly);
 
-            CreateAfterImport(localTrack.Artist, trackFile);
+            CreateAfterTrackImport(localTrack.Artist, trackFile);
         }
 
         public void ImportExtraFiles(LocalTrack localTrack, TrackFile trackFile, bool isReadOnly)
@@ -123,7 +124,7 @@ namespace NzbDrone.Core.Extras
             }
         }
 
-        private void CreateAfterImport(Artist artist, TrackFile trackFile)
+        private void CreateAfterTrackImport(Artist artist, TrackFile trackFile)
         {
             foreach (var extraFileManager in _extraFileManagers)
             {
@@ -132,6 +133,19 @@ namespace NzbDrone.Core.Extras
         }
 
         public void Handle(MediaCoversUpdatedEvent message)
+        {
+            if (message.Updated)
+            {
+                var artist = message.Artist;
+
+                foreach (var extraFileManager in _extraFileManagers)
+                {
+                    extraFileManager.CreateAfterMediaCoverUpdate(artist);
+                }
+            }
+        }
+
+        public void Handle(ArtistScannedEvent message)
         {
             var artist = message.Artist;
 
@@ -150,7 +164,7 @@ namespace NzbDrone.Core.Extras
 
             foreach (var extraFileManager in _extraFileManagers)
             {
-                extraFileManager.CreateAfterTrackImport(artist, album, message.ArtistFolder, message.AlbumFolder);
+                extraFileManager.CreateAfterTrackFolder(artist, album, message.ArtistFolder, message.AlbumFolder);
             }
         }
 

--- a/src/NzbDrone.Core/Extras/Files/ExtraFileManager.cs
+++ b/src/NzbDrone.Core/Extras/Files/ExtraFileManager.cs
@@ -14,9 +14,10 @@ namespace NzbDrone.Core.Extras.Files
     public interface IManageExtraFiles
     {
         int Order { get; }
+        IEnumerable<ExtraFile> CreateAfterMediaCoverUpdate(Artist artist);
         IEnumerable<ExtraFile> CreateAfterArtistScan(Artist artist, List<TrackFile> trackFiles);
         IEnumerable<ExtraFile> CreateAfterTrackImport(Artist artist, TrackFile trackFile);
-        IEnumerable<ExtraFile> CreateAfterTrackImport(Artist artist, Album album, string artistFolder, string albumFolder);
+        IEnumerable<ExtraFile> CreateAfterTrackFolder(Artist artist, Album album, string artistFolder, string albumFolder);
         IEnumerable<ExtraFile> MoveFilesAfterRename(Artist artist, List<TrackFile> trackFiles);
         ExtraFile Import(Artist artist, TrackFile trackFile, string path, string extension, bool readOnly);
     }
@@ -41,9 +42,10 @@ namespace NzbDrone.Core.Extras.Files
         }
 
         public abstract int Order { get; }
+        public abstract IEnumerable<ExtraFile> CreateAfterMediaCoverUpdate(Artist artist);
         public abstract IEnumerable<ExtraFile> CreateAfterArtistScan(Artist artist, List<TrackFile> trackFiles);
         public abstract IEnumerable<ExtraFile> CreateAfterTrackImport(Artist artist, TrackFile trackFile);
-        public abstract IEnumerable<ExtraFile> CreateAfterTrackImport(Artist artist, Album album, string artistFolder, string albumFolder);
+        public abstract IEnumerable<ExtraFile> CreateAfterTrackFolder(Artist artist, Album album, string artistFolder, string albumFolder);
         public abstract IEnumerable<ExtraFile> MoveFilesAfterRename(Artist artist, List<TrackFile> trackFiles);
         public abstract ExtraFile Import(Artist artist, TrackFile trackFile, string path, string extension, bool readOnly);
 

--- a/src/NzbDrone.Core/Extras/Lyrics/LyricService.cs
+++ b/src/NzbDrone.Core/Extras/Lyrics/LyricService.cs
@@ -33,6 +33,11 @@ namespace NzbDrone.Core.Extras.Lyrics
 
         public override int Order => 1;
 
+        public override IEnumerable<ExtraFile> CreateAfterMediaCoverUpdate(Artist artist)
+        {
+            return Enumerable.Empty<ExtraFile>();
+        }
+
         public override IEnumerable<ExtraFile> CreateAfterArtistScan(Artist artist, List<TrackFile> trackFiles)
         {
             return Enumerable.Empty<LyricFile>();
@@ -43,7 +48,7 @@ namespace NzbDrone.Core.Extras.Lyrics
             return Enumerable.Empty<LyricFile>();
         }
 
-        public override IEnumerable<ExtraFile> CreateAfterTrackImport(Artist artist, Album album, string artistFolder, string albumFolder)
+        public override IEnumerable<ExtraFile> CreateAfterTrackFolder(Artist artist, Album album, string artistFolder, string albumFolder)
         {
             return Enumerable.Empty<LyricFile>();
         }

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -141,6 +141,8 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                 return null;
             }
 
+            var albumRelease = album.AlbumReleases.Value.Single(x => x.Monitored);
+
             _logger.Debug("Generating album.nfo for: {0}", album.Title);
             var sb = new StringBuilder();
             var xws = new XmlWriterSettings();
@@ -158,9 +160,11 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                     albumElement.Add(new XElement("rating", album.Ratings.Value));
                 }
 
-                albumElement.Add(new XElement("musicbrainzalbumid", album.ForeignAlbumId));
+                albumElement.Add(new XElement("musicbrainzreleasegroupid", album.ForeignAlbumId));
+                albumElement.Add(new XElement("musicbrainzalbumid", albumRelease.ForeignReleaseId));
                 albumElement.Add(new XElement("artistdesc", artist.Metadata.Value.Overview));
                 albumElement.Add(new XElement("releasedate", album.ReleaseDate.Value.ToShortDateString()));
+                albumElement.Add(new XElement("label", albumRelease.Label));
 
                 var doc = new XDocument(albumElement);
                 doc.Save(xw);

--- a/src/NzbDrone.Core/Extras/Metadata/MetadataService.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/MetadataService.cs
@@ -104,12 +104,12 @@ namespace NzbDrone.Core.Extras.Metadata
                 files.AddIfNotNull(ProcessArtistMetadata(consumer, artist, consumerFiles));
                 files.AddRange(ProcessArtistImages(consumer, artist, consumerFiles));
 
-                var albumGroups = trackFiles.GroupBy(s => Path.GetDirectoryName(s.Path)).ToList();
+                var albumGroups = trackFiles.GroupBy(s => s.AlbumId).ToList();
 
                 foreach (var group in albumGroups)
                 {
-                    var album = _albumService.GetAlbum(group.First().AlbumId);
-                    var albumFolder = group.Key;
+                    var album = _albumService.GetAlbum(group.Key);
+                    var albumFolder = Path.GetDirectoryName(group.First().Path);
                     files.AddIfNotNull(ProcessAlbumMetadata(consumer, artist, album, albumFolder, consumerFiles));
                     files.AddRange(ProcessAlbumImages(consumer, artist, album, albumFolder, consumerFiles));
 
@@ -158,6 +158,12 @@ namespace NzbDrone.Core.Extras.Metadata
                 {
                     files.AddIfNotNull(ProcessArtistMetadata(consumer, artist, consumerFiles));
                     files.AddRange(ProcessArtistImages(consumer, artist, consumerFiles));
+                }
+
+                if (albumFolder.IsNotNullOrWhiteSpace())
+                {
+                    files.AddIfNotNull(ProcessAlbumMetadata(consumer, artist, album, albumFolder, consumerFiles));
+                    files.AddRange(ProcessAlbumImages(consumer, artist, album, albumFolder, consumerFiles));
                 }
             }
 

--- a/src/NzbDrone.Core/Extras/Others/OtherExtraService.cs
+++ b/src/NzbDrone.Core/Extras/Others/OtherExtraService.cs
@@ -29,6 +29,11 @@ namespace NzbDrone.Core.Extras.Others
 
         public override int Order => 2;
 
+        public override IEnumerable<ExtraFile> CreateAfterMediaCoverUpdate(Artist artist)
+        {
+            return Enumerable.Empty<ExtraFile>();
+        }
+
         public override IEnumerable<ExtraFile> CreateAfterArtistScan(Artist artist, List<TrackFile> trackFiles)
         {
             return Enumerable.Empty<ExtraFile>();
@@ -39,7 +44,7 @@ namespace NzbDrone.Core.Extras.Others
             return Enumerable.Empty<ExtraFile>();
         }
 
-        public override IEnumerable<ExtraFile> CreateAfterTrackImport(Artist artist, Album album, string artistFolder, string albumFolder)
+        public override IEnumerable<ExtraFile> CreateAfterTrackFolder(Artist artist, Album album, string artistFolder, string albumFolder)
         {
             return Enumerable.Empty<ExtraFile>();
         }

--- a/src/NzbDrone.Core/MediaCover/MediaCoverService.cs
+++ b/src/NzbDrone.Core/MediaCover/MediaCoverService.cs
@@ -290,10 +290,7 @@ namespace NzbDrone.Core.MediaCover
                 updated |= EnsureAlbumCovers(album);
             }
 
-            if (updated)
-            {
-                _eventAggregator.PublishEvent(new MediaCoversUpdatedEvent(message.Artist));
-            }
+            _eventAggregator.PublishEvent(new MediaCoversUpdatedEvent(message.Artist, updated));
         }
 
         public void HandleAsync(ArtistDeletedEvent message)
@@ -310,10 +307,8 @@ namespace NzbDrone.Core.MediaCover
             if (message.DoRefresh)
             {
                 var updated = EnsureAlbumCovers(message.Album);
-                if (updated)
-                {
-                    _eventAggregator.PublishEvent(new MediaCoversUpdatedEvent(message.Album));
-                }
+
+                _eventAggregator.PublishEvent(new MediaCoversUpdatedEvent(message.Album, updated));
             }
         }
 

--- a/src/NzbDrone.Core/MediaCover/MediaCoversUpdatedEvent.cs
+++ b/src/NzbDrone.Core/MediaCover/MediaCoversUpdatedEvent.cs
@@ -7,15 +7,18 @@ namespace NzbDrone.Core.MediaCover
     {
         public Artist Artist { get; set; }
         public Album Album { get; set; }
+        public bool Updated { get; set; }
 
-        public MediaCoversUpdatedEvent(Artist artist)
+        public MediaCoversUpdatedEvent(Artist artist, bool updated)
         {
             Artist = artist;
+            Updated = updated;
         }
 
-        public MediaCoversUpdatedEvent(Album album)
+        public MediaCoversUpdatedEvent(Album album, bool updated)
         {
             Album = album;
+            Updated = updated;
         }
     }
 }

--- a/src/NzbDrone.Core/Music/Services/ArtistService.cs
+++ b/src/NzbDrone.Core/Music/Services/ArtistService.cs
@@ -24,7 +24,7 @@ namespace NzbDrone.Core.Music
         void DeleteArtist(int artistId, bool deleteFiles, bool addImportListExclusion = false);
         List<Artist> GetAllArtists();
         List<Artist> AllForTag(int tagId);
-        Artist UpdateArtist(Artist artist);
+        Artist UpdateArtist(Artist artist, bool publishUpdatedEvent = true);
         List<Artist> UpdateArtists(List<Artist> artist, bool useExistingRelativeFolder);
         bool ArtistPathExists(string folder);
         void RemoveAddOptions(Artist artist);
@@ -194,12 +194,16 @@ namespace NzbDrone.Core.Music
             _artistRepository.SetFields(artist, s => s.AddOptions);
         }
 
-        public Artist UpdateArtist(Artist artist)
+        public Artist UpdateArtist(Artist artist, bool publishUpdatedEvent = true)
         {
             _cache.Clear();
             var storedArtist = GetArtist(artist.Id);
             var updatedArtist = _artistRepository.Update(artist);
-            _eventAggregator.PublishEvent(new ArtistEditedEvent(updatedArtist, storedArtist));
+
+            if (publishUpdatedEvent)
+            {
+                _eventAggregator.PublishEvent(new ArtistEditedEvent(updatedArtist, storedArtist));
+            }
 
             return updatedArtist;
         }

--- a/src/NzbDrone.Core/Music/Services/RefreshAlbumService.cs
+++ b/src/NzbDrone.Core/Music/Services/RefreshAlbumService.cs
@@ -174,8 +174,10 @@ namespace NzbDrone.Core.Music
             // Force update and fetch covers if images have changed so that we can write them into tags
             if (remote.Images.Any() && !local.Images.SequenceEqual(remote.Images))
             {
-                _mediaCoverService.EnsureAlbumCovers(remote);
-                result = UpdateResult.UpdateTags;
+                if (_mediaCoverService.EnsureAlbumCovers(remote))
+                {
+                    result = UpdateResult.UpdateTags;
+                }
             }
 
             local.UseMetadataFrom(remote);

--- a/src/NzbDrone.Core/Music/Services/RefreshArtistService.cs
+++ b/src/NzbDrone.Core/Music/Services/RefreshArtistService.cs
@@ -190,7 +190,7 @@ namespace NzbDrone.Core.Music
 
         protected override void SaveEntity(Artist local)
         {
-            _artistService.UpdateArtist(local);
+            _artistService.UpdateArtist(local, publishUpdatedEvent: false);
         }
 
         protected override void DeleteEntity(Artist local, bool deleteFiles)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
It was writing the musicbrainz releasegroupid as album id, it should be writing the releaseid

#### Todos
- [x] Tests

#### Issues fixed
- Closes #1399 
- Closes #1338  
- Closes #1318 
