### PR TITLE
fix: add end date to calendar events

### DIFF
--- a/src/Lidarr.Api.V1/Calendar/CalendarFeedController.cs
+++ b/src/Lidarr.Api.V1/Calendar/CalendarFeedController.cs
@@ -66,6 +66,8 @@ namespace Lidarr.Api.V1.Calendar
                 occurrence.Categories = album.Genres;
 
                 occurrence.Start = new CalDateTime(album.ReleaseDate.Value.ToLocalTime()) { HasTime = false };
+                occurrence.End = occurrence.Start;
+                occurrence.IsAllDay = true;
 
                 occurrence.Summary = $"{artist.Name} - {album.Title}";
             }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adds a `DTEND` tag to the iCal events

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

Fixes: #3218