### PR TITLE
Fixed: (Parser) Strip `produced by` from track titles

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -72,6 +72,8 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Science Fiction/Double Feature", "Science Fiction/Double Feature")]
         [TestCase("Dancing Feathers", "Dancing Feathers")]
         [TestCase("D.J. (2017 Remaster)", "D.J.")]
+        [TestCase("The Kiss (Skit) (Produced By Eminem)", "The Kiss (Skit)")]
+        [TestCase("Without Me (Produced By Eminem & Jeff Bass)", "Without Me")]
         public void should_remove_common_tags_from_track_title(string title, string correct)
         {
             var result = Parser.Parser.CleanTrackTitle(title);

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -217,7 +217,7 @@ namespace NzbDrone.Core.Parser
 
         private static readonly Regex[] CommonTagRegex = new Regex[]
         {
-            new Regex(@"(\[|\()*\b((featuring|feat.|feat|ft|ft.)\s{1}){1}\s*.*(\]|\))*", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            new Regex(@"(\[|\()*\b((featuring|feat.|feat|ft|ft.|produced by)\s{1}){1}\s*.*(\]|\))*", RegexOptions.IgnoreCase | RegexOptions.Compiled),
             new Regex(@"(?:\(|\[)(?:[^\(\[]*)(?:version|limited|deluxe|single|clean|album|special|bonus|promo|remaster(ed)?)(?:[^\)\]]*)(?:\)|\])", RegexOptions.IgnoreCase | RegexOptions.Compiled)
         };
 


### PR DESCRIPTION
#### Database Migration
NO