### PR TITLE
Fixed: Remove checkbox to unmonitor tracks on delete

### DIFF
--- a/frontend/src/Settings/MediaManagement/MediaManagement.js
+++ b/frontend/src/Settings/MediaManagement/MediaManagement.js
@@ -219,18 +219,6 @@ class MediaManagement extends Component {
                 <FieldSet
                   legend="File Management"
                 >
-                  <FormGroup size={sizes.MEDIUM}>
-                    <FormLabel>Ignore Deleted Tracks</FormLabel>
-
-                    <FormInputGroup
-                      type={inputTypes.CHECK}
-                      name="autoUnmonitorPreviouslyDownloadedTracks"
-                      helpText="Tracks deleted from disk are automatically unmonitored in Lidarr"
-                      onChange={onInputChange}
-                      {...settings.autoUnmonitorPreviouslyDownloadedTracks}
-                    />
-                  </FormGroup>
-
                   <FormGroup
                     advancedSettings={advancedSettings}
                     isAdvanced={true}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
In Media Management, there was a checkbox to Unmonitor Deleted Tracks, which was not hooked up to any code. This PR removes that checkbox from the UI to avoid any confusion.

#### Screenshot (if UI related)

![image](https://user-images.githubusercontent.com/15488393/125464643-9890d213-d780-4e8a-87ab-c54aaff7b3f7.png)

#### Todos
- [ ] Tests
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR
