### PR TITLE
Fixed: Trim all leading dots from nested folders (#2371)

### DIFF
--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/NestedFileNameBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/NestedFileNameBuilderFixture.cs
@@ -29,11 +29,11 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
         {
             _artist = Builder<Artist>
                     .CreateNew()
-                    .With(s => s.Name = "Linkin Park")
+                    .With(s => s.Name = "Metallica")
                     .With(s => s.Metadata = new ArtistMetadata
                     {
-                        Disambiguation = "US Rock Band",
-                        Name = "Linkin Park"
+                        Disambiguation = "US Metal Band",
+                        Name = "Metallica"
                     })
                     .Build();
 
@@ -55,7 +55,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
 
             _album = Builder<Album>
                 .CreateNew()
-                .With(s => s.Title = "Hybrid Theory")
+                .With(s => s.Title = "...And Justice For All")
                 .With(s => s.ReleaseDate = new DateTime(2020, 1, 15))
                 .With(s => s.AlbumType = "Album")
                 .With(s => s.Disambiguation = "The Best Album")
@@ -97,7 +97,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
             _namingConfig.StandardTrackFormat = "{Album Title} {(Release Year)}/{Artist Name} - {track:00} [{Quality Title}] {[Quality Proper]}";
 
             Subject.BuildTrackFileName(new List<Track> { _track1 }, _artist, _album, _trackFile)
-                   .Should().Be("Hybrid Theory (2020)\\Linkin Park - 06 [MP3-256]".AsOsAgnostic());
+                   .Should().Be("And Justice For All (2020)\\Metallica - 06 [MP3-256]".AsOsAgnostic());
         }
 
         [Test]
@@ -106,7 +106,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
             _namingConfig.StandardTrackFormat = "{Album Title} {(Release Year)}\\{Artist Name} - {track:00} [{Quality Title}] {[Quality Proper]}";
 
             Subject.BuildTrackFileName(new List<Track> { _track1 }, _artist, _album, _trackFile)
-                   .Should().Be("Hybrid Theory (2020)\\Linkin Park - 06 [MP3-256]".AsOsAgnostic());
+                   .Should().Be("And Justice For All (2020)\\Metallica - 06 [MP3-256]".AsOsAgnostic());
         }
 
         [Test]
@@ -117,7 +117,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
             _release.Media.Add(_medium2);
 
             Subject.BuildTrackFileName(new List<Track> { _track1 }, _artist, _album, _trackFile)
-                   .Should().Be("Hybrid Theory (2020)\\CD 03\\Linkin Park - 06 [MP3-256]".AsOsAgnostic());
+                   .Should().Be("And Justice For All (2020)\\CD 03\\Metallica - 06 [MP3-256]".AsOsAgnostic());
         }
 
         [Test]
@@ -128,7 +128,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
             _release.Media.Add(_medium2);
 
             Subject.BuildTrackFileName(new List<Track> { _track1 }, _artist, _album, _trackFile)
-                   .Should().Be("Hybrid Theory (2020)\\CD 03\\Linkin Park - 06 [MP3-256]".AsOsAgnostic());
+                   .Should().Be("And Justice For All (2020)\\CD 03\\Metallica - 06 [MP3-256]".AsOsAgnostic());
         }
     }
 }

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -131,7 +131,7 @@ namespace NzbDrone.Core.Organizer
 
                 var component = ReplaceTokens(splitPattern, tokenHandlers, namingConfig).Trim();
 
-                component = FileNameCleanupRegex.Replace(component, match => match.Captures[0].Value[0].ToString());
+                component = CleanFolderName(component);
                 component = TrimSeparatorsRegex.Replace(component, string.Empty);
 
                 if (component.IsNotNullOrWhiteSpace())


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Remove leading ellipses/dots from nested folder names so that they are not hidden.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #2371