### PR TITLE
Remove non-audio media filter

### DIFF
--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -25,7 +25,6 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
         private readonly IMetadataProfileService _metadataProfileService;
         private readonly ICached<HashSet<string>> _cache;
 
-        private static readonly List<string> NonAudioMedia = new List<string> { "DVD", "DVD-Video", "Blu-ray", "HD-DVD", "VCD", "SVCD", "UMD", "VHS" };
         private static readonly List<string> SkippedTracks = new List<string> { "[data track]" };
 
         public SkyHookProxy(IHttpClient httpClient,
@@ -496,11 +495,8 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
                 }
             }
 
-            // Skip non-audio media
-            var audioMediaNumbers = allMedia.Where(x => !NonAudioMedia.Contains(x.Format)).Select(x => x.Number);
-
             // Get tracks on the audio media and omit any that are skipped
-            release.Tracks = allTracks.Where(x => audioMediaNumbers.Contains(x.MediumNumber) && !SkippedTracks.Contains(x.Title)).ToList();
+            release.Tracks = allTracks.Where(x => !SkippedTracks.Contains(x.Title)).ToList();
             release.TrackCount = release.Tracks.Value.Count;
 
             // Only include the media that contain the tracks we have selected


### PR DESCRIPTION
#### Database Migration

NO

#### Description

It removes the filter to strip out non-audio media from a release.

The current implementation is confusing (I didn't understand why I could see certain releases in Musicbrainz but not in Lidarr).

With this change all media types are available in Lidarr. This adds support for releases based on audio-only blu-rays (or more accurately - downloads associated with audio-only blu-rays), DVD concert rips, and so on.

#### Screenshot (if UI related)

Backend-only, no screenshots.

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #4123 
* Fixes #2084