### PR TITLE
Fixed: NullReferenceException manually importing an unparseable release

### DIFF
--- a/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceTests/ImportFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceTests/ImportFixture.cs
@@ -167,7 +167,7 @@ namespace NzbDrone.Core.Test.Download.CompletedDownloadServiceTests
 
             Subject.Import(_trackedDownload);
 
-            _trackedDownload.State.Should().Be(TrackedDownloadState.Importing);
+            _trackedDownload.State.Should().Be(TrackedDownloadState.ImportPending);
         }
 
         [Test]

--- a/src/NzbDrone.Core/Download/CompletedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/CompletedDownloadService.cs
@@ -109,16 +109,13 @@ namespace NzbDrone.Core.Download
             if (importResults.Empty())
             {
                 trackedDownload.Warn("No files found are eligible for import in {0}", outputPath);
+                trackedDownload.State = TrackedDownloadState.ImportPending;
                 return;
             }
 
             var allTracksImported = importResults.All(c => c.Result == ImportResultType.Imported) ||
                 importResults.Count(c => c.Result == ImportResultType.Imported) >=
                 Math.Max(1, trackedDownload.RemoteAlbum.Albums.Sum(x => x.AlbumReleases.Value.Where(y => y.Monitored).Sum(z => z.TrackCount)));
-
-            Console.WriteLine($"allimported: {allTracksImported}");
-            Console.WriteLine($"count: {importResults.Count(c => c.Result == ImportResultType.Imported)}");
-            Console.WriteLine($"max: {Math.Max(1, trackedDownload.RemoteAlbum.Albums.Sum(x => x.AlbumReleases.Value.Where(y => y.Monitored).Sum(z => z.TrackCount)))}");
 
             if (allTracksImported)
             {
@@ -147,11 +144,6 @@ namespace NzbDrone.Core.Download
             }
 
             trackedDownload.State = TrackedDownloadState.ImportPending;
-
-            if (importResults.Empty())
-            {
-                trackedDownload.Warn("No files found are eligible for import in {0}", outputPath);
-            }
 
             if (importResults.Any(c => c.Result != ImportResultType.Imported))
             {

--- a/src/NzbDrone.Core/Download/DownloadProcessingService.cs
+++ b/src/NzbDrone.Core/Download/DownloadProcessingService.cs
@@ -54,15 +54,22 @@ namespace NzbDrone.Core.Download
 
             foreach (var trackedDownload in trackedDownloads)
             {
+                _logger.Trace($"Processing tracked download {trackedDownload.DownloadItem.Title}");
                 try
                 {
                     if (trackedDownload.State == TrackedDownloadState.DownloadFailedPending)
                     {
+                        _logger.Trace("Failed");
                         _failedDownloadService.ProcessFailed(trackedDownload);
                     }
                     else if (enableCompletedDownloadHandling && trackedDownload.State == TrackedDownloadState.ImportPending)
                     {
+                        _logger.Trace("ImportPending");
                         _completedDownloadService.Import(trackedDownload);
+                    }
+                    else
+                    {
+                        _logger.Trace($"state is {trackedDownload.State}, no action taken");
                     }
                 }
                 catch (Exception e)

--- a/src/NzbDrone.Core/Download/TrackedDownloads/DownloadMonitoringService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/DownloadMonitoringService.cs
@@ -114,6 +114,7 @@ namespace NzbDrone.Core.Download.TrackedDownloads
             try
             {
                 var trackedDownload = _trackedDownloadService.TrackDownload((DownloadClientDefinition)downloadClient.Definition, downloadItem);
+                _logger.Trace($"processing item {trackedDownload.DownloadItem.Title}");
 
                 if (trackedDownload != null && trackedDownload.State == TrackedDownloadState.Downloading)
                 {
@@ -138,12 +139,14 @@ namespace NzbDrone.Core.Download.TrackedDownloads
                 trackedDownload.State == TrackedDownloadState.DownloadFailed ||
                 trackedDownload.State == TrackedDownloadState.Ignored)
             {
+                _logger.Trace($"Download {trackedDownload.DownloadItem.Title} not trackable, state is {trackedDownload.State}");
                 return false;
             }
 
             // If CDH is disabled and the download status is complete don't track it
             if (!_configService.EnableCompletedDownloadHandling && trackedDownload.DownloadItem.Status == DownloadItemStatus.Completed)
             {
+                _logger.Trace("no CDH enabled");
                 return false;
             }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fix exception manually importing release from queue if `RemoteAlbum` is `null`

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes Sentry LIDARR-GY