### PR TITLE
Sync `OsInfo` class from Sonarr

### DIFF
--- a/src/NzbDrone.Common/EnvironmentInfo/OsInfo.cs
+++ b/src/NzbDrone.Common/EnvironmentInfo/OsInfo.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -109,18 +109,31 @@ namespace NzbDrone.Common.EnvironmentInfo
 
         private static string RunAndCapture(string filename, string args)
         {
-            var p = new Process();
-            p.StartInfo.FileName = filename;
-            p.StartInfo.Arguments = args;
-            p.StartInfo.UseShellExecute = false;
-            p.StartInfo.CreateNoWindow = true;
-            p.StartInfo.RedirectStandardOutput = true;
+            var processStartInfo = new ProcessStartInfo
+            {
+                FileName = filename,
+                Arguments = args,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true
+            };
 
-            p.Start();
+            var output = string.Empty;
 
-            // To avoid deadlocks, always read the output stream first and then wait.
-            var output = p.StandardOutput.ReadToEnd();
-            p.WaitForExit(1000);
+            try
+            {
+                using (var p = Process.Start(processStartInfo))
+                {
+                    // To avoid deadlocks, always read the output stream first and then wait.
+                    output = p.StandardOutput.ReadToEnd();
+
+                    p.WaitForExit(1000);
+                }
+            }
+            catch (Exception)
+            {
+                output = string.Empty;
+            }
 
             return output;
         }
@@ -131,7 +144,6 @@ namespace NzbDrone.Common.EnvironmentInfo
         string Version { get; }
         string Name { get; }
         string FullName { get; }
-
         bool IsDocker { get; }
     }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description

This PR syncs the `OsInfo` class from Sonarr. The main difference  is that the `uname` process invocation is in a try/catch block, allowing Lidarr to gracefully handle any error encountered when trying to run `uname`. Both Radarr and Prowlarr also use this try/catch pattern.

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)
