### PR TITLE
Temporary fix for issue #4977 until a more thoughtful fix can be implemented

### DIFF
--- a/src/NzbDrone.Core/Download/FailedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/FailedDownloadService.cs
@@ -129,7 +129,7 @@ namespace NzbDrone.Core.Download
 
         private void PublishDownloadFailedEvent(List<EntityHistory> historyItems, string message, TrackedDownload trackedDownload = null, bool skipRedownload = false)
         {
-            var historyItem = historyItems.Last();
+            var historyItem = historyItems.First(); // items are returned in reverse chronological order, so first is the most recent
             Enum.TryParse(historyItem.Data.GetValueOrDefault(EntityHistory.RELEASE_SOURCE, ReleaseSourceType.Unknown.ToString()), out ReleaseSourceType releaseSource);
 
             var downloadFailedEvent = new DownloadFailedEvent


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Full details [here](https://github.com/Lidarr/Lidarr/issues/4977#issuecomment-2274370685).  In short, this is a quick/temporary fix for a problem with getting the torrentInfoHash from downloads marked as failed until I, or a better developer, can code a more thoughtful fix.  That fix would most likely end up looking like carrying the known torrent hash from the activity queue all the way into the `DownloadFailedEvent` message properties.

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Addresses #4977