### PR TITLE
Fixed: Ensure ImportResults is not empty when verifying imports (#2746)

### DIFF
--- a/src/NzbDrone.Core/Download/CompletedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/CompletedDownloadService.cs
@@ -166,7 +166,7 @@ namespace NzbDrone.Core.Download
 
         public bool VerifyImport(TrackedDownload trackedDownload, List<ImportResult> importResults)
         {
-            var allTracksImported = importResults.All(c => c.Result == ImportResultType.Imported) ||
+            var allTracksImported = (importResults.Any() && importResults.All(c => c.Result == ImportResultType.Imported)) ||
                 importResults.Count(c => c.Result == ImportResultType.Imported) >=
                 Math.Max(1, trackedDownload.RemoteAlbum.Albums.Sum(x => x.AlbumReleases.Value.Where(y => y.Monitored).Sum(z => z.TrackCount)));
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
[Enumerable.All](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.all?view=net-8.0#returns) returns true if the list is empty so the `CompletedDownloadService` was incorrectly marking downloads as completed when nothing was actually imported

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #2746