### PR TITLE
New: Token for track artist (as opposed to album artist)

### DIFF
--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
@@ -82,6 +82,12 @@ const trackTitleTokens = [
   { token: '{Track CleanTitle}', example: 'Track Title' }
 ];
 
+const trackArtistTokens = [
+  { token: '{Track ArtistName}', example: 'Artist Name' },
+  { token: '{Track ArtistNameThe}', example: 'Artist Name, The' },
+  { token: '{Track ArtistCleanName}', example: 'Artist Name' }
+];
+
 const qualityTokens = [
   { token: '{Quality Full}', example: 'FLAC Proper' },
   { token: '{Quality Title}', example: 'FLAC' }
@@ -393,6 +399,28 @@ class NamingModal extends Component {
                     <div className={styles.groups}>
                       {
                         trackTitleTokens.map(({ token, example }) => {
+                          return (
+                            <NamingOption
+                              key={token}
+                              name={name}
+                              value={value}
+                              token={token}
+                              example={example}
+                              tokenSeparator={tokenSeparator}
+                              tokenCase={tokenCase}
+                              onPress={this.onOptionPress}
+                            />
+                          );
+                        }
+                        )
+                      }
+                    </div>
+                  </FieldSet>
+
+                  <FieldSet legend="Track Artist">
+                    <div className={styles.groups}>
+                      {
+                        trackArtistTokens.map(({ token, example }) => {
                           return (
                             <NamingOption
                               key={token}

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -114,6 +114,7 @@ namespace NzbDrone.Core.Organizer
             AddAlbumTokens(tokenHandlers, album);
             AddMediumTokens(tokenHandlers, tracks.First().AlbumRelease.Value.Media.SingleOrDefault(m => m.Number == tracks.First().MediumNumber));
             AddTrackTokens(tokenHandlers, tracks);
+            AddTrackArtistTokens(tokenHandlers, tracks);
             AddTrackFileTokens(tokenHandlers, trackFile);
             AddQualityTokens(tokenHandlers, artist, trackFile);
             AddMediaInfoTokens(tokenHandlers, trackFile);
@@ -272,6 +273,16 @@ namespace NzbDrone.Core.Organizer
             {
                 tokenHandlers["{Artist Disambiguation}"] = m => artist.Metadata.Value.Disambiguation;
             }
+        }
+
+        private void AddTrackArtistTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, List<Track> tracks)
+        {
+            var artists = tracks.Select(t => t.ArtistMetadata.Value)
+                .DistinctBy(a => a.Name)
+                .ToList();
+
+            tokenHandlers["{Track ArtistName}"] = m => string.Join("+", artists.Select(a => a.Name));
+            tokenHandlers["{Track ArtistCleanName}"] = m => string.Join("+", artists.Select(a => a.Name));
         }
 
         private void AddAlbumTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, Album album)

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -113,7 +113,7 @@ namespace NzbDrone.Core.Organizer
             AddArtistTokens(tokenHandlers, artist);
             AddAlbumTokens(tokenHandlers, album);
             AddMediumTokens(tokenHandlers, tracks.First().AlbumRelease.Value.Media.SingleOrDefault(m => m.Number == tracks.First().MediumNumber));
-            AddTrackTokens(tokenHandlers, tracks);
+            AddTrackTokens(tokenHandlers, tracks, artist);
             AddTrackFileTokens(tokenHandlers, trackFile);
             AddQualityTokens(tokenHandlers, artist, trackFile);
             AddMediaInfoTokens(tokenHandlers, trackFile);
@@ -301,12 +301,15 @@ namespace NzbDrone.Core.Organizer
             tokenHandlers["{Medium Format}"] = m => medium.Format;
         }
 
-        private void AddTrackTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, List<Track> tracks)
+        private void AddTrackTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, List<Track> tracks, Artist artist)
         {
             tokenHandlers["{Track Title}"] = m => GetTrackTitle(tracks, "+");
             tokenHandlers["{Track CleanTitle}"] = m => CleanTitle(GetTrackTitle(tracks, "and"));
 
-            var firstArtist = tracks.Select(t => t.ArtistMetadata?.Value).FirstOrDefault();
+            // Use the track's ArtistMetadata by default, as it will handle the "Various Artists" case
+            // (where the album artist is "Various Artists" but each track has its own artist). Fall back
+            // to the album artist if we don't have any track ArtistMetadata for whatever reason.
+            var firstArtist = tracks.Select(t => t.ArtistMetadata?.Value).FirstOrDefault() ?? artist.Metadata;
             if (firstArtist != null)
             {
                 tokenHandlers["{Track ArtistName}"] = m => firstArtist.Name;

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -114,7 +114,6 @@ namespace NzbDrone.Core.Organizer
             AddAlbumTokens(tokenHandlers, album);
             AddMediumTokens(tokenHandlers, tracks.First().AlbumRelease.Value.Media.SingleOrDefault(m => m.Number == tracks.First().MediumNumber));
             AddTrackTokens(tokenHandlers, tracks);
-            AddTrackArtistTokens(tokenHandlers, tracks);
             AddTrackFileTokens(tokenHandlers, trackFile);
             AddQualityTokens(tokenHandlers, artist, trackFile);
             AddMediaInfoTokens(tokenHandlers, trackFile);
@@ -275,16 +274,6 @@ namespace NzbDrone.Core.Organizer
             }
         }
 
