### PR TITLE
Youtube Music Import List

### DIFF
--- a/src/NzbDrone.Core/ImportLists/ImportListType.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListType.cs
@@ -5,6 +5,7 @@ namespace NzbDrone.Core.ImportLists
         Program,
         Spotify,
         LastFm,
+        Youtube,
         Other,
         Advanced
     }

--- a/src/NzbDrone.Core/ImportLists/Youtube/YoutubeImportListBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Youtube/YoutubeImportListBase.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using FluentValidation.Results;
+using Google.Apis.Services;
+using Google.Apis.YouTube.v3;
+using NLog;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Parser;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.ImportLists.Youtube
+{
+    public abstract class  YoutubeImportListBase<TSettings> : ImportListBase<TSettings>
+        where TSettings : YoutubeSettingsBase<TSettings>, new()
+    {
+        private IHttpClient _httpClient;
+
+        protected YoutubeImportListBase(IImportListStatusService importListStatusService,
+                                        IConfigService configService,
+                                        IParsingService parsingService,
+                                        IHttpClient httpClient,
+                                        Logger logger)
+            : base(importListStatusService, configService, parsingService, logger)
+        {
+            _httpClient = httpClient;
+        }
+
+        public override ImportListType ListType => ImportListType.Youtube;
+        public override TimeSpan MinRefreshInterval => TimeSpan.FromSeconds(1);
+
+        public override IList<ImportListItemInfo> Fetch()
+        {
+            IList<YoutubeImportListItemInfo> releases = new List<YoutubeImportListItemInfo>();
+
+            using (var service = new YouTubeService(new BaseClientService.Initializer()
+                   {
+                       ApiKey = ""
+                   }))
+            {
+                releases = Fetch(service);
+            }
+
+            // TODO remap
+
+            return CleanupListItems(releases);
+        }
+
+        public IList<YoutubeImportListItemInfo> MapYoutubeReleases(IList<YoutubeImportListItemInfo> items)
+        {
+            return items;
+        }
+
+        public abstract IList<YoutubeImportListItemInfo> Fetch(YouTubeService service);
+
+        protected override void Test(List<ValidationFailure> failures)
+        {
+            failures.AddIfNotNull(TestConnection());
+        }
+
+        private ValidationFailure TestConnection()
+        {
+            return null;
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Youtube/YoutubeImportListBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Youtube/YoutubeImportListBase.cs
@@ -15,8 +15,6 @@ namespace NzbDrone.Core.ImportLists.Youtube
     public abstract class  YoutubeImportListBase<TSettings> : ImportListBase<TSettings>
         where TSettings : YoutubePlaylistSettings, new()
     {
-        private IHttpClient _httpClient;
-
         protected YoutubeImportListBase(IImportListStatusService importListStatusService,
                                         IConfigService configService,
                                         IParsingService parsingService,
@@ -24,7 +22,6 @@ namespace NzbDrone.Core.ImportLists.Youtube
                                         Logger logger)
             : base(importListStatusService, configService, parsingService, logger)
         {
-            _httpClient = httpClient;
         }
 
         public override ImportListType ListType => ImportListType.Youtube;
@@ -43,11 +40,6 @@ namespace NzbDrone.Core.ImportLists.Youtube
             }
 
             return CleanupListItems(releases);
-        }
-
-        public IList<YoutubeImportListItemInfo> MapYoutubeReleases(IList<YoutubeImportListItemInfo> items)
-        {
-            return items;
         }
 
         public abstract IList<YoutubeImportListItemInfo> Fetch(YouTubeService service);

--- a/src/NzbDrone.Core/ImportLists/Youtube/YoutubeImportListBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Youtube/YoutubeImportListBase.cs
@@ -42,8 +42,6 @@ namespace NzbDrone.Core.ImportLists.Youtube
                 releases = Fetch(service);
             }
 
-            // TODO remap
-
             return CleanupListItems(releases);
         }
 

