### PR TITLE
deluge: create a category for lidarr to consider a download failed. c…

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/Deluge/DelugeProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/DelugeProxy.cs
@@ -32,7 +32,7 @@ namespace NzbDrone.Core.Download.Clients.Deluge
 
     public class DelugeProxy : IDelugeProxy
     {
-        private static readonly string[] RequiredProperties = new string[] { "hash", "name", "state", "progress", "eta", "message", "is_finished", "save_path", "total_size", "total_done", "time_added", "active_time", "ratio", "is_auto_managed", "stop_at_ratio", "remove_at_ratio", "stop_ratio" };
+        private static readonly string[] RequiredProperties = new string[] { "hash", "name", "state", "progress", "eta", "message", "is_finished", "save_path", "total_size", "total_done", "time_added", "active_time", "ratio", "is_auto_managed", "stop_at_ratio", "remove_at_ratio", "stop_ratio", "label" };
 
         private readonly IHttpClient _httpClient;
         private readonly Logger _logger;

--- a/src/NzbDrone.Core/Download/Clients/Deluge/DelugeSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/DelugeSettings.cs
@@ -50,6 +50,9 @@ namespace NzbDrone.Core.Download.Clients.Deluge
         [FieldDefinition(6, Label = "Post-Import Category", Type = FieldType.Textbox, Advanced = true, HelpText = "Category for Lidarr to set after it has imported the download. Lidarr will not remove torrents in that category even if seeding finished. Leave blank to keep same category.")]
         public string MusicImportedCategory { get; set; }
 
+        [FieldDefinition(6, Label = "Failure Category", Type = FieldType.Textbox, Advanced = true, HelpText = "Category for Lidarr to treat a download as failed (applied externally). Leave blank to ignore.")]
+        public string MusicFailureCategory { get; set; }
+
         [FieldDefinition(7, Label = "Recent Priority", Type = FieldType.Select, SelectOptions = typeof(DelugePriority), HelpText = "Priority to use when grabbing albums released within the last 14 days")]
         public int RecentTvPriority { get; set; }
 

--- a/src/NzbDrone.Core/Download/Clients/Deluge/DelugeTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/DelugeTorrent.cs
@@ -51,5 +51,8 @@ namespace NzbDrone.Core.Download.Clients.Deluge
 
         [JsonProperty(PropertyName = "stop_ratio")]
         public double StopRatio { get; set; }
+
+        [JsonProperty(PropertyName = "label")]
+        public string Label { get; set; }
     }
 }


### PR DESCRIPTION
…ategory can be applied by an external tool to handle stalled downloads.

#### Database Migration
NO

#### Description
Allow users to apply a category that lidarr to consider a download a failure. This should allow users to detect and handle stalled downloads either manually or with an external automation tool to detect stalled or slow torrents.

#### Screenshot (if UI related)

#### Todos
- [?] Tests
- [?] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [X] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR
* Fixes #436