### PR TITLE
Fixed: Rescan Folder task ignores .jpg, .nfo, and .lrc files

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
@@ -35,7 +35,7 @@ namespace NzbDrone.Core.MediaFiles
         IExecute<RescanFoldersCommand>
     {
         public static readonly Regex ExcludedSubFoldersRegex = new Regex(@"(?:\\|\/|^)(?:extras|@eadir|\.@__thumb|extrafanart|plex versions|\.[^\\/]+)(?:\\|\/)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        public static readonly Regex ExcludedFilesRegex = new Regex(@"^\._|^Thumbs\.db$|^\.DS_store$|\.partial~$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        public static readonly Regex ExcludedFilesRegex = new Regex(@"^\._|^Thumbs\.db$|^\.DS_store$|\.partial~$|\.jpg|\.nfo|\.lrc", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private readonly IConfigService _configService;
         private readonly IDiskProvider _diskProvider;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The scheduled rescan folder task was taking a long time if users were keeping .jpg, .nfo, or .lrc files because Lidarr was trying to match these to albums/tracks every run. Updated the regex to ignore files of these types.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR
