### PR TITLE
Use name instead of title for XBMC artist.nfo metadata

### DIFF
--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -114,7 +114,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
             {
                 var artistElement = new XElement("artist");
 
-                artistElement.Add(new XElement("title", artist.Name));
+                artistElement.Add(new XElement("name", artist.Name));
 
                 if (artist.Metadata.Value.Ratings != null && artist.Metadata.Value.Ratings.Votes > 0)
                 {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Kodi reads the artist name from the `name` field, not the `title` field. See [kodi.wiki](https://kodi.wiki/view/NFO_files/Music#nfo_Tags). I think this was missed when tvshow.nfo was converted to artist.nfo.

It doesn't look like there are any tests for writing metadata. Should I create one for this change?

#### Todos
- [ ] Tests
- [ ] Wiki Updates

#### Issues Fixed or Closed by this PR

* N/A
