### PR TITLE
feat: rename download clients vars from tv to music

### DIFF
--- a/src/NzbDrone.Core.Test/Datastore/Migration/036_add_download_client_priorityFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/Migration/036_add_download_client_priorityFixture.cs
@@ -158,8 +158,8 @@ namespace NzbDrone.Core.Test.Datastore.Migration
         public string UrlBase { get; set; }
         public string Password { get; set; }
         public string MusicCategory { get; set; }
-        public int RecentTvPriority { get; set; }
-        public int OlderTvPriority { get; set; }
+        public int RecentMusicPriority { get; set; }
+        public int OlderMusicPriority { get; set; }
         public bool UseSsl { get; set; }
     }
 
@@ -171,8 +171,8 @@ namespace NzbDrone.Core.Test.Datastore.Migration
         public string Username { get; set; }
         public string Password { get; set; }
         public string MusicCategory { get; set; }
-        public int RecentTvPriority { get; set; }
-        public int OlderTvPriority { get; set; }
+        public int RecentMusicPriority { get; set; }
+        public int OlderMusicPriority { get; set; }
         public bool UseSsl { get; set; }
     }
 }

--- a/src/NzbDrone.Core.Test/Datastore/Migration/051_cdh_per_downloadclientFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/Migration/051_cdh_per_downloadclientFixture.cs
@@ -124,8 +124,8 @@ namespace NzbDrone.Core.Test.Datastore.Migration
         public string UrlBase { get; set; }
         public string Password { get; set; }
         public string MovieCategory { get; set; }
-        public int RecentTvPriority { get; set; }
-        public int OlderTvPriority { get; set; }
+        public int RecentMusicPriority { get; set; }
+        public int OlderMusicPriority { get; set; }
         public bool UseSsl { get; set; }
     }
 }

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/TorrentDownloadStationFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/TorrentDownloadStationFixture.cs
@@ -324,9 +324,9 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
             _settings.MusicCategory = _category;
         }
 
-        protected void GivenTvDirectory()
+        protected void GivenMusicDirectory()
         {
-            _settings.TvDirectory = _musicDirectory;
+            _settings.MusicDirectory = _musicDirectory;
         }
 
         protected virtual void GivenTasks(List<DownloadStationTask> torrents)
@@ -385,10 +385,10 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
         }
 
         [Test]
-        public void Download_with_TvDirectory_should_force_directory()
+        public void Download_with_MusicDirectory_should_force_directory()
         {
             GivenSerialNumber();
-            GivenTvDirectory();
+            GivenMusicDirectory();
             GivenSuccessfulDownload();
 
             var remoteAlbum = CreateRemoteAlbum();
@@ -419,7 +419,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
         }
 
         [Test]
