### PR TITLE
Skip inaccessible children when scanning media directories

### DIFF
--- a/src/NzbDrone.Common/Disk/DiskProviderBase.cs
+++ b/src/NzbDrone.Common/Disk/DiskProviderBase.cs
@@ -506,7 +506,13 @@ namespace NzbDrone.Common.Disk
 
             var di = _fileSystem.DirectoryInfo.FromDirectoryName(path);
 
-            return di.GetFiles("*", searchOption).ToList();
+            var enumerationOpts = new EnumerationOptions
+            {
+                IgnoreInaccessible = true,
+                RecurseSubdirectories = searchOption == SearchOption.AllDirectories
+            };
+
+            return di.EnumerateFiles("*", enumerationOpts).ToList();
         }
 
         public IFileInfo GetFileInfo(string path)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When running Lidarr on macOS and using an external volume as a root directory, Lidarr fails to scan the root directory. This is because user accounts typically lack permissions to read the `.Spotlight-V100` and in some cases `.Trashes` subdirectories.

<img width="1082" alt="Screenshot 2022-10-14 at 16 23 23" src="https://user-images.githubusercontent.com/3542064/195883296-257c108b-74d4-49e6-bc25-58fcb79dd337.png">

It would be more helpful for me here if Lidarr were to just skip over any failed directories rather than marking the entire scan job as failed.

The newer `EnumerateFiles` method within `DirectoryInfo` allows you to pass in an `EnumerationOptions`, which has a `IgnoreInaccessible` property. By setting this to `true`, the scan will continue.

#### Considerations

This may lead Lidarr to believe that a scan has succeeded even if an external volume has been unmounted/removed. In this case, would Lidarr mark all of the tracks as missing? This would not be the correct behaviour.
