### PR TITLE
Stop erroneous propagation of MapToLocal changes (Lidarr#2443)

### DIFF
--- a/src/Lidarr.Api.V1/Albums/AlbumControllerWithSignalR.cs
+++ b/src/Lidarr.Api.V1/Albums/AlbumControllerWithSignalR.cs
@@ -42,6 +42,15 @@ namespace Lidarr.Api.V1.Albums
         {
             var resource = album.ToResource();
 
+            // To prevent propagating changes to the MediaCovers in the Images list (made by MapCoversToLocal below), clone the items for this resource
+            // N.B. Done here it does not affect every album resource grab (e.g. browsing from UI), only notifications from Album Import/Changes
+            List<MediaCover> newImages = new List<MediaCover>(resource.Images.Count);
+            resource.Images.ForEach((item) =>
+            {
+                newImages.Add((MediaCover)item.Clone());
+            });
+            resource.Images = newImages;
+
             if (includeArtist)
             {
                 var artist = album.Artist.Value;

--- a/src/NzbDrone.Core/MediaCover/MediaCover.cs
+++ b/src/NzbDrone.Core/MediaCover/MediaCover.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using Equ;
 using NzbDrone.Common.Extensions;
@@ -24,7 +25,7 @@ namespace NzbDrone.Core.MediaCover
         Album = 1
     }
 
-    public class MediaCover : MemberwiseEquatable<MediaCover>, IEmbeddedDocument
+    public class MediaCover : MemberwiseEquatable<MediaCover>, IEmbeddedDocument, ICloneable
     {
         private string _url;
         public string Url
@@ -54,6 +55,12 @@ namespace NzbDrone.Core.MediaCover
         {
             CoverType = coverType;
             Url = url;
+        }
+
+        public object Clone()
+        {
+            //Implement ICloneable to ease cloning.
+            return this.MemberwiseClone();
         }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
tl;dr: Prevent changing the url for MediaCover images to a local resource when processing album change notifications.

The web API is making changes to the items in the Images list of the Album resource. Since it is using a direct reference to `model.Images` the `MediaCover` items in the list are being modified to local resources by `MapCoversToLocal(resource);`. This causes problems when the source of the model is a notification that is being sent to many consumers.

I originally put this in `AlbumResourceMapper->ToResource<AlbumResource>`; however, that gets called every time a model is converted to a resource (all web grabs) which is overkill. Putting it here limits unnecessary clones.

To ease cloning a MediaCover item, I added ICloneable, since it's a structure consisting of only primitive types.

#### Screenshot (if UI related)
N/A

#### Todos
- [ ] Tests
- [x] [Wiki Updates](https://wiki.servarr.com) - N/A

#### Issues Fixed or Closed by this PR

* Fixes #2443 