-        public void Download_without_TvDirectory_and_Category_should_use_default()
+        public void Download_without_MusicDirectory_and_Category_should_use_default()
         {
             GivenSerialNumber();
             GivenSuccessfulDownload();
@@ -459,7 +459,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
         [Test]
         public void GetItems_should_ignore_downloads_in_wrong_folder()
         {
-            _settings.TvDirectory = @"/shared/folder/sub";
+            _settings.MusicDirectory = @"/shared/folder/sub";
 
             GivenSerialNumber();
             GivenSharedFolder();
@@ -526,7 +526,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
         public void GetStatus_should_map_outputpath_when_using_destination()
         {
             GivenSerialNumber();
-            GivenTvDirectory();
+            GivenMusicDirectory();
             GivenSharedFolder($"/{_musicDirectory}");
 
             var status = Subject.GetStatus();

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/UsenetDownloadStationFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/UsenetDownloadStationFixture.cs
@@ -216,9 +216,9 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
             _settings.MusicCategory = _category;
         }
 
-        protected void GivenTvDirectory()
+        protected void GivenMusicDirectory()
         {
-            _settings.TvDirectory = _musicDirectory;
+            _settings.MusicDirectory = _musicDirectory;
         }
 
         protected virtual void GivenTasks(List<DownloadStationTask> nzbs)
@@ -267,10 +267,10 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
         }
 
         [Test]
-        public void Download_with_TvDirectory_should_force_directory()
+        public void Download_with_MusicDirectory_should_force_directory()
         {
             GivenSerialNumber();
-            GivenTvDirectory();
+            GivenMusicDirectory();
             GivenSuccessfulDownload();
 
             var remoteAlbum = CreateRemoteAlbum();
@@ -301,7 +301,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
         }
 
         [Test]
-        public void Download_without_TvDirectory_and_Category_should_use_default()
+        public void Download_without_MusicDirectory_and_Category_should_use_default()
         {
             GivenSerialNumber();
             GivenSuccessfulDownload();
@@ -341,7 +341,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
         [Test]
         public void GetItems_should_ignore_downloads_in_wrong_folder()
         {
-            _settings.TvDirectory = @"/shared/folder/sub";
+            _settings.MusicDirectory = @"/shared/folder/sub";
 
             GivenSerialNumber();
             GivenSharedFolder();
@@ -408,7 +408,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
         public void GetStatus_should_map_outputpath_when_using_destination()
         {
             GivenSerialNumber();
-            GivenTvDirectory();
+            GivenMusicDirectory();
             GivenSharedFolder($"/{_musicDirectory}");
 
             var status = Subject.GetStatus();

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/NzbVortexTests/NzbVortexFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/NzbVortexTests/NzbVortexFixture.cs
@@ -33,7 +33,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.NzbVortexTests
                 Port = 2222,
                 ApiKey = "1234-ABCD",
                 MusicCategory = "Music",
-                RecentTvPriority = (int)NzbgetPriority.High
+                RecentMusicPriority = (int)NzbgetPriority.High
             };
 
             _queued = new NzbVortexQueueItem

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/NzbgetTests/NzbgetFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/NzbgetTests/NzbgetFixture.cs
@@ -34,7 +34,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.NzbgetTests
                 Username = "admin",
                 Password = "pass",
                 MusicCategory = "music",
-                RecentTvPriority = (int)NzbgetPriority.High
+                RecentMusicPriority = (int)NzbgetPriority.High
             };
 
             _queued = new NzbgetQueueItem

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
@@ -103,8 +103,8 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
 
         protected void GivenHighPriority()
         {
-            Subject.Definition.Settings.As<QBittorrentSettings>().OlderTvPriority = (int)QBittorrentPriority.First;
-            Subject.Definition.Settings.As<QBittorrentSettings>().RecentTvPriority = (int)QBittorrentPriority.First;
+            Subject.Definition.Settings.As<QBittorrentSettings>().OlderMusicPriority = (int)QBittorrentPriority.First;
+            Subject.Definition.Settings.As<QBittorrentSettings>().RecentMusicPriority = (int)QBittorrentPriority.First;
         }
 
         protected void GivenGlobalSeedLimits(float maxRatio, int maxSeedingTime = -1, QBittorrentMaxRatioAction maxRatioAction = QBittorrentMaxRatioAction.Pause)

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/SabnzbdTests/SabnzbdFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/SabnzbdTests/SabnzbdFixture.cs
@@ -38,7 +38,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.SabnzbdTests
                 Username = "admin",
                 Password = "pass",
                 MusicCategory = "tv",
-                RecentTvPriority = (int)SabnzbdPriority.High
+                RecentMusicPriority = (int)SabnzbdPriority.High
             };
             _queued = new SabnzbdQueue
             {
@@ -353,7 +353,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.SabnzbdTests
         }
 
         [Test]
-        public void Download_should_use_sabRecentTvPriority_when_recentEpisode_is_true()
+        public void Download_should_use_sabRecentMusicPriority_when_recentAlbum_is_true()
         {
             Mocker.GetMock<ISabnzbdProxy>()
                     .Setup(s => s.DownloadNzb(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<string>(), (int)SabnzbdPriority.High, It.IsAny<SabnzbdSettings>()))

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixture.cs
@@ -66,9 +66,9 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
         }
 
         [Test]
-        public void Download_with_TvDirectory_should_force_directory()
+        public void Download_with_MusicDirectory_should_force_directory()
         {
-            GivenTvDirectory();
+            GivenMusicDirectory();
             GivenSuccessfulDownload();
 
             var remoteAlbum = CreateRemoteAlbum();
@@ -116,7 +116,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
         }
 
         [Test]
-        public void Download_without_TvDirectory_and_Category_should_use_default()
+        public void Download_without_MusicDirectory_and_Category_should_use_default()
         {
             GivenSuccessfulDownload();
 
@@ -224,9 +224,9 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
         }
 
         [Test]
-        public void should_exclude_items_not_in_TvDirectory()
+        public void should_exclude_items_not_in_MusicDirectory()
         {
-            GivenTvDirectory();
+            GivenMusicDirectory();
 
             _downloading.DownloadDir = @"C:/Downloads/Finished/Lidarr/subdir";
 

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixtureBase.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixtureBase.cs
@@ -117,9 +117,9 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
             _settings.MusicCategory = "Lidarr";
         }
 
-        protected void GivenTvDirectory()
+        protected void GivenMusicDirectory()
         {
-            _settings.TvDirectory = @"C:/Downloads/Finished/Lidarr";
+            _settings.MusicDirectory = @"C:/Downloads/Finished/Lidarr";
         }
 
         protected void GivenFailedDownload()

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/VuzeTests/VuzeFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/VuzeTests/VuzeFixture.cs
@@ -75,9 +75,9 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.VuzeTests
         }
 
         [Test]
-        public void Download_with_TvDirectory_should_force_directory()
+        public void Download_with_MusicDirectory_should_force_directory()
         {
-            GivenTvDirectory();
+            GivenMusicDirectory();
             GivenSuccessfulDownload();
 
             var remoteAlbum = CreateRemoteAlbum();
@@ -125,7 +125,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.VuzeTests
         }
 
         [Test]
-        public void Download_without_TvDirectory_and_Category_should_use_default()
+        public void Download_without_MusicDirectory_and_Category_should_use_default()
         {
             GivenSuccessfulDownload();
 
@@ -233,9 +233,9 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.VuzeTests
         }
 
         [Test]