--- a/src/NzbDrone.Core/ImportLists/Youtube/YoutubeImportListBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Youtube/YoutubeImportListBase.cs
@@ -13,7 +13,7 @@ using NzbDrone.Core.Parser.Model;
 namespace NzbDrone.Core.ImportLists.Youtube
 {
     public abstract class  YoutubeImportListBase<TSettings> : ImportListBase<TSettings>
-        where TSettings : YoutubeSettingsBase<TSettings>, new()
+        where TSettings : YoutubePlaylistSettings, new()
     {
         private IHttpClient _httpClient;
 
@@ -36,7 +36,7 @@ namespace NzbDrone.Core.ImportLists.Youtube
 
             using (var service = new YouTubeService(new BaseClientService.Initializer()
                    {
-                       ApiKey = ""
+                       ApiKey = Settings.YoutubeApiKey,
                    }))
             {
                 releases = Fetch(service);

--- a/src/NzbDrone.Core/ImportLists/Youtube/YoutubeImportListBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Youtube/YoutubeImportListBase.cs
@@ -57,9 +57,17 @@ namespace NzbDrone.Core.ImportLists.Youtube
             failures.AddIfNotNull(TestConnection());
         }
 
+        public abstract ValidationFailure TestConnection(YouTubeService service);
+
         private ValidationFailure TestConnection()
         {
-            return null;
+            using (var service = new YouTubeService(new BaseClientService.Initializer()
+                   {
+                       ApiKey = Settings.YoutubeApiKey,
+                   }))
+            {
+             return   TestConnection(service);
+            }
         }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/Youtube/YoutubeImportListItemInfo.cs
+++ b/src/NzbDrone.Core/ImportLists/Youtube/YoutubeImportListItemInfo.cs
@@ -1,0 +1,14 @@
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.ImportLists.Youtube;
+
+public class YoutubeImportListItemInfo : ImportListItemInfo
+{
+    public string ArtistYoutubeId { get; set; }
+    public string AlbumYoutubeId { get; set; }
+
+    public override string ToString()
+    {
+        return string.Format("[{0}] {1}", ArtistYoutubeId, AlbumYoutubeId);
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Youtube/YoutubePlaylist.cs
+++ b/src/NzbDrone.Core/ImportLists/Youtube/YoutubePlaylist.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using DryIoc.ImTools;
 using FluentValidation.Results;
 using Google.Apis.YouTube.v3;
@@ -62,6 +63,7 @@ namespace NzbDrone.Core.ImportLists.Youtube
                     results.Add(listItem);
                 }
 
+                Thread.Sleep(TimeSpan.FromSeconds(1));
                 playlist = req.Execute();
             }
             while (playlist.NextPageToken != null && page < 10);

--- a/src/NzbDrone.Core/ImportLists/Youtube/YoutubePlaylist.cs
+++ b/src/NzbDrone.Core/ImportLists/Youtube/YoutubePlaylist.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DryIoc.ImTools;
+using Google.Apis.YouTube.v3;
+using Google.Apis.YouTube.v3.Data;
+using NLog;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Parser;
+
+namespace NzbDrone.Core.ImportLists.Youtube
+{
+    public class YoutubePlaylist : YoutubeImportListBase<YoutubePlaylistSettings>
+    {
+        public YoutubePlaylist(IImportListStatusService importListStatusService,
+            IImportListRepository importListRepository,
+            IConfigService configService,
+            IParsingService parsingService,
+            IHttpClient httpClient,
+            Logger logger)
+            : base(importListStatusService, configService, parsingService, httpClient, logger)
+        {
+        }
+
+        public override string Name => "Youtube Playlists";
+
+        public override IList<YoutubeImportListItemInfo> Fetch(YouTubeService service)
+        {
+            return Settings.PlaylistIds.SelectMany(x => Fetch(service, x)).ToList();
+        }
+
+        public IList<YoutubeImportListItemInfo> Fetch(YouTubeService service, string playlistId)
+        {
+            // TODO playlist
+            var results = new List<YoutubeImportListItemInfo>();
+            var req = service.PlaylistItems.List("contentDetails,snippet");
+            req.PlaylistId = playlistId;
+            req.MaxResults = 50;
+
+            while (true)
+            {
+                var playlist = req.Execute();
+                req.PageToken = playlist.NextPageToken;
+
+                foreach (var song in playlist.Items)
+                {
+                    var listItem = new YoutubeImportListItemInfo();
+                    var topicChannel = song.Snippet.VideoOwnerChannelTitle.EndsWith("- Topic");
+                    if (topicChannel)
+                    {
+                        ParseTopicChannel(song, ref listItem);
+                    }
+                    else
+                    {
+                        // No album name just video
+                        listItem.ReleaseDate = ParseDateTimeOffset(song);
+                        listItem.Artist = song.Snippet.VideoOwnerChannelTitle;
+                    }
+
+                    results.Add(listItem);
+                }
+
+                if (playlist.NextPageToken == null)
+                {
+                    break;
+                }
+            }
+
+            return results;
+        }
+
+        public void ParseTopicChannel(PlaylistItem playlistItem, ref YoutubeImportListItemInfo listItem)
+        {
+            var description = playlistItem.Snippet.Description;
+            var descArgs = description.Split("\n\n");
+
+            listItem.Artist = playlistItem.Snippet.VideoOwnerChannelTitle.Contains("- Topic") ?
+                playlistItem.Snippet.VideoOwnerChannelTitle[.. (playlistItem.Snippet.VideoOwnerChannelTitle.LastIndexOf('-') - 1)] :
+                playlistItem.Snippet.VideoOwnerChannelTitle;
+            listItem.Album = descArgs[2];
+
+            if (descArgs.Any(s => s.StartsWith("Released on:")))
+            {
+                // Custom release date
+                var release = descArgs.FindFirst(s => s.StartsWith("Released on:"));
+                var date = release.Substring(release.IndexOf(':') + 1);
+                listItem.ReleaseDate = DateTime.Parse(date);
+            }
+            else
+            {
+                listItem.ReleaseDate = ParseDateTimeOffset(playlistItem);
+            }
+        }
+
+        private DateTime ParseDateTimeOffset(PlaylistItem playlistItem)
+        {
+            return (playlistItem.ContentDetails.VideoPublishedAtDateTimeOffset ?? DateTimeOffset.UnixEpoch).DateTime;
+        }
+
+        private DateTime ParseYoutubeDate(string date, PlaylistItem song)
+        {
+            return DateTime.Now;
+        }
+
+        public override object RequestAction(string action, IDictionary<string, string> query)
+        {
+            Console.Out.WriteLine(action);
+
+            return base.RequestAction(action, query);
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Youtube/YoutubePlaylist.cs
+++ b/src/NzbDrone.Core/ImportLists/Youtube/YoutubePlaylist.cs
@@ -105,8 +105,6 @@ namespace NzbDrone.Core.ImportLists.Youtube
 
         public override object RequestAction(string action, IDictionary<string, string> query)
         {
-            Console.Out.WriteLine(action);
-
             return base.RequestAction(action, query);
         }
     }

--- a/src/NzbDrone.Core/ImportLists/Youtube/YoutubePlaylist.cs
+++ b/src/NzbDrone.Core/ImportLists/Youtube/YoutubePlaylist.cs
@@ -98,11 +98,6 @@ namespace NzbDrone.Core.ImportLists.Youtube
             return (playlistItem.ContentDetails.VideoPublishedAtDateTimeOffset ?? DateTimeOffset.UnixEpoch).DateTime;
         }
 
-        private DateTime ParseYoutubeDate(string date, PlaylistItem song)
-        {
-            return DateTime.Now;
-        }
-
         public override object RequestAction(string action, IDictionary<string, string> query)
         {
             return base.RequestAction(action, query);

--- a/src/NzbDrone.Core/ImportLists/Youtube/YoutubePlaylist.cs
+++ b/src/NzbDrone.Core/ImportLists/Youtube/YoutubePlaylist.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using DryIoc.ImTools;
+using FluentValidation.Results;
 using Google.Apis.YouTube.v3;
 using Google.Apis.YouTube.v3.Data;
 using NLog;
@@ -93,6 +94,26 @@ namespace NzbDrone.Core.ImportLists.Youtube
         private DateTime ParseDateTimeOffset(PlaylistItem playlistItem)
         {
             return (playlistItem.ContentDetails.VideoPublishedAtDateTimeOffset ?? DateTimeOffset.UnixEpoch).DateTime;
+        }
+
+        public override ValidationFailure TestConnection(YouTubeService service)
+        {
+            foreach (var id in Settings.PlaylistIds)
+            {
+                try
+                {
+                    var req = service.PlaylistItems.List("contentDetails,snippet");
+                    req.PlaylistId = id;
+                    req.MaxResults = 1;
+                    req.Execute();
+                }
+                catch (Exception e)
+                {
+                    return new ValidationFailure(string.Empty, e.Message);
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/Youtube/YoutubePlaylistSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Youtube/YoutubePlaylistSettings.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using FluentValidation;
+using NzbDrone.Core.Annotations;
+
+namespace NzbDrone.Core.ImportLists.Youtube
+{
+    public class YoutubePlaylistSettingsValidator : YoutubeSettingsBaseValidator<YoutubePlaylistSettings>
+    {
+        public YoutubePlaylistSettingsValidator()
+        : base()
+        {
+            RuleFor(c => c.PlaylistIds).NotEmpty();
+        }
+    }
+
+    public class YoutubePlaylistSettings : YoutubeSettingsBase<YoutubePlaylistSettings>
+    {
+        protected override AbstractValidator<YoutubePlaylistSettings> Validator =>
+            new YoutubePlaylistSettingsValidator();
+
+        public YoutubePlaylistSettings()
+        {
+            PlaylistIds = System.Array.Empty<string>();
+        }
+
+        // public override string Scope => "playlist-read-private";
+
+        [FieldDefinition(1, Label = "Playlists", Type = FieldType.Textbox)]
+        public IEnumerable<string> PlaylistIds { get; set; }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Youtube/YoutubePlaylistSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Youtube/YoutubePlaylistSettings.cs
@@ -23,7 +23,8 @@ namespace NzbDrone.Core.ImportLists.Youtube
             PlaylistIds = System.Array.Empty<string>();
         }
 
-        // public override string Scope => "playlist-read-private";
+        [FieldDefinition(1, Label = "Youtube API key", Type = FieldType.Textbox)]
+        public string YoutubeApiKey { get; set; }
 
         [FieldDefinition(1, Label = "Playlists", Type = FieldType.Textbox)]
         public IEnumerable<string> PlaylistIds { get; set; }

--- a/src/NzbDrone.Core/ImportLists/Youtube/YoutubeSettingsBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Youtube/YoutubeSettingsBase.cs
@@ -8,10 +8,6 @@ namespace NzbDrone.Core.ImportLists.Youtube
     public class YoutubeSettingsBaseValidator<TSettings> : AbstractValidator<TSettings>
         where TSettings : YoutubeSettingsBase<TSettings>
     {
-        public YoutubeSettingsBaseValidator()
-        {
-            // TODO
-        }
     }
 
     public class YoutubeSettingsBase<TSettings> : IImportListSettings
@@ -31,9 +27,6 @@ namespace NzbDrone.Core.ImportLists.Youtube
 
         [FieldDefinition(0, Label = "Expires", Type = FieldType.Textbox, Hidden = HiddenType.Hidden)]
         public DateTime Expires { get; set; }
-
-        // [FieldDefinition(99, Label = "Authenticate with Google", Type = FieldType.OAuth)]
-        // public string SignIn { get; set; }
 
         public NzbDroneValidationResult Validate()
         {

--- a/src/NzbDrone.Core/ImportLists/Youtube/YoutubeSettingsBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Youtube/YoutubeSettingsBase.cs
@@ -1,0 +1,48 @@
+using System;
+using FluentValidation;
+using NzbDrone.Core.Annotations;
+using NzbDrone.Core.Validation;
+
+namespace NzbDrone.Core.ImportLists.Youtube
+{
+    public class YoutubeSettingsBaseValidator<TSettings> : AbstractValidator<TSettings>
+        where TSettings : YoutubeSettingsBase<TSettings>
+    {
+        public YoutubeSettingsBaseValidator()
+        {
+            // TODO
+        }
+    }
+
+    public class YoutubeSettingsBase<TSettings> : IImportListSettings
+        where TSettings : YoutubeSettingsBase<TSettings>
+    {
+        protected virtual AbstractValidator<TSettings> Validator => new YoutubeSettingsBaseValidator<TSettings>();
+
+        public YoutubeSettingsBase()
+        {
+            BaseUrl = "todo";
+        }
+
+        public string BaseUrl { get; set; }
+
+        public virtual string Scope => "";
+
+        [FieldDefinition(0, Label = "Access Token", Type = FieldType.Textbox, Hidden = HiddenType.Hidden)]
+        public string AccessToken { get; set; }
+
+        [FieldDefinition(0, Label = "Refresh Token", Type = FieldType.Textbox, Hidden = HiddenType.Hidden)]
+        public string RefreshToken { get; set; }
+
+        [FieldDefinition(0, Label = "Expires", Type = FieldType.Textbox, Hidden = HiddenType.Hidden)]
+        public DateTime Expires { get; set; }
+
+        // [FieldDefinition(99, Label = "Authenticate with Google", Type = FieldType.OAuth)]
+        // public string SignIn { get; set; }
+
+        public NzbDroneValidationResult Validate()
+        {
+            return new NzbDroneValidationResult(Validator.Validate((TSettings)this));
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Youtube/YoutubeSettingsBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Youtube/YoutubeSettingsBase.cs
@@ -1,6 +1,4 @@
-using System;
 using FluentValidation;
-using NzbDrone.Core.Annotations;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.ImportLists.Youtube
@@ -16,17 +14,6 @@ namespace NzbDrone.Core.ImportLists.Youtube
         protected virtual AbstractValidator<TSettings> Validator => new YoutubeSettingsBaseValidator<TSettings>();
 
         public string BaseUrl { get; set; }
-
-        public virtual string Scope => "";
-
-        [FieldDefinition(0, Label = "Access Token", Type = FieldType.Textbox, Hidden = HiddenType.Hidden)]
-        public string AccessToken { get; set; }
-
-        [FieldDefinition(0, Label = "Refresh Token", Type = FieldType.Textbox, Hidden = HiddenType.Hidden)]
-        public string RefreshToken { get; set; }
-
-        [FieldDefinition(0, Label = "Expires", Type = FieldType.Textbox, Hidden = HiddenType.Hidden)]
-        public DateTime Expires { get; set; }
 
         public NzbDroneValidationResult Validate()
         {

--- a/src/NzbDrone.Core/ImportLists/Youtube/YoutubeSettingsBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Youtube/YoutubeSettingsBase.cs
@@ -19,11 +19,6 @@ namespace NzbDrone.Core.ImportLists.Youtube
     {
         protected virtual AbstractValidator<TSettings> Validator => new YoutubeSettingsBaseValidator<TSettings>();
 
-        public YoutubeSettingsBase()
-        {
-            BaseUrl = "todo";
-        }
-
         public string BaseUrl { get; set; }
 
         public virtual string Scope => "";

--- a/src/NzbDrone.Core/Lidarr.Core.csproj
+++ b/src/NzbDrone.Core/Lidarr.Core.csproj
@@ -6,6 +6,7 @@
     <PackageReference Include="Dapper" Version="2.0.151" />
     <PackageReference Include="Diacritical.Net" Version="1.0.4" />
     <PackageReference Include="Equ" Version="2.3.0" />
+    <PackageReference Include="Google.Apis.YouTube.v3" Version="1.69.0.3680" />
     <PackageReference Include="MailKit" Version="4.8.0" />
     <PackageReference Include="Polly" Version="8.5.2" />
     <PackageReference Include="System.Text.Json" Version="6.0.10" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Add YouTube as an ImportList option.

This isn't quite ready but is working. I wanted to get some feedback around authentication. Right now I'm using an API key I got from my own Google Cloud Console, but not sure the best approach. API keys can't access private data, and we can't sign-in and access our own users playlists they only work for public lists. I saw the spotify import list uses some lidarr auth URLs maybe we can do the same for this?

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #1543 