### PR TITLE
Fix: Properly detect a postgres connection

### DIFF
--- a/src/NzbDrone.Core/Datastore/Database.cs
+++ b/src/NzbDrone.Core/Datastore/Database.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Data;
+using System.Data.SQLite;
 using System.Text.RegularExpressions;
 using Dapper;
 using NLog;
@@ -40,14 +41,7 @@ namespace NzbDrone.Core.Datastore
             {
                 using (var db = _datamapperFactory())
                 {
-                    if (db.ConnectionString.Contains(".db"))
-                    {
-                        return DatabaseType.SQLite;
-                    }
-                    else
-                    {
-                        return DatabaseType.PostgreSQL;
-                    }
+                    return db is SQLiteConnection ? DatabaseType.SQLite : DatabaseType.PostgreSQL;
                 }
             }
         }


### PR DESCRIPTION
#### Database Migration
No

#### Description

Previously was looking for a ".db" in the connection string, which is the typical sqlite filename. The problem is if your connection string has a .db anywhere in it, such as postgres.db.internal it'll think its a sqlite file

Solution borrowed from sonarr:

https://github.com/Sonarr/Sonarr/blob/develop/src/NzbDrone.Core/Datastore/Database.cs#L43

#### Screenshot (if UI related)

NA

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)
