### PR TITLE
Fix file filtering bug caused by mismatched timezones

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/MediaFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileService.cs
@@ -128,7 +128,7 @@ namespace NzbDrone.Core.MediaFiles
             {
                 unwanted = combined
                     .Where(x => x.DiskFile.Length == x.DbFile.Size &&
-                           Math.Abs((x.DiskFile.LastWriteTimeUtc - x.DbFile.Modified).TotalSeconds) <= 1)
+                           Math.Abs((x.DiskFile.LastWriteTimeUtc - x.DbFile.Modified.ToUniversalTime()).TotalSeconds) <= 1)
                     .Select(x => x.DiskFile)
                     .ToList();
                 _logger.Trace($"{unwanted.Count} unchanged existing files");
@@ -137,7 +137,7 @@ namespace NzbDrone.Core.MediaFiles
             {
                 unwanted = combined
                     .Where(x => x.DiskFile.Length == x.DbFile.Size &&
-                           Math.Abs((x.DiskFile.LastWriteTimeUtc - x.DbFile.Modified).TotalSeconds) <= 1 &&
+                           Math.Abs((x.DiskFile.LastWriteTimeUtc - x.DbFile.Modified.ToUniversalTime()).TotalSeconds) <= 1 &&
                            (x.DbFile.Tracks == null || (x.DbFile.Tracks.IsLoaded && x.DbFile.Tracks.Value.Any())))
                     .Select(x => x.DiskFile)
                     .ToList();


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This PR fixes issues related to the calculation of the difference of two `DateTime` objects. The value being substracted from is in UTC, but the second DateTime is not. On my system I was getting 3600 seconds instead of the expected `<= 1`. 

As a result of this, multiple tests were failing locally on the latest develop.

The impact of the bug is probably minor. Unchanged files will not be filtered by the `MediaFileService.FilterUnchangedFiles` method.

#### Todos
- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)
