### PR TITLE
Missing secondary type (Audio drama) added

### DIFF
--- a/src/NzbDrone.Core.Test/Files/Identification/CorruptFile.json
+++ b/src/NzbDrone.Core.Test/Files/Identification/CorruptFile.json
@@ -114,6 +114,13 @@
               "name": "Compilation"
             },
             "allowed": false
+          },
+          {
+            "secondaryAlbumType": {
+              "id": 11,
+              "name": "Audio drama"
+            },
+            "allowed": false
           }
         ],
         "releaseStatuses": [

--- a/src/NzbDrone.Core.Test/Files/Identification/FilesWithMBIds.json
+++ b/src/NzbDrone.Core.Test/Files/Identification/FilesWithMBIds.json
@@ -116,6 +116,13 @@
               "name": "Compilation"
             },
             "allowed": false
+          },
+          {
+            "secondaryAlbumType": {
+              "id": 11,
+              "name": "Audio drama"
+            },
+            "allowed": false
           }
         ],
         "releaseStatuses": [

--- a/src/NzbDrone.Core.Test/Files/Identification/FilesWithoutTags.json
+++ b/src/NzbDrone.Core.Test/Files/Identification/FilesWithoutTags.json
@@ -114,6 +114,13 @@
               "name": "Compilation"
             },
             "allowed": false
+          },
+          {
+            "secondaryAlbumType": {
+              "id": 11,
+              "name": "Audio drama"
+            },
+            "allowed": false
           }
         ],
         "releaseStatuses": [

--- a/src/NzbDrone.Core.Test/Files/Identification/InconsistentTyposInAlbum.json
+++ b/src/NzbDrone.Core.Test/Files/Identification/InconsistentTyposInAlbum.json
@@ -114,6 +114,13 @@
               "name": "Compilation"
             },
             "allowed": false
+          },
+          {
+            "secondaryAlbumType": {
+              "id": 11,
+              "name": "Audio drama"
+            },
+            "allowed": false
           }
         ],
         "releaseStatuses": [

--- a/src/NzbDrone.Core.Test/Files/Identification/PenalizeUnknownMedia.json
+++ b/src/NzbDrone.Core.Test/Files/Identification/PenalizeUnknownMedia.json
@@ -114,6 +114,13 @@
               "name": "Compilation"
             },
             "allowed": false
+          },
+          {
+            "secondaryAlbumType": {
+              "id": 11,
+              "name": "Audio drama"
+            },
+            "allowed": false
           }
         ],
         "releaseStatuses": [

--- a/src/NzbDrone.Core.Test/Files/Identification/PreferMissingToBadMatch.json
+++ b/src/NzbDrone.Core.Test/Files/Identification/PreferMissingToBadMatch.json
@@ -114,6 +114,13 @@
               "name": "Studio"
             },
             "allowed": true
+          },
+          {
+            "secondaryAlbumType": {
+              "id": 11,
+              "name": "Audio drama"
+            },
+            "allowed": false
           }
         ],
         "releaseStatuses": [

--- a/src/NzbDrone.Core.Test/Files/Identification/SucceedWhenManyAlbumsHaveSameTitle.json
+++ b/src/NzbDrone.Core.Test/Files/Identification/SucceedWhenManyAlbumsHaveSameTitle.json
@@ -114,6 +114,13 @@
               "name": "Compilation"
             },
             "allowed": false
+          },
+          {
+            "secondaryAlbumType": {
+              "id": 11,
+              "name": "Audio drama"
+            },
+            "allowed": false
           }
         ],
         "releaseStatuses": [

--- a/src/NzbDrone.Core/Datastore/Migration/060_update_audio_types.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/060_update_audio_types.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+using System.Data;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Dapper;
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(060)]
+    public class update_audio_types : NzbDroneMigrationBase
+    {
+        private readonly JsonSerializerOptions _serializerSettings;
+
+        public update_audio_types()
+        {
+            _serializerSettings = new JsonSerializerOptions
+            {
+                AllowTrailingCommas = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+                PropertyNameCaseInsensitive = true,
+                DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                WriteIndented = true
+            };
+        }
+
+        protected override void MainDbUpgrade()
+        {
+            Execute.WithConnection(GetEntries);
+        }
+
+        private void GetEntries(IDbConnection conn, IDbTransaction tran)
+        {
+            var profiles = conn.Query<MetadataProfile059>($"SELECT \"Id\", \"SecondaryAlbumTypes\" FROM \"MetadataProfiles\"");
+
+            var corrected = new List<MetadataProfile059>();
+
+            foreach (var profile in profiles)
+            {
+                var oldTypes = JsonSerializer.Deserialize<List<SecondaryAlbumType059>>(profile.SecondaryAlbumTypes, _serializerSettings);
+
+                oldTypes.Add(new SecondaryAlbumType059
+                {
+                    SecondaryAlbumType = 11,
+                    Allowed = false
+                });
+
+                corrected.Add(new MetadataProfile059
+                {
+                    Id = profile.Id,
+                    SecondaryAlbumTypes = JsonSerializer.Serialize(oldTypes, _serializerSettings)
+                });
+            }
+
+            var updateSql = $"UPDATE \"MetadataProfiles\" SET \"SecondaryAlbumTypes\" = @SecondaryAlbumTypes WHERE \"Id\" = @Id";
+            conn.Execute(updateSql, corrected, transaction: tran);
+        }
+
+        private class MetadataProfile059
+        {
+            public int Id { get; set; }
+            public string SecondaryAlbumTypes { get; set; }
+        }
+
+        private class SecondaryAlbumType059
+        {
+            public int SecondaryAlbumType { get; set; }
+            public bool Allowed { get; set; }
+        }
+    }
+}

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -652,6 +652,8 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
                     return SecondaryAlbumType.Mixtape;
                 case "demo":
                     return SecondaryAlbumType.Demo;
+                case "audio drama":
+                    return SecondaryAlbumType.Audiodrama;
                 default:
                     return SecondaryAlbumType.Studio;
             }

--- a/src/NzbDrone.Core/Music/Model/SecondaryAlbumType.cs
+++ b/src/NzbDrone.Core/Music/Model/SecondaryAlbumType.cs
@@ -76,6 +76,7 @@ namespace NzbDrone.Core.Music
         public static SecondaryAlbumType DJMix => new SecondaryAlbumType(8, "DJ-mix");
         public static SecondaryAlbumType Mixtape => new SecondaryAlbumType(9, "Mixtape/Street");
         public static SecondaryAlbumType Demo => new SecondaryAlbumType(10, "Demo");
+        public static SecondaryAlbumType Audiodrama => new SecondaryAlbumType(11, "Audio drama");
 
         public static readonly List<SecondaryAlbumType> All = new List<SecondaryAlbumType>
         {
@@ -88,7 +89,8 @@ namespace NzbDrone.Core.Music
             Remix,
             DJMix,
             Mixtape,
-            Demo
+            Demo,
+            Audiodrama
         };
 
         public static SecondaryAlbumType FindById(int id)


### PR DESCRIPTION
#### Screenshot (if UI related)

<img width="736" alt="image" src="https://user-images.githubusercontent.com/60104758/167716660-d02b791b-1b4f-4dd2-9b45-16d4eb16baa8.png">

#### Todos
- [X] Tests
- [X] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [X] [Wiki Updates](https://wiki.servarr.com)

* Fixes Metadata Profile selector - "Audio drama" missing in "Edit Metadata Profile" (https://musicbrainz.org/doc/Release_Group/Type)