### PR TITLE
Fixed: Specify UTF-8 when serving text files to avoid incorrect detection by browsers

### DIFF
--- a/src/Lidarr.Http/Frontend/Mappers/StaticResourceMapperBase.cs
+++ b/src/Lidarr.Http/Frontend/Mappers/StaticResourceMapperBase.cs
@@ -1,7 +1,9 @@
 using System;
 using System.IO;
+using System.Text;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Net.Http.Headers;
 using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnvironmentInfo;
@@ -39,7 +41,10 @@ namespace Lidarr.Http.Frontend.Mappers
                     contentType = "application/octet-stream";
                 }
 
-                return new FileStreamResult(GetContentStream(filePath), contentType);
+                return new FileStreamResult(GetContentStream(filePath), new MediaTypeHeaderValue(contentType)
+                {
+                    Encoding = contentType == "text/plain" ? Encoding.UTF8 : null
+                });
             }
 
             _logger.Warn("File {0} not found", filePath);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Serve text files as UTF-8, so as to ensure they are properly decoded by browsers. This fixes issues with log readability.

This is the same fix as Prowlarr/Prowlarr#1372, for Lidarr.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

