### PR TITLE
Handle library path locations that are parent paths; Fix fallback library scan to remove artist relative path to prevent not finding new media

### DIFF
--- a/src/NzbDrone.Core/Notifications/Plex/Server/PlexServerService.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/Server/PlexServerService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using FluentValidation.Results;
@@ -119,6 +120,17 @@ namespace NzbDrone.Core.Notifications.Plex.Server
 
                         return;
                     }
+
+                    if (location.Path.IsParentPath(mappedPath.FullPath))
+                    {
+                        var subfolderPath = location.Path.GetRelativePath(mappedPath.FullPath);
+                        var newArtistRelativePath = Path.Combine(subfolderPath, artistRelativePath);
+                        _logger.Debug("Updating matching section with parent location match, {0}", location.Path);
+                        _logger.Debug("Prepending artist relative path with subfolder : {0} => {1}", artistRelativePath, newArtistRelativePath);
+                        UpdateSectionPath(newArtistRelativePath, section, location, settings);
+
+                        return;
+                    }
                 }
             }
 
@@ -128,7 +140,8 @@ namespace NzbDrone.Core.Notifications.Plex.Server
             {
                 foreach (var location in section.Locations)
                 {
-                    UpdateSectionPath(artistRelativePath, section, location, settings);
+                    // Do not include artistRelativePath so we trigger a full library scan since we aren't sure where the files actually are!
+                    UpdateSectionPath("", section, location, settings);
                 }
             }
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Handle library path locations that are parent paths; Fix fallback library scan to remove artist relative path to prevent not finding new media.  Current assumption is that the Plex path will have <artist> directly below and that isn't always the case.

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #4973