### PR TITLE
Fixed: Custom Lists using only ArtistMusicBrainzId

### DIFF
--- a/src/NzbDrone.Core/ImportLists/FetchAndParseImportListService.cs
+++ b/src/NzbDrone.Core/ImportLists/FetchAndParseImportListService.cs
@@ -86,7 +86,7 @@ namespace NzbDrone.Core.ImportLists
 
             Task.WaitAll(taskList.ToArray());
 
-            result = result.DistinctBy(r => new { r.Artist, r.Album }).ToList();
+            result = result.DistinctBy(r => new { r.Artist, r.Album,  r.ArtistMusicBrainzId}).ToList();
 
             _logger.Debug("Found {0} total reports from {1} lists", result.Count, importLists.Count);
 

--- a/src/NzbDrone.Core/ImportLists/FetchAndParseImportListService.cs
+++ b/src/NzbDrone.Core/ImportLists/FetchAndParseImportListService.cs
@@ -135,7 +135,7 @@ namespace NzbDrone.Core.ImportLists
 
             Task.WaitAll(taskList.ToArray());
 
-            result = result.DistinctBy(r => new { r.Artist, r.Album }).ToList();
+            result = result.DistinctBy(r => new { r.Artist, r.Album, r.ArtistMusicBrainzId }).ToList();
 
             return result;
         }

--- a/src/NzbDrone.Core/ImportLists/FetchAndParseImportListService.cs
+++ b/src/NzbDrone.Core/ImportLists/FetchAndParseImportListService.cs
@@ -86,7 +86,7 @@ namespace NzbDrone.Core.ImportLists
 
             Task.WaitAll(taskList.ToArray());
 
-            result = result.DistinctBy(r => new { r.Artist, r.Album,  r.ArtistMusicBrainzId}).ToList();
+            result = result.DistinctBy(r => new { r.Artist, r.Album,  r.ArtistMusicBrainzId }).ToList();
 
             _logger.Debug("Found {0} total reports from {1} lists", result.Count, importLists.Count);
 

--- a/src/NzbDrone.Core/ImportLists/ImportListBase.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListBase.cs
@@ -64,7 +64,7 @@ namespace NzbDrone.Core.ImportLists
 
         protected virtual IList<ImportListItemInfo> CleanupListItems(IEnumerable<ImportListItemInfo> releases)
         {
-            var result = releases.DistinctBy(r => new { r.Artist, r.Album }).ToList();
+            var result = releases.DistinctBy(r => new { r.Artist, r.Album, r.ArtistMusicBrainzId }).ToList();
 
             result.ForEach(c =>
             {


### PR DESCRIPTION
Fix: Custom List import using and artist's MusicBrainzId

#### Database Migration
NO

#### Description
It appears then when importing a JSON list as a custom list that only has an artists MusicBrainzId, the list was being filtered to only pass on the first item in the list. 

By adding the r.ArtistMusicBrainzId when generating the hash, it allows items to pass, even though the id's were already unique.

#### Todos
- [ ] Tests
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #5396 