### PR TITLE
Fixed: Don't Fail Artist Refresh if Album Refresh fails

### DIFF
--- a/src/NzbDrone.Core/Music/Services/RefreshAlbumService.cs
+++ b/src/NzbDrone.Core/Music/Services/RefreshAlbumService.cs
@@ -346,7 +346,7 @@ namespace NzbDrone.Core.Music
                     }
                     catch (Exception e)
                     {
-                        _logger.Error(e, "Couldn't refresh info for {0}", album);
+                        _logger.Error(e, "Couldn't refresh info for album {0}", album.Title);
                     }
                 }
                 else

--- a/src/NzbDrone.Core/Music/Services/RefreshAlbumService.cs
+++ b/src/NzbDrone.Core/Music/Services/RefreshAlbumService.cs
@@ -340,7 +340,14 @@ namespace NzbDrone.Core.Music
                     (updatedMusicbrainzAlbums == null && _checkIfAlbumShouldBeRefreshed.ShouldRefresh(album)) ||
                     (updatedMusicbrainzAlbums != null && updatedMusicbrainzAlbums.Contains(album.ForeignAlbumId)))
                 {
-                    updated |= RefreshAlbumInfo(album, remoteAlbums, forceUpdateFileTags);
+                    try
+                    {
+                        updated |= RefreshAlbumInfo(album, remoteAlbums, forceUpdateFileTags);
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.Error(e, "Couldn't refresh info for {0}", album);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When refreshing an artist, it refreshes every album for the artist in order. However, if an album fails to refresh for some reason, the artist refresh terminates leaving all remaining albums unrefreshed. This PR adds basic exception handling to `RefreshAlbumService` to match the exception handling done in `RefreshSelectedArtists()` as part of `RefreshArtistService`, allowing Lidarr to continue refreshing albums under an artist even if one or more experience exceptions. This is especially needed during the current dial-up of the new metadata service.

#### Screenshot (if UI related)
N/A

#### Todos
- [ X ] Tests
- [ N/A ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ N/A ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR
None