### PR TITLE
Blocklist Torrent Hash should prefer getting the hash (DownloadId) from the tracked download item, if available, and fall back to the history item only if the tracked item is unavailable

### DIFF
--- a/src/NzbDrone.Core/Blocklisting/BlocklistService.cs
+++ b/src/NzbDrone.Core/Blocklisting/BlocklistService.cs
@@ -185,7 +185,7 @@ namespace NzbDrone.Core.Blocklisting
                 Indexer = message.Data.GetValueOrDefault("indexer"),
                 Protocol = (DownloadProtocol)Convert.ToInt32(message.Data.GetValueOrDefault("protocol")),
                 Message = message.Message,
-                TorrentInfoHash = message.Data.GetValueOrDefault("torrentInfoHash")
+                TorrentInfoHash = message.TrackedDownload == null ? message.Data.GetValueOrDefault("torrentInfoHash") : message.TrackedDownload.DownloadItem.DownloadId
             };
 
             if (Enum.TryParse(message.Data.GetValueOrDefault("indexerFlags"), true, out IndexerFlags flags))


### PR DESCRIPTION
#### Database Migration
NO

#### Description
`TorrentInfoHash` is currently being set by a pseudo-random history item's torrent hash instead of the hash of the actual queue item the user has elected to block.  I say "pseudo-random" because `historyItem` in `PublishDownloadFailedEvent` has a history of flipping between `First()` and `Last()`.

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #4977