### PR TITLE
New: Make Genres Sortable

### DIFF
--- a/frontend/src/Store/Actions/artistIndexActions.js
+++ b/frontend/src/Store/Actions/artistIndexActions.js
@@ -151,7 +151,7 @@ export const defaultState = {
     {
       name: 'genres',
       label: () => translate('Genres'),
-      isSortable: false,
+      isSortable: true,
       isVisible: false
     },
     {

--- a/src/.idea/.idea.Lidarr/.idea/indexLayout.xml
+++ b/src/.idea/.idea.Lidarr/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>


### PR DESCRIPTION
Makes genres sortable in the table. 

* Fixes #5507

#### Screenshot (if UI related)
![sortable1](https://github.com/user-attachments/assets/ad42007d-55cb-467e-99dc-2a31905d22d2)
![sortable2](https://github.com/user-attachments/assets/d1b5b78c-5819-45a6-945c-ffb1213891f8)