-        public void should_exclude_items_not_in_TvDirectory()
+        public void should_exclude_items_not_in_MusicDirectory()
         {
-            GivenTvDirectory();
+            GivenMusicDirectory();
 
             _downloading.DownloadDir = @"C:/Downloads/Finished/Lidarr/subdir";
 

--- a/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
@@ -68,8 +68,8 @@ namespace NzbDrone.Core.Download.Clients.Deluge
 
             var isRecentAlbum = remoteAlbum.IsRecentAlbum();
 
-            if ((isRecentAlbum && Settings.RecentTvPriority == (int)DelugePriority.First) ||
-                (!isRecentAlbum && Settings.OlderTvPriority == (int)DelugePriority.First))
+            if ((isRecentAlbum && Settings.RecentMusicPriority == (int)DelugePriority.First) ||
+                (!isRecentAlbum && Settings.OlderMusicPriority == (int)DelugePriority.First))
             {
                 _proxy.MoveTorrentToTopInQueue(actualHash, Settings);
             }
@@ -95,8 +95,8 @@ namespace NzbDrone.Core.Download.Clients.Deluge
 
             var isRecentAlbum = remoteAlbum.IsRecentAlbum();
 
-            if ((isRecentAlbum && Settings.RecentTvPriority == (int)DelugePriority.First) ||
-                (!isRecentAlbum && Settings.OlderTvPriority == (int)DelugePriority.First))
+            if ((isRecentAlbum && Settings.RecentMusicPriority == (int)DelugePriority.First) ||
+                (!isRecentAlbum && Settings.OlderMusicPriority == (int)DelugePriority.First))
             {
                 _proxy.MoveTorrentToTopInQueue(actualHash, Settings);
             }

--- a/src/NzbDrone.Core/Download/Clients/Deluge/DelugeSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/DelugeSettings.cs
@@ -51,10 +51,10 @@ namespace NzbDrone.Core.Download.Clients.Deluge
         public string MusicImportedCategory { get; set; }
 
         [FieldDefinition(7, Label = "Recent Priority", Type = FieldType.Select, SelectOptions = typeof(DelugePriority), HelpText = "Priority to use when grabbing albums released within the last 14 days")]
-        public int RecentTvPriority { get; set; }
+        public int RecentMusicPriority { get; set; }
 
         [FieldDefinition(8, Label = "Older Priority", Type = FieldType.Select, SelectOptions = typeof(DelugePriority), HelpText = "Priority to use when grabbing albums released over 14 days ago")]
-        public int OlderTvPriority { get; set; }
+        public int OlderMusicPriority { get; set; }
 
         [FieldDefinition(9, Label = "Add Paused", Type = FieldType.Checkbox)]
         public bool AddPaused { get; set; }

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/DownloadStationSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/DownloadStationSettings.cs
@@ -14,14 +14,14 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
             RuleFor(c => c.Host).ValidHost();
             RuleFor(c => c.Port).InclusiveBetween(1, 65535);
 
-            RuleFor(c => c.TvDirectory).Matches(@"^(?!/).+")
-                                       .When(c => c.TvDirectory.IsNotNullOrWhiteSpace())
+            RuleFor(c => c.MusicDirectory).Matches(@"^(?!/).+")
+                                       .When(c => c.MusicDirectory.IsNotNullOrWhiteSpace())
                                        .WithMessage("Cannot start with /");
 
             RuleFor(c => c.MusicCategory).Matches(@"^\.?[-a-z]*$", RegexOptions.IgnoreCase).WithMessage("Allowed characters a-z and -");
 
             RuleFor(c => c.MusicCategory).Empty()
-                                      .When(c => c.TvDirectory.IsNotNullOrWhiteSpace())
+                                      .When(c => c.MusicDirectory.IsNotNullOrWhiteSpace())
                                       .WithMessage("Cannot use Category and Directory");
         }
     }
@@ -49,7 +49,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
         public string MusicCategory { get; set; }
 
         [FieldDefinition(6, Label = "Directory", Type = FieldType.Textbox, HelpText = "Optional shared folder to put downloads into, leave blank to use the default Download Station location")]
