### PR TITLE
Bump SixLabors.ImageSharp to 3.1.11

### DIFF
--- a/src/NzbDrone.Core/Lidarr.Core.csproj
+++ b/src/NzbDrone.Core/Lidarr.Core.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="TagLibSharp-Lidarr" Version="2.2.0.27" />
     <PackageReference Include="Npgsql" Version="7.0.10" />
     <PackageReference Include="SpotifyAPI.Web" Version="5.1.1" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.9" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
     <PackageReference Include="MonoTorrent" Version="2.0.7" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Bump SixLabors.ImageSharp to 3.1.11 to fix vulnerability [GitHub Advisory GHSA-rxmq-m78w-7wmc](https://github.com/advisories/GHSA-rxmq-m78w-7wmc)

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

- None