### PR TITLE
New: Add Metadata Source URL option in UI settings

### DIFF
--- a/frontend/src/Settings/Metadata/MetadataProvider/MetadataProvider.js
+++ b/frontend/src/Settings/Metadata/MetadataProvider/MetadataProvider.js
@@ -19,6 +19,7 @@ const writeAudioTagOptions = [
 
 function MetadataProvider(props) {
   const {
+    advancedSettings,
     isFetching,
     error,
     settings,
@@ -89,6 +90,24 @@ function MetadataProvider(props) {
                   helpText={translate('ScrubAudioTagsHelpText')}
                   onChange={onInputChange}
                   {...settings.scrubAudioTags}
+                />
+              </FormGroup>
+
+              <FormGroup
+                advancedSettings={advancedSettings}
+                isAdvanced={true}
+              >
+                <FormLabel>
+                  {translate('MetadataSourceUrl')}
+                </FormLabel>
+
+                <FormInputGroup
+                  type={inputTypes.TEXT}
+                  name="metadataSource"
+                  helpText={translate('MetadataSourceUrlHelpText')}
+                  onChange={onInputChange}
+                  placeholder="https://api.lidarr.audio/api/v0.4/"
+                  {...settings.metadataSource}
                 />
               </FormGroup>
 

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -741,6 +741,8 @@
   "MetadataProfiles": "Metadata Profiles",
   "MetadataSettings": "Metadata Settings",
   "MetadataSettingsArtistSummary": "Create metadata files when tracks are imported or artist are refreshed",
+  "MetadataSourceUrl": "Metadata Source URL",
+  "MetadataSourceUrlHelpText": "The URL for the metadata source to use for additional information.",
   "Min": "Min",
   "MinFormatScoreHelpText": "Minimum custom format score allowed to download",
   "MinimumAge": "Minimum Age",


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This exposes the Metadata Source URL config option in Settings > Metadata 

#### Screenshot (if UI related)
![image](https://github.com/user-attachments/assets/9babe8a8-577a-45dd-8fb9-9cf152cbb117)


#### Todos
- [ ] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