-        public string TvDirectory { get; set; }
+        public string MusicDirectory { get; set; }
 
         public DownloadStationSettings()
         {

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
@@ -68,9 +68,9 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
             {
                 var outputPath = new OsPath($"/{torrent.Additional.Detail["destination"]}");
 
-                if (Settings.TvDirectory.IsNotNullOrWhiteSpace())
+                if (Settings.MusicDirectory.IsNotNullOrWhiteSpace())
                 {
-                    if (!new OsPath($"/{Settings.TvDirectory}").Contains(outputPath))
+                    if (!new OsPath($"/{Settings.MusicDirectory}").Contains(outputPath))
                     {
                         continue;
                     }
@@ -315,7 +315,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
 
                 if (downloadDir == null)
                 {
-                    return new NzbDroneValidationFailure(nameof(Settings.TvDirectory), "No default destination")
+                    return new NzbDroneValidationFailure(nameof(Settings.MusicDirectory), "No default destination")
                     {
                         DetailedDescription = $"You must login into your Diskstation as {Settings.Username} and manually set it up into DownloadStation settings under BT/HTTP/FTP/NZB -> Location."
                     };
@@ -326,7 +326,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
                 if (downloadDir != null)
                 {
                     var sharedFolder = downloadDir.Split('\\', '/')[0];
-                    var fieldName = Settings.TvDirectory.IsNotNullOrWhiteSpace() ? nameof(Settings.TvDirectory) : nameof(Settings.MusicCategory);
+                    var fieldName = Settings.MusicDirectory.IsNotNullOrWhiteSpace() ? nameof(Settings.MusicDirectory) : nameof(Settings.MusicCategory);
 
                     var folderInfo = _fileStationProxy.GetInfoFileOrDirectory($"/{downloadDir}", Settings);
 
@@ -449,9 +449,9 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
 
         protected string GetDownloadDirectory()
         {
-            if (Settings.TvDirectory.IsNotNullOrWhiteSpace())
+            if (Settings.MusicDirectory.IsNotNullOrWhiteSpace())
             {
-                return Settings.TvDirectory.TrimStart('/');
+                return Settings.MusicDirectory.TrimStart('/');
             }
 
             var destDir = GetDefaultDir();

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
@@ -78,9 +78,9 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
                     totalRemainingSize += taskRemainingSize;
                 }
 
-                if (Settings.TvDirectory.IsNotNullOrWhiteSpace())
+                if (Settings.MusicDirectory.IsNotNullOrWhiteSpace())
                 {
-                    if (!new OsPath($"/{Settings.TvDirectory}").Contains(outputPath))
+                    if (!new OsPath($"/{Settings.MusicDirectory}").Contains(outputPath))
                     {
                         continue;
                     }
@@ -213,7 +213,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
 
                 if (downloadDir == null)
                 {
-                    return new NzbDroneValidationFailure(nameof(Settings.TvDirectory), "No default destination")
+                    return new NzbDroneValidationFailure(nameof(Settings.MusicDirectory), "No default destination")
                     {
                         DetailedDescription = $"You must login into your Diskstation as {Settings.Username} and manually set it up into DownloadStation settings under BT/HTTP/FTP/NZB -> Location."
                     };
@@ -224,7 +224,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
                 if (downloadDir != null)
                 {
                     var sharedFolder = downloadDir.Split('\\', '/')[0];
-                    var fieldName = Settings.TvDirectory.IsNotNullOrWhiteSpace() ? nameof(Settings.TvDirectory) : nameof(Settings.MusicCategory);
+                    var fieldName = Settings.MusicDirectory.IsNotNullOrWhiteSpace() ? nameof(Settings.MusicDirectory) : nameof(Settings.MusicCategory);
 
                     var folderInfo = _fileStationProxy.GetInfoFileOrDirectory($"/{downloadDir}", Settings);
 
@@ -425,9 +425,9 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
 
         protected string GetDownloadDirectory()
         {
-            if (Settings.TvDirectory.IsNotNullOrWhiteSpace())
+            if (Settings.MusicDirectory.IsNotNullOrWhiteSpace())
             {
-                return Settings.TvDirectory.TrimStart('/');
+                return Settings.MusicDirectory.TrimStart('/');
             }
 
             var destDir = GetDefaultDir();

--- a/src/NzbDrone.Core/Download/Clients/NzbVortex/NzbVortex.cs
+++ b/src/NzbDrone.Core/Download/Clients/NzbVortex/NzbVortex.cs
@@ -32,7 +32,7 @@ namespace NzbDrone.Core.Download.Clients.NzbVortex
 
         protected override string AddFromNzbFile(RemoteAlbum remoteAlbum, string filename, byte[] fileContent)
         {
-            var priority = remoteAlbum.IsRecentAlbum() ? Settings.RecentTvPriority : Settings.OlderTvPriority;
+            var priority = remoteAlbum.IsRecentAlbum() ? Settings.RecentMusicPriority : Settings.OlderMusicPriority;
 
             var response = _proxy.DownloadNzb(fileContent, filename, priority, Settings);
 

--- a/src/NzbDrone.Core/Download/Clients/NzbVortex/NzbVortexSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/NzbVortex/NzbVortexSettings.cs
@@ -32,8 +32,8 @@ namespace NzbDrone.Core.Download.Clients.NzbVortex
             Host = "localhost";
             Port = 4321;
             MusicCategory = "Music";
-            RecentTvPriority = (int)NzbVortexPriority.Normal;
-            OlderTvPriority = (int)NzbVortexPriority.Normal;
+            RecentMusicPriority = (int)NzbVortexPriority.Normal;
+            OlderMusicPriority = (int)NzbVortexPriority.Normal;
         }
 
         [FieldDefinition(0, Label = "Host", Type = FieldType.Textbox)]
@@ -52,10 +52,10 @@ namespace NzbDrone.Core.Download.Clients.NzbVortex
         public string MusicCategory { get; set; }
 
         [FieldDefinition(5, Label = "Recent Priority", Type = FieldType.Select, SelectOptions = typeof(NzbVortexPriority), HelpText = "Priority to use when grabbing albums released within the last 14 days")]
-        public int RecentTvPriority { get; set; }
+        public int RecentMusicPriority { get; set; }
 
         [FieldDefinition(6, Label = "Older Priority", Type = FieldType.Select, SelectOptions = typeof(NzbVortexPriority), HelpText = "Priority to use when grabbing albums released over 14 days ago")]
-        public int OlderTvPriority { get; set; }
+        public int OlderMusicPriority { get; set; }
 
         public NzbDroneValidationResult Validate()
         {

--- a/src/NzbDrone.Core/Download/Clients/Nzbget/Nzbget.cs
+++ b/src/NzbDrone.Core/Download/Clients/Nzbget/Nzbget.cs
@@ -37,7 +37,7 @@ namespace NzbDrone.Core.Download.Clients.Nzbget
         protected override string AddFromNzbFile(RemoteAlbum remoteAlbum, string filename, byte[] fileContent)
         {
             var category = Settings.MusicCategory;
-            var priority = remoteAlbum.IsRecentAlbum() ? Settings.RecentTvPriority : Settings.OlderTvPriority;
+            var priority = remoteAlbum.IsRecentAlbum() ? Settings.RecentMusicPriority : Settings.OlderMusicPriority;
 
             var addpaused = Settings.AddPaused;
             var response = _proxy.DownloadNzb(fileContent, filename, category, priority, addpaused, Settings);

--- a/src/NzbDrone.Core/Download/Clients/Nzbget/NzbgetSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Nzbget/NzbgetSettings.cs
@@ -32,8 +32,8 @@ namespace NzbDrone.Core.Download.Clients.Nzbget
             MusicCategory = "Music";
             Username = "nzbget";
             Password = "tegbzn6789";
-            RecentTvPriority = (int)NzbgetPriority.Normal;
-            OlderTvPriority = (int)NzbgetPriority.Normal;
+            RecentMusicPriority = (int)NzbgetPriority.Normal;
+            OlderMusicPriority = (int)NzbgetPriority.Normal;
         }
 
         [FieldDefinition(0, Label = "Host", Type = FieldType.Textbox)]
@@ -58,10 +58,10 @@ namespace NzbDrone.Core.Download.Clients.Nzbget
         public string MusicCategory { get; set; }
 
         [FieldDefinition(7, Label = "Recent Priority", Type = FieldType.Select, SelectOptions = typeof(NzbgetPriority), HelpText = "Priority to use when grabbing albums released within the last 14 days")]
-        public int RecentTvPriority { get; set; }
+        public int RecentMusicPriority { get; set; }
 
         [FieldDefinition(8, Label = "Older Priority", Type = FieldType.Select, SelectOptions = typeof(NzbgetPriority), HelpText = "Priority to use when grabbing albums released over 14 days ago")]
-        public int OlderTvPriority { get; set; }
+        public int OlderMusicPriority { get; set; }
 
         [FieldDefinition(9, Label = "Add Paused", Type = FieldType.Checkbox, HelpText = "This option requires at least NzbGet version 16.0")]
         public bool AddPaused { get; set; }

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -74,7 +74,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             var setShareLimits = remoteAlbum.SeedConfiguration != null && (remoteAlbum.SeedConfiguration.Ratio.HasValue || remoteAlbum.SeedConfiguration.SeedTime.HasValue);
             var addHasSetShareLimits = setShareLimits && ProxyApiVersion >= new Version(2, 8, 1);
             var isRecentAlbum = remoteAlbum.IsRecentAlbum();
-            var moveToTop = (isRecentAlbum && Settings.RecentTvPriority == (int)QBittorrentPriority.First) || (!isRecentAlbum && Settings.OlderTvPriority == (int)QBittorrentPriority.First);
+            var moveToTop = (isRecentAlbum && Settings.RecentMusicPriority == (int)QBittorrentPriority.First) || (!isRecentAlbum && Settings.OlderMusicPriority == (int)QBittorrentPriority.First);
             var forceStart = (QBittorrentState)Settings.InitialState == QBittorrentState.ForceStart;
 
             Proxy.AddTorrentFromUrl(magnetLink, addHasSetShareLimits && setShareLimits ? remoteAlbum.SeedConfiguration : null, Settings);
@@ -131,7 +131,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             var setShareLimits = remoteAlbum.SeedConfiguration != null && (remoteAlbum.SeedConfiguration.Ratio.HasValue || remoteAlbum.SeedConfiguration.SeedTime.HasValue);
             var addHasSetShareLimits = setShareLimits && ProxyApiVersion >= new Version(2, 8, 1);
             var isRecentAlbum = remoteAlbum.IsRecentAlbum();
-            var moveToTop = (isRecentAlbum && Settings.RecentTvPriority == (int)QBittorrentPriority.First) || (!isRecentAlbum && Settings.OlderTvPriority == (int)QBittorrentPriority.First);
+            var moveToTop = (isRecentAlbum && Settings.RecentMusicPriority == (int)QBittorrentPriority.First) || (!isRecentAlbum && Settings.OlderMusicPriority == (int)QBittorrentPriority.First);
             var forceStart = (QBittorrentState)Settings.InitialState == QBittorrentState.ForceStart;
 
             Proxy.AddTorrentFromFile(filename, fileContent, addHasSetShareLimits ? remoteAlbum.SeedConfiguration : null, Settings);
@@ -529,8 +529,8 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
         private ValidationFailure TestPrioritySupport()
         {
-            var recentPriorityDefault = Settings.RecentTvPriority == (int)QBittorrentPriority.Last;
-            var olderPriorityDefault = Settings.OlderTvPriority == (int)QBittorrentPriority.Last;
+            var recentPriorityDefault = Settings.RecentMusicPriority == (int)QBittorrentPriority.Last;
+            var olderPriorityDefault = Settings.OlderMusicPriority == (int)QBittorrentPriority.Last;
 
             if (olderPriorityDefault && recentPriorityDefault)
             {
@@ -545,11 +545,11 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                 {
                     if (!recentPriorityDefault)
                     {
-                        return new NzbDroneValidationFailure(nameof(Settings.RecentTvPriority), "Queueing not enabled") { DetailedDescription = "Torrent Queueing is not enabled in your qBittorrent settings. Enable it in qBittorrent or select 'Last' as priority." };
+                        return new NzbDroneValidationFailure(nameof(Settings.RecentMusicPriority), "Queueing not enabled") { DetailedDescription = "Torrent Queueing is not enabled in your qBittorrent settings. Enable it in qBittorrent or select 'Last' as priority." };
                     }
                     else if (!olderPriorityDefault)
                     {
-                        return new NzbDroneValidationFailure(nameof(Settings.OlderTvPriority), "Queueing not enabled") { DetailedDescription = "Torrent Queueing is not enabled in your qBittorrent settings. Enable it in qBittorrent or select 'Last' as priority." };
+                        return new NzbDroneValidationFailure(nameof(Settings.OlderMusicPriority), "Queueing not enabled") { DetailedDescription = "Torrent Queueing is not enabled in your qBittorrent settings. Enable it in qBittorrent or select 'Last' as priority." };
                     }
                 }
             }

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs
@@ -55,10 +55,10 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
         public string MusicImportedCategory { get; set; }
 
         [FieldDefinition(8, Label = "Recent Priority", Type = FieldType.Select, SelectOptions = typeof(QBittorrentPriority), HelpText = "Priority to use when grabbing albums released within the last 14 days")]
-        public int RecentTvPriority { get; set; }
+        public int RecentMusicPriority { get; set; }
 
         [FieldDefinition(9, Label = "Older Priority", Type = FieldType.Select, SelectOptions = typeof(QBittorrentPriority), HelpText = "Priority to use when grabbing albums released over 14 days ago")]
-        public int OlderTvPriority { get; set; }
+        public int OlderMusicPriority { get; set; }
 
         [FieldDefinition(10, Label = "Initial State", Type = FieldType.Select, SelectOptions = typeof(QBittorrentState), HelpText = "Initial state for torrents added to qBittorrent")]
         public int InitialState { get; set; }

--- a/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
+++ b/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
@@ -38,7 +38,7 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
         protected override string AddFromNzbFile(RemoteAlbum remoteAlbum, string filename, byte[] fileContent)
         {
             var category = Settings.MusicCategory;
-            var priority = remoteAlbum.IsRecentAlbum() ? Settings.RecentTvPriority : Settings.OlderTvPriority;
+            var priority = remoteAlbum.IsRecentAlbum() ? Settings.RecentMusicPriority : Settings.OlderMusicPriority;
 
             var response = _proxy.DownloadNzb(fileContent, filename, category, priority, Settings);
 

--- a/src/NzbDrone.Core/Download/Clients/Sabnzbd/SabnzbdSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Sabnzbd/SabnzbdSettings.cs
@@ -41,8 +41,8 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
             Host = "localhost";
             Port = 8080;
             MusicCategory = "music";
-            RecentTvPriority = (int)SabnzbdPriority.Default;
-            OlderTvPriority = (int)SabnzbdPriority.Default;
+            RecentMusicPriority = (int)SabnzbdPriority.Default;
+            OlderMusicPriority = (int)SabnzbdPriority.Default;
         }
 
         [FieldDefinition(0, Label = "Host", Type = FieldType.Textbox)]
@@ -70,10 +70,10 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
         public string MusicCategory { get; set; }
 
         [FieldDefinition(8, Label = "Recent Priority", Type = FieldType.Select, SelectOptions = typeof(SabnzbdPriority), HelpText = "Priority to use when grabbing albums released within the last 14 days")]
-        public int RecentTvPriority { get; set; }
+        public int RecentMusicPriority { get; set; }
 
         [FieldDefinition(9, Label = "Older Priority", Type = FieldType.Select, SelectOptions = typeof(SabnzbdPriority), HelpText = "Priority to use when grabbing albums released over 14 days ago")]
-        public int OlderTvPriority { get; set; }
+        public int OlderMusicPriority { get; set; }
 
         public NzbDroneValidationResult Validate()
         {

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
@@ -47,9 +47,9 @@ namespace NzbDrone.Core.Download.Clients.Transmission
 
                 var outputPath = new OsPath(torrent.DownloadDir);
 
-                if (Settings.TvDirectory.IsNotNullOrWhiteSpace())
+                if (Settings.MusicDirectory.IsNotNullOrWhiteSpace())
                 {
-                    if (!new OsPath(Settings.TvDirectory).Contains(outputPath))
+                    if (!new OsPath(Settings.MusicDirectory).Contains(outputPath))
                     {
                         continue;
                     }
@@ -165,9 +165,9 @@ namespace NzbDrone.Core.Download.Clients.Transmission
         public override DownloadClientInfo GetStatus()
         {
             string destDir;
-            if (Settings.TvDirectory.IsNotNullOrWhiteSpace())
+            if (Settings.MusicDirectory.IsNotNullOrWhiteSpace())
             {
-                destDir = Settings.TvDirectory;
+                destDir = Settings.MusicDirectory;
             }
             else
             {
@@ -194,8 +194,8 @@ namespace NzbDrone.Core.Download.Clients.Transmission
 
             var isRecentAlbum = remoteAlbum.IsRecentAlbum();
 
-            if ((isRecentAlbum && Settings.RecentTvPriority == (int)TransmissionPriority.First) ||
-                (!isRecentAlbum && Settings.OlderTvPriority == (int)TransmissionPriority.First))
+            if ((isRecentAlbum && Settings.RecentMusicPriority == (int)TransmissionPriority.First) ||
+                (!isRecentAlbum && Settings.OlderMusicPriority == (int)TransmissionPriority.First))
             {
                 _proxy.MoveTorrentToTopInQueue(hash, Settings);
             }
@@ -210,8 +210,8 @@ namespace NzbDrone.Core.Download.Clients.Transmission
 
             var isRecentAlbum = remoteAlbum.IsRecentAlbum();
 
-            if ((isRecentAlbum && Settings.RecentTvPriority == (int)TransmissionPriority.First) ||
-                (!isRecentAlbum && Settings.OlderTvPriority == (int)TransmissionPriority.First))
+            if ((isRecentAlbum && Settings.RecentMusicPriority == (int)TransmissionPriority.First) ||
+                (!isRecentAlbum && Settings.OlderMusicPriority == (int)TransmissionPriority.First))
             {
                 _proxy.MoveTorrentToTopInQueue(hash, Settings);
             }
@@ -237,9 +237,9 @@ namespace NzbDrone.Core.Download.Clients.Transmission
 
         protected string GetDownloadDirectory()
         {
-            if (Settings.TvDirectory.IsNotNullOrWhiteSpace())
+            if (Settings.MusicDirectory.IsNotNullOrWhiteSpace())
             {
-                return Settings.TvDirectory;
+                return Settings.MusicDirectory;
             }
 
             if (!Settings.MusicCategory.IsNotNullOrWhiteSpace())

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionSettings.cs
@@ -19,7 +19,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
             RuleFor(c => c.MusicCategory).Matches(@"^\.?[-a-z]*$", RegexOptions.IgnoreCase).WithMessage("Allowed characters a-z and -");
 
             RuleFor(c => c.MusicCategory).Empty()
-                .When(c => c.TvDirectory.IsNotNullOrWhiteSpace())
+                .When(c => c.MusicDirectory.IsNotNullOrWhiteSpace())
                 .WithMessage("Cannot use Category and Directory");
         }
     }
@@ -57,13 +57,13 @@ namespace NzbDrone.Core.Download.Clients.Transmission
         public string MusicCategory { get; set; }
 
         [FieldDefinition(7, Label = "Directory", Type = FieldType.Textbox, Advanced = true, HelpText = "Optional location to put downloads in, leave blank to use the default Transmission location")]
-        public string TvDirectory { get; set; }
+        public string MusicDirectory { get; set; }
 
         [FieldDefinition(8, Label = "Recent Priority", Type = FieldType.Select, SelectOptions = typeof(TransmissionPriority), HelpText = "Priority to use when grabbing albums released within the last 14 days")]
-        public int RecentTvPriority { get; set; }
+        public int RecentMusicPriority { get; set; }
 
         [FieldDefinition(9, Label = "Older Priority", Type = FieldType.Select, SelectOptions = typeof(TransmissionPriority), HelpText = "Priority to use when grabbing albums released over 14 days ago")]
-        public int OlderTvPriority { get; set; }
+        public int OlderMusicPriority { get; set; }
 
         [FieldDefinition(10, Label = "Add Paused", Type = FieldType.Checkbox)]
         public bool AddPaused { get; set; }

--- a/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
@@ -74,7 +74,7 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
 
         protected override string AddFromMagnetLink(RemoteAlbum remoteAlbum, string hash, string magnetLink)
         {
-            var priority = (RTorrentPriority)(remoteAlbum.IsRecentAlbum() ? Settings.RecentTvPriority : Settings.OlderTvPriority);
+            var priority = (RTorrentPriority)(remoteAlbum.IsRecentAlbum() ? Settings.RecentMusicPriority : Settings.OlderMusicPriority);
 
             _proxy.AddTorrentFromUrl(magnetLink, Settings.MusicCategory, priority, Settings.MusicDirectory, Settings);
 
@@ -94,7 +94,7 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
 
         protected override string AddFromTorrentFile(RemoteAlbum remoteAlbum, string hash, string filename, byte[] fileContent)
         {
-            var priority = (RTorrentPriority)(remoteAlbum.IsRecentAlbum() ? Settings.RecentTvPriority : Settings.OlderTvPriority);
+            var priority = (RTorrentPriority)(remoteAlbum.IsRecentAlbum() ? Settings.RecentMusicPriority : Settings.OlderMusicPriority);
 
             _proxy.AddTorrentFromFile(filename, fileContent, Settings.MusicCategory, priority, Settings.MusicDirectory, Settings);
 

--- a/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrentSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrentSettings.cs
@@ -27,8 +27,8 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
             Port = 8080;
             UrlBase = "RPC2";
             MusicCategory = "lidarr";
-            OlderTvPriority = (int)RTorrentPriority.Normal;
-            RecentTvPriority = (int)RTorrentPriority.Normal;
+            OlderMusicPriority = (int)RTorrentPriority.Normal;
+            RecentMusicPriority = (int)RTorrentPriority.Normal;
         }
 
         [FieldDefinition(0, Label = "Host", Type = FieldType.Textbox)]
@@ -59,10 +59,10 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
         public string MusicDirectory { get; set; }
 
         [FieldDefinition(9, Label = "Recent Priority", Type = FieldType.Select, SelectOptions = typeof(RTorrentPriority), HelpText = "Priority to use when grabbing albums released within the last 14 days")]
-        public int RecentTvPriority { get; set; }
+        public int RecentMusicPriority { get; set; }
 
         [FieldDefinition(10, Label = "Older Priority", Type = FieldType.Select, SelectOptions = typeof(RTorrentPriority), HelpText = "Priority to use when grabbing albums released over 14 days ago")]
-        public int OlderTvPriority { get; set; }
+        public int OlderMusicPriority { get; set; }
 
         [FieldDefinition(11, Label = "Add Stopped", Type = FieldType.Checkbox, HelpText = "Enabling will add torrents and magnets to rTorrent in a stopped state. This may break magnet files.")]
         public bool AddStopped { get; set; }

--- a/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrent.cs
@@ -64,8 +64,8 @@ namespace NzbDrone.Core.Download.Clients.UTorrent
 
             var isRecentAlbum = remoteAlbum.IsRecentAlbum();
 
-            if ((isRecentAlbum && Settings.RecentTvPriority == (int)UTorrentPriority.First) ||
-                (!isRecentAlbum && Settings.OlderTvPriority == (int)UTorrentPriority.First))
+            if ((isRecentAlbum && Settings.RecentMusicPriority == (int)UTorrentPriority.First) ||
+                (!isRecentAlbum && Settings.OlderMusicPriority == (int)UTorrentPriority.First))
             {
                 _proxy.MoveTorrentToTopInQueue(hash, Settings);
             }
@@ -87,8 +87,8 @@ namespace NzbDrone.Core.Download.Clients.UTorrent
 
             var isRecentAlbum = remoteAlbum.IsRecentAlbum();
 
-            if ((isRecentAlbum && Settings.RecentTvPriority == (int)UTorrentPriority.First) ||
-                (!isRecentAlbum && Settings.OlderTvPriority == (int)UTorrentPriority.First))
+            if ((isRecentAlbum && Settings.RecentMusicPriority == (int)UTorrentPriority.First) ||
+                (!isRecentAlbum && Settings.OlderMusicPriority == (int)UTorrentPriority.First))
             {
                 _proxy.MoveTorrentToTopInQueue(hash, Settings);
             }

--- a/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrentSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrentSettings.cs
@@ -53,10 +53,10 @@ namespace NzbDrone.Core.Download.Clients.UTorrent
         public string MusicImportedCategory { get; set; }
 
         [FieldDefinition(8, Label = "Recent Priority", Type = FieldType.Select, SelectOptions = typeof(UTorrentPriority), HelpText = "Priority to use when grabbing albums released within the last 14 days")]
-        public int RecentTvPriority { get; set; }
+        public int RecentMusicPriority { get; set; }
 
         [FieldDefinition(9, Label = "Older Priority", Type = FieldType.Select, SelectOptions = typeof(UTorrentPriority), HelpText = "Priority to use when grabbing albums released over 14 days ago")]
-        public int OlderTvPriority { get; set; }
+        public int OlderMusicPriority { get; set; }
 
         [FieldDefinition(10, Label = "Initial State", Type = FieldType.Select, SelectOptions = typeof(UTorrentState), HelpText = "Initial state for torrents added to uTorrent")]
         public int IntialState { get; set; }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
In download clients implementations there are few vars and functions that are still referring to tv instead of music which could be misleading.
Purpose of this PR is to rename them. Main changes are:
- Rename `RecentTvPriority` to `RecentMusicPriority`
- Rename `OlderTvPriority` to `OlderMusicPriority`
- Rename `TvDirectory` to `MusicDirectory`

Used `Music` to align with RTorrent naming.

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)