### PR TITLE
Add Spotify Liked Songs playlist in Import List

### DIFF
--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyPlaylist.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyPlaylist.cs
@@ -5,6 +5,7 @@ using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Localization;
 using NzbDrone.Core.MetadataSource;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Validation;
@@ -22,14 +23,18 @@ namespace NzbDrone.Core.ImportLists.Spotify
                                IConfigService configService,
                                IParsingService parsingService,
                                IHttpClient httpClient,
+                               ILocalizationService localizationService,
                                Logger logger)
         : base(spotifyProxy, requestBuilder, importListStatusService, importListRepository, configService, parsingService, httpClient, logger)
         {
+            _localizationService = localizationService;
         }
 
         public override string Name => "Spotify Playlists";
 
         private const string LIKEDSONGSID = "LikedSongs";
+
+        private readonly ILocalizationService _localizationService;
 
         public override IList<SpotifyImportListItemInfo> Fetch(SpotifyWebAPI api)
         {
@@ -162,7 +167,7 @@ namespace NzbDrone.Core.ImportLists.Spotify
                                     {
                                         id = p.Id,
                                         name = p.Name
-                                    }).Prepend(new { id = LIKEDSONGSID, name = "Liked Songs" }) // TODO : Add Translation
+                                    }).Prepend(new { id = LIKEDSONGSID, name = _localizationService.GetLocalizedString("LikedSongs") })
                             }
                         };
                     }

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyPlaylist.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyPlaylist.cs
@@ -30,9 +30,8 @@ namespace NzbDrone.Core.ImportLists.Spotify
             _localizationService = localizationService;
         }
 
+        private const string LIKED_SONGS_ID = "LikedSongs";
         public override string Name => "Spotify Playlists";
-
-        private const string LIKEDSONGSID = "LikedSongs";
 
         private readonly ILocalizationService _localizationService;
 
@@ -49,7 +48,7 @@ namespace NzbDrone.Core.ImportLists.Spotify
 
             Paging<PlaylistTrack> playlistTracks;
 
-            if (playlistId.Equals(LIKEDSONGSID))
+            if (playlistId.Equals(LIKED_SONGS_ID))
             {
                 var savedTracks = _spotifyProxy.GetSavedTracks(this, api);
                 playlistTracks = new Paging<PlaylistTrack>
@@ -167,7 +166,7 @@ namespace NzbDrone.Core.ImportLists.Spotify
                                     {
                                         id = p.Id,
                                         name = p.Name
-                                    }).Prepend(new { id = LIKEDSONGSID, name = _localizationService.GetLocalizedString("LikedSongs") })
+                                    }).Prepend(new { id = LIKED_SONGS_ID, name = _localizationService.GetLocalizedString("LikedSongs") })
                             }
                         };
                     }

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyPlaylistSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyPlaylistSettings.cs
@@ -22,7 +22,7 @@ namespace NzbDrone.Core.ImportLists.Spotify
             PlaylistIds = System.Array.Empty<string>();
         }
 
-        public override string Scope => "playlist-read-private";
+        public override string Scope => "playlist-read-private user-library-read";
 
         [FieldDefinition(1, Label = "Playlists", Type = FieldType.Playlist)]
         public IEnumerable<string> PlaylistIds { get; set; }

--- a/src/NzbDrone.Core/ImportLists/Spotify/SpotifyProxy.cs
+++ b/src/NzbDrone.Core/ImportLists/Spotify/SpotifyProxy.cs
@@ -18,6 +18,8 @@ namespace NzbDrone.Core.ImportLists.Spotify
             where TSettings : SpotifySettingsBase<TSettings>, new();
         Paging<PlaylistTrack> GetPlaylistTracks<TSettings>(SpotifyImportListBase<TSettings> list, SpotifyWebAPI api, string id, string fields)
             where TSettings : SpotifySettingsBase<TSettings>, new();
+        Paging<SavedTrack> GetSavedTracks<TSettings>(SpotifyImportListBase<TSettings> list, SpotifyWebAPI api)
+            where TSettings : SpotifySettingsBase<TSettings>, new();
         Paging<T> GetNextPage<T, TSettings>(SpotifyImportListBase<TSettings> list, SpotifyWebAPI api, Paging<T> item)
             where TSettings : SpotifySettingsBase<TSettings>, new();
         FollowedArtists GetNextPage<TSettings>(SpotifyImportListBase<TSettings> list, SpotifyWebAPI api, FollowedArtists item)
@@ -61,6 +63,12 @@ namespace NzbDrone.Core.ImportLists.Spotify
             where TSettings : SpotifySettingsBase<TSettings>, new()
         {
             return Execute(list, api, x => x.GetPlaylistTracks(id, fields: fields));
+        }
+
+        public Paging<SavedTrack> GetSavedTracks<TSettings>(SpotifyImportListBase<TSettings> list, SpotifyWebAPI api)
+            where TSettings : SpotifySettingsBase<TSettings>, new()
+        {
+            return Execute(list, api, x => x.GetSavedTracks(50));
         }
 
         public Paging<T> GetNextPage<T, TSettings>(SpotifyImportListBase<TSettings> list, SpotifyWebAPI api, Paging<T> item)

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -611,6 +611,7 @@
   "LidarrSupportsAnyIndexerThatUsesTheNewznabStandardAsWellAsOtherIndexersListedBelow": "{appName} supports any indexer that uses the Newznab standard, as well as other indexers listed below.",
   "LidarrSupportsMultipleListsForImportingAlbumsAndArtistsIntoTheDatabase": "{appName} supports multiple lists for importing Albums and Artists into the database.",
   "LidarrTags": "{appName} Tags",
+  "LikedSongs": "Liked Songs",
   "Links": "Links",
   "ListRefreshInterval": "List Refresh Interval",
   "ListWillRefreshEveryInterp": "List will refresh every {0}",


### PR DESCRIPTION
#### Database Migration
NO

#### Description
There is currently no Import List supporting the Spotify Liked Songs playlist. This PR aims at adding it into the SpotifyPlaylist Import List.

#### Todos
- [ ] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

* Fixes #2565 