### PR TITLE
Properly import extra files

### DIFF
--- a/src/NzbDrone.Core/Extras/ExtraService.cs
+++ b/src/NzbDrone.Core/Extras/ExtraService.cs
@@ -60,14 +60,11 @@ namespace NzbDrone.Core.Extras
             var sourceFileName = Path.GetFileNameWithoutExtension(trackFile.Path);
             var files = _diskProvider.GetFiles(sourceFolder, false);
 
-            var wantedExtensions = _configService.ExtraFileExtensions
-                .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
-                .Select(e => e.Trim(' ', '.'))
-                .ToList();
+            var wantedExtensions = _configService.ExtraFileExtensions.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+                                                                              .Select(e => e.Trim(' ', '.'))
+                                                                              .ToList();
 
-            var matchingFilenames = files.Where(f =>
-                Path.GetFileNameWithoutExtension(f)
-                    .StartsWith(sourceFileName, StringComparison.InvariantCultureIgnoreCase)).ToList();
+            var matchingFilenames = files.Where(f => Path.GetFileNameWithoutExtension(f).StartsWith(sourceFileName, StringComparison.InvariantCultureIgnoreCase)).ToList();
             var filteredFilenames = new List<string>();
             var hasNfo = false;
 

--- a/src/NzbDrone.Core/Extras/ExtraService.cs
+++ b/src/NzbDrone.Core/Extras/ExtraService.cs
@@ -61,8 +61,8 @@ namespace NzbDrone.Core.Extras
             var files = _diskProvider.GetFiles(sourceFolder, false);
 
             var wantedExtensions = _configService.ExtraFileExtensions.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
-                                                                              .Select(e => e.Trim(' ', '.'))
-                                                                              .ToList();
+                                                                     .Select(e => e.Trim(' ', '.'))
+                                                                     .ToList();
 
             var matchingFilenames = files.Where(f => Path.GetFileNameWithoutExtension(f).StartsWith(sourceFileName, StringComparison.InvariantCultureIgnoreCase)).ToList();
             var filteredFilenames = new List<string>();

--- a/src/NzbDrone.Core/Extras/ExtraService.cs
+++ b/src/NzbDrone.Core/Extras/ExtraService.cs
@@ -98,10 +98,10 @@ namespace NzbDrone.Core.Extras
 
                 try
                 {
-                    foreach (var extraFileManager1 in _extraFileManagers)
+                    foreach (var extraFileManager in _extraFileManagers)
                     {
                         var extension = Path.GetExtension(matchingFilename);
-                        var extraFile = extraFileManager1.Import(trackFile.Artist, trackFile, matchingFilename, extension, isReadOnly);
+                        var extraFile = extraFileManager.Import(trackFile.Artist, trackFile, matchingFilename, extension, isReadOnly);
 
                         if (extraFile != null)
                         {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Currently, extra files are only imported if they match the name of a track that is being imported. All extra files should be imported (if their extensions matches the configured extensions).

#### Todos
- [ ] Find out if refactoring `Import()` completely is required or not for getting the album/single/EP "root" directory
- [ ] Actually get it working

#### Issues Fixed or Closed by this PR

* Fixes #484