### PR TITLE
Fixed: Standardize single quotes and allow the neutral apostrophe

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerSearchTests/SearchDefinitionFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerSearchTests/SearchDefinitionFixture.cs
@@ -20,8 +20,11 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         [TestCase("American III: Solitary Man", "American+III+Solitary+Man")]
         [TestCase("Sad Clowns & Hillbillies", "Sad+Clowns+Hillbillies")]
         [TestCase("¿Quién sabe?", "Quien+sabe")]
-        [TestCase("Seal the Deal & Let’s Boogie", "Seal+the+Deal+Lets+Boogie")]
-        [TestCase("Section.80", "Section80")]
+        [TestCase("Seal the Deal & Let’s Boogie", "Seal+the+Deal+Let's+Boogie")]
+        [TestCase("Section.80", "Section+80")]
+        [TestCase("Anthology: Hey Ho, Let’s Go!", "Anthology+Hey+Ho+Let's+Go")]
+        [TestCase("Vankelsteg - Mot Okända Hembygder", "Vankelsteg+Mot+Okanda+Hembygder")]
+        [TestCase("The Beach Boys - The Beach Boys' Christmas Album", "Beach+Boys+The+Beach+Boys'+Christmas+Album")]
         public void should_replace_some_special_characters(string album, string expected)
         {
             Subject.AlbumTitle = album;

--- a/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
@@ -8,9 +8,9 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
 {
     public abstract class SearchCriteriaBase
     {
-        private static readonly Regex SpecialCharacter = new Regex(@"[`'’.]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex NonWord = new Regex(@"[\W]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex NonWord = new Regex(@"[^\w']+", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex BeginningThe = new Regex(@"^the\s", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex StandardizeSingleQuotesRegex = new Regex(@"[\u0060\u00B4\u2018\u2019]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         public virtual bool MonitoredEpisodesOnly { get; set; }
         public virtual bool UserInvokedSearch { get; set; }
@@ -34,9 +34,7 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
             }
 
             var cleanTitle = BeginningThe.Replace(title, string.Empty);
-
-            cleanTitle = cleanTitle.Replace(" & ", " ");
-            cleanTitle = SpecialCharacter.Replace(cleanTitle, "");
+            cleanTitle = StandardizeSingleQuotesRegex.Replace(cleanTitle, "'");
             cleanTitle = NonWord.Replace(cleanTitle, "+");
 
             // remove any repeating +s


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Mostly undoing 1eea545c0a9e2ea871a98f5adcede515055a0d95 d765d1eaeff42a12da294666904a9109031cdf28

Currently `Section80` returns 0 results on RED/OPS, while `Section 80` returns the `Section.80` album.
Same for `Anthology Hey Ho Lets Go` vs `Anthology Hey Ho Let's Go`.