### PR TITLE
Pull Sonarr commit 'New: Config file setting to disable log database'

### DIFF
--- a/src/Lidarr.Api.V1/Logs/LogController.cs
+++ b/src/Lidarr.Api.V1/Logs/LogController.cs
@@ -2,6 +2,7 @@ using Lidarr.Http;
 using Lidarr.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Instrumentation;
 
 namespace Lidarr.Api.V1.Logs
@@ -10,16 +11,23 @@ namespace Lidarr.Api.V1.Logs
     public class LogController : Controller
     {
         private readonly ILogService _logService;
+        private readonly IConfigFileProvider _configFileProvider;
 
-        public LogController(ILogService logService)
+        public LogController(ILogService logService, IConfigFileProvider configFileProvider)
         {
             _logService = logService;
+            _configFileProvider = configFileProvider;
         }
 
         [HttpGet]
         [Produces("application/json")]
         public PagingResource<LogResource> GetLogs([FromQuery] PagingRequestResource paging, string level)
         {
+            if (!_configFileProvider.LogDbEnabled)
+            {
+                return new PagingResource<LogResource>();
+            }
+
             var pagingResource = new PagingResource<LogResource>(paging);
             var pageSpec = pagingResource.MapToPagingSpec<LogResource, Log>();
 

--- a/src/Lidarr.Http/PagingResource.cs
+++ b/src/Lidarr.Http/PagingResource.cs
@@ -21,7 +21,7 @@ namespace Lidarr.Http
         public string SortKey { get; set; }
         public SortDirection SortDirection { get; set; }
         public int TotalRecords { get; set; }
-        public List<TResource> Records { get; set; }
+        public List<TResource> Records { get; set; } = new ();
 
         public PagingResource()
         {

--- a/src/NzbDrone.Common.Test/ServiceFactoryFixture.cs
+++ b/src/NzbDrone.Common.Test/ServiceFactoryFixture.cs
@@ -30,6 +30,7 @@ namespace NzbDrone.Common.Test
                 .AddNzbDroneLogger()
                 .AutoAddServices(Bootstrap.ASSEMBLIES)
                 .AddDummyDatabase()
+                .AddDummyLogDatabase()
                 .AddStartupContext(new StartupContext("first", "second"));
 
             container.RegisterInstance(new Mock<IHostLifetime>().Object);

--- a/src/NzbDrone.Common/Options/LogOptions.cs
+++ b/src/NzbDrone.Common/Options/LogOptions.cs
@@ -13,4 +13,5 @@ public class LogOptions
     public string SyslogServer { get; set; }
     public int? SyslogPort { get; set; }
     public string SyslogLevel { get; set; }
+    public bool? DbEnabled { get; set; }
 }

--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -57,6 +57,7 @@ namespace NzbDrone.Core.Configuration
         string SyslogServer { get; }
         int SyslogPort { get; }
         string SyslogLevel { get; }
+        bool LogDbEnabled { get; }
         string Theme { get; }
         string PostgresHost { get; }
         int PostgresPort { get; }
@@ -237,7 +238,7 @@ namespace NzbDrone.Core.Configuration
         public string PostgresMainDb => _postgresOptions?.MainDb ?? GetValue("PostgresMainDb", "lidarr-main", persist: false);
         public string PostgresLogDb => _postgresOptions?.LogDb ?? GetValue("PostgresLogDb", "lidarr-log", persist: false);
         public int PostgresPort => (_postgresOptions?.Port ?? 0) != 0 ? _postgresOptions.Port : GetValueInt("PostgresPort", 5432, persist: false);
-
+        public bool LogDbEnabled => _logOptions.DbEnabled ?? GetValueBoolean("LogDbEnabled", true, persist: false);
         public bool LogSql => _logOptions.Sql ?? GetValueBoolean("LogSql", false, persist: false);
         public int LogRotate => _logOptions.Rotate ?? GetValueInt("LogRotate", 50, persist: false);
         public int LogSizeLimit => Math.Min(Math.Max(_logOptions.SizeLimit ?? GetValueInt("LogSizeLimit", 1, persist: false), 0), 10);

--- a/src/NzbDrone.Core/Datastore/Extensions/CompositionExtensions.cs
+++ b/src/NzbDrone.Core/Datastore/Extensions/CompositionExtensions.cs
@@ -8,6 +8,12 @@ namespace NzbDrone.Core.Datastore.Extensions
         public static IContainer AddDatabase(this IContainer container)
         {
             container.RegisterDelegate<IDbFactory, IMainDatabase>(f => new MainDatabase(f.Create()), Reuse.Singleton);
+
+            return container;
+        }
+
+        public static IContainer AddLogDatabase(this IContainer container)
+        {
             container.RegisterDelegate<IDbFactory, ILogDatabase>(f => new LogDatabase(f.Create(MigrationType.Log)), Reuse.Singleton);
 
             return container;
@@ -16,6 +22,12 @@ namespace NzbDrone.Core.Datastore.Extensions
         public static IContainer AddDummyDatabase(this IContainer container)
         {
             container.RegisterInstance<IMainDatabase>(new MainDatabase(null));
+
+            return container;
+        }
+
+        public static IContainer AddDummyLogDatabase(this IContainer container)
+        {
             container.RegisterInstance<ILogDatabase>(new LogDatabase(null));
 
             return container;

--- a/src/NzbDrone.Core/Housekeeping/Housekeepers/TrimLogDatabase.cs
+++ b/src/NzbDrone.Core/Housekeeping/Housekeepers/TrimLogDatabase.cs
@@ -1,18 +1,26 @@
-﻿using NzbDrone.Core.Instrumentation;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Instrumentation;
 
 namespace NzbDrone.Core.Housekeeping.Housekeepers
 {
     public class TrimLogDatabase : IHousekeepingTask
     {
         private readonly ILogRepository _logRepo;
+        private readonly IConfigFileProvider _configFileProvider;
 
-        public TrimLogDatabase(ILogRepository logRepo)
+        public TrimLogDatabase(ILogRepository logRepo, IConfigFileProvider configFileProvider)
         {
             _logRepo = logRepo;
+            _configFileProvider = configFileProvider;
         }
 
         public void Clean()
         {
+            if (!_configFileProvider.LogDbEnabled)
+            {
+                return;
+            }
+
             _logRepo.Trim();
         }
     }

--- a/src/NzbDrone.Core/Update/History/UpdateHistoryService.cs
+++ b/src/NzbDrone.Core/Update/History/UpdateHistoryService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using NLog;
 using NzbDrone.Common.EnvironmentInfo;
+using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Lifecycle;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Update.History.Events;
@@ -18,13 +19,15 @@ namespace NzbDrone.Core.Update.History
     {
         private readonly IUpdateHistoryRepository _repository;
         private readonly IEventAggregator _eventAggregator;
+        private readonly IConfigFileProvider _configFileProvider;
         private readonly Logger _logger;
         private Version _prevVersion;
 
-        public UpdateHistoryService(IUpdateHistoryRepository repository, IEventAggregator eventAggregator, Logger logger)
+        public UpdateHistoryService(IUpdateHistoryRepository repository, IEventAggregator eventAggregator, IConfigFileProvider configFileProvider, Logger logger)
         {
             _repository = repository;
             _eventAggregator = eventAggregator;
+            _configFileProvider = configFileProvider;
             _logger = logger;
         }
 
@@ -58,7 +61,7 @@ namespace NzbDrone.Core.Update.History
 
         public void Handle(ApplicationStartedEvent message)
         {
-            if (BuildInfo.Version.Major == 10)
+            if (BuildInfo.Version.Major == 10 || !_configFileProvider.LogDbEnabled)
             {
                 // Don't save dev versions, they change constantly
                 return;

--- a/src/NzbDrone.Core/Update/RecentUpdateProvider.cs
+++ b/src/NzbDrone.Core/Update/RecentUpdateProvider.cs
@@ -29,7 +29,7 @@ namespace NzbDrone.Core.Update
         {
             var branch = _configFileProvider.Branch;
             var version = BuildInfo.Version;
-            var prevVersion = _updateHistoryService.PreviouslyInstalled();
+            var prevVersion = _configFileProvider.LogDbEnabled ? _updateHistoryService.PreviouslyInstalled() : null;
             return _updatePackageProvider.GetRecentUpdates(branch, version, prevVersion);
         }
     }

--- a/src/NzbDrone.Host/Bootstrap.cs
+++ b/src/NzbDrone.Host/Bootstrap.cs
@@ -94,6 +94,15 @@ namespace NzbDrone.Host
                                     .AddStartupContext(startupContext)
                                     .Resolve<UtilityModeRouter>()
                                     .Route(appMode);
+
+                                if (config.GetValue(nameof(ConfigFileProvider.LogDbEnabled), true))
+                                {
+                                    c.AddLogDatabase();
+                                }
+                                else
+                                {
+                                    c.AddDummyLogDatabase();
+                                }
                             })
                             .ConfigureServices(services =>
                             {
@@ -139,6 +148,7 @@ namespace NzbDrone.Host
             var enableSsl = config.GetValue<bool?>($"Lidarr:Server:{nameof(ServerOptions.EnableSsl)}") ?? config.GetValue(nameof(ConfigFileProvider.EnableSsl), false);
             var sslCertPath = config.GetValue<string>($"Lidarr:Server:{nameof(ServerOptions.SslCertPath)}") ?? config.GetValue<string>(nameof(ConfigFileProvider.SslCertPath));
             var sslCertPassword = config.GetValue<string>($"Lidarr:Server:{nameof(ServerOptions.SslCertPassword)}") ?? config.GetValue<string>(nameof(ConfigFileProvider.SslCertPassword));
+            var logDbEnabled = config.GetValue<bool?>($"Lidarr:Log:{nameof(LogOptions.DbEnabled)}") ?? config.GetValue(nameof(ConfigFileProvider.LogDbEnabled), true);
 
             var urls = new List<string> { BuildUrl("http", bindAddress, port) };
 
@@ -156,6 +166,15 @@ namespace NzbDrone.Host
                         .AddNzbDroneLogger()
                         .AddDatabase()
                         .AddStartupContext(context);
+
+                    if (logDbEnabled)
+                    {
+                        c.AddLogDatabase();
+                    }
+                    else
+                    {
+                        c.AddDummyLogDatabase();
+                    }
                 })
                 .ConfigureServices(services =>
                 {

--- a/src/NzbDrone.Host/Startup.cs
+++ b/src/NzbDrone.Host/Startup.cs
@@ -239,9 +239,13 @@ namespace NzbDrone.Host
 
             // instantiate the databases to initialize/migrate them
             _ = mainDatabaseFactory.Value;
-            _ = logDatabaseFactory.Value;
 
-            dbTarget.Register();
+            if (configFileProvider.LogDbEnabled)
+            {
+                _ = logDatabaseFactory.Value;
+                dbTarget.Register();
+            }
+
             SchemaBuilder.Initialize(container);
 
             if (OsInfo.IsNotWindows)


### PR DESCRIPTION
#### Description

cherry picked from commits Sonarr/sonarr@92eab4b2e26741b7f20b6b7177418402cb15a3aa & Sonarr/sonarr@d5dff8e8d6301b661a713702e1c476705423fc4f

A config.xml and environment variable (LIDARR__LOG__DBENABLED) to disable the log database. This change disables the update and event pages on the frontend by returning default empty values.
This change is not breaking as it defaults to enabled if the configuration is omitted.

#### Database Migration
NO


#### Issues Fixed or Closed by this PR

* Fixes #4785 
* Fixes #4878 