### PR TITLE
Add support for Catalan Language

### DIFF
--- a/src/NzbDrone.Core/Languages/Language.cs
+++ b/src/NzbDrone.Core/Languages/Language.cs
@@ -102,6 +102,7 @@ namespace NzbDrone.Core.Languages
         public static Language Bulgarian => new Language(29, "Bulgarian");
         public static Language PortugueseBR => new Language(30, "Portuguese (Brazil)");
         public static Language Arabic => new Language(31, "Arabic");
+        public static Language Catalan => new Language(32, "Catalan");
         public static Language Any => new Language(-1, "Any");
         public static Language Original => new Language(-2, "Original");
 
@@ -143,6 +144,7 @@ namespace NzbDrone.Core.Languages
                     Bulgarian,
                     PortugueseBR,
                     Arabic,
+                    Catalan,
                     Any,
                     Original
                 };

--- a/src/NzbDrone.Core/Parser/IsoLanguages.cs
+++ b/src/NzbDrone.Core/Parser/IsoLanguages.cs
@@ -38,7 +38,8 @@ namespace NzbDrone.Core.Parser
                                                                new IsoLanguage("bg", "", "bul", "Bulgarian", Language.Bulgarian),
                                                                new IsoLanguage("ro", "", "ron", "Romanian", Language.Romanian),
                                                                new IsoLanguage("pt", "br", "", "Portuguese (Brazil)", Language.PortugueseBR),
-                                                               new IsoLanguage("ar", "", "ara", "Arabic", Language.Arabic)
+                                                               new IsoLanguage("ar", "", "ara", "Arabic", Language.Arabic),
+                                                               new IsoLanguage("ca", "", "cat", "Catalan", Language.Catalan)
                                                            };
 
         public static IsoLanguage Find(string isoCode)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Add support for Catalan Languages. The localization file already exists.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/ca.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)
