### PR TITLE
Introducing Lidarr Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 ![Github Downloads](https://img.shields.io/github/downloads/lidarr/lidarr/total.svg)
 [![Backers on Open Collective](https://opencollective.com/lidarr/backers/badge.svg)](#backers) 
 [![Sponsors on Open Collective](https://opencollective.com/lidarr/sponsors/badge.svg)](#sponsors)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Lidarr%20Guru-006BFF)](https://gurubase.io/g/lidarr)
 
 Lidarr is a music collection manager for Usenet and BitTorrent users. It can monitor multiple RSS feeds for new tracks from your favorite artists and will grab, sort and rename them. It can also be configured to automatically upgrade the quality of files already downloaded when a better quality format becomes available.
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Lidarr Guru](https://gurubase.io/g/lidarr) to Gurubase. Lidarr Guru uses the data from this repo and data from the [docs](https://wiki.servarr.com/lidarr) to answer questions by leveraging the LLM.

In this PR, I showcased the "Lidarr Guru", which highlights that Lidarr now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Lidarr Guru in Gurubase, just let me know that's totally fine.
