### PR TITLE
Fixed: Use raw search query for the Redacted indexer

### DIFF
--- a/src/NzbDrone.Core/Indexers/Redacted/RedactedRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Redacted/RedactedRequestGenerator.cs
@@ -28,14 +28,14 @@ namespace NzbDrone.Core.Indexers.Redacted
         public IndexerPageableRequestChain GetSearchRequests(AlbumSearchCriteria searchCriteria)
         {
             var pageableRequests = new IndexerPageableRequestChain();
-            pageableRequests.Add(GetRequest(string.Format("&artistname={0}&groupname={1}", searchCriteria.CleanArtistQuery, searchCriteria.CleanAlbumQuery)));
+            pageableRequests.Add(GetRequest(string.Format("&artistname={0}&groupname={1}", searchCriteria.ArtistQuery, searchCriteria.AlbumQuery)));
             return pageableRequests;
         }
 
         public IndexerPageableRequestChain GetSearchRequests(ArtistSearchCriteria searchCriteria)
         {
             var pageableRequests = new IndexerPageableRequestChain();
-            pageableRequests.Add(GetRequest(string.Format("&artistname={0}", searchCriteria.CleanArtistQuery)));
+            pageableRequests.Add(GetRequest(string.Format("&artistname={0}", searchCriteria.ArtistQuery)));
             return pageableRequests;
         }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixes #1180 for redacted.ch by passing the apostrophe and other punctuation to Redacted search as-is. I don't have other gazelle to test, but likely a similar change would work for the gazelle indexer as well.

#### Screenshot (if UI related)
![exclamation-point-redacted_search](https://user-images.githubusercontent.com/1476684/231069796-35b3af4d-60f3-4103-aed3-a2256c610631.PNG)
![apostrophe-redacted_search](https://user-images.githubusercontent.com/1476684/231069799-910dc4a8-e3e0-4a08-98b9-97767154fd20.PNG)


#### Issues Fixed or Closed by this PR

* Partially Fixes #1180 (fixed for RED, but not other trackers)