-        private void AddTrackArtistTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, List<Track> tracks)
-        {
-            var artists = tracks.Select(t => t.ArtistMetadata.Value)
-                .DistinctBy(a => a.Name)
-                .ToList();
-
-            tokenHandlers["{Track ArtistName}"] = m => string.Join("+", artists.Select(a => a.Name));
-            tokenHandlers["{Track ArtistCleanName}"] = m => string.Join("+", artists.Select(a => a.Name));
-        }
-
         private void AddAlbumTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, Album album)
         {
             tokenHandlers["{Album Title}"] = m => album.Title;
@@ -316,6 +305,14 @@ namespace NzbDrone.Core.Organizer
         {
             tokenHandlers["{Track Title}"] = m => GetTrackTitle(tracks, "+");
             tokenHandlers["{Track CleanTitle}"] = m => CleanTitle(GetTrackTitle(tracks, "and"));
+
+            var firstArtist = tracks.Select(t => t.ArtistMetadata?.Value).FirstOrDefault();
+            if (firstArtist != null)
+            {
+                tokenHandlers["{Track ArtistName}"] = m => firstArtist.Name;
+                tokenHandlers["{Track ArtistCleanName}"] = m => CleanTitle(firstArtist.Name);
+                tokenHandlers["{Track ArtistNameThe}"] = m => TitleThe(firstArtist.Name);
+            }
         }
 
         private void AddTrackFileTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, TrackFile trackFile)

--- a/src/NzbDrone.Core/Organizer/FileNameSampleService.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameSampleService.cs
@@ -86,6 +86,7 @@ namespace NzbDrone.Core.Organizer
             _track1 = new Track
             {
                 AlbumRelease = _singleRelease,
+                Artist = _standardArtist,
                 AbsoluteTrackNumber = 3,
                 MediumNumber = 1,
 

--- a/src/NzbDrone.Core/Organizer/FileNameSampleService.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameSampleService.cs
@@ -29,14 +29,15 @@ namespace NzbDrone.Core.Organizer
         public FileNameSampleService(IBuildFileNames buildFileNames)
         {
             _buildFileNames = buildFileNames;
+            var artistMetadata = new ArtistMetadata
+            {
+                Name = "The Artist Name",
+                Disambiguation = "US Rock Band"
+            };
 
             _standardArtist = new Artist
             {
-                Metadata = new ArtistMetadata
-                {
-                    Name = "The Artist Name",
-                    Disambiguation = "US Rock Band"
-                }
+                Metadata = artistMetadata
             };
 
             _standardAlbum = new Album
@@ -89,6 +90,7 @@ namespace NzbDrone.Core.Organizer
                 Artist = _standardArtist,
                 AbsoluteTrackNumber = 3,
                 MediumNumber = 1,
+                ArtistMetadata = artistMetadata,
 
                 Title = "Track Title (1)",
             };


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adds a new `{Track ArtistName}` token that contains the track's artist name, not the album's artist name. This is primarily useful with "Various Artists" albums.

I originally tried calling it `{Track Artist Name}` but the `TitleRegex` only allows a single space in the token name, so I went with `{Track ArtistName}` instead. Let me know if you'd prefer some other token.

Before:
![image](https://user-images.githubusercontent.com/91933/104822635-e925b300-57f8-11eb-9a42-9bd72c2161a7.png)

After:
![image](https://user-images.githubusercontent.com/91933/104822655-fd69b000-57f8-11eb-9fcf-d4340518c296.png)

#### Todos
- [x] Tests
- [ ] Wiki Updates

#### Issues Fixed or Closed by this PR

* Fixes #1791
