### PR TITLE
New: Add {Release Date} token

### DIFF
--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
@@ -111,7 +111,8 @@ const trackTokens = [
 ];
 
 const releaseDateTokens = [
-  { token: '{Release Year}', example: '2016' }
+  { token: '{Release Year}', example: '2016' },
+  { token: '{Release Date}', example: '2016-01-31' }
 ];
 
 const trackTitleTokens = [

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -340,6 +340,10 @@ namespace NzbDrone.Core.Organizer
             tokenHandlers["{Release Year}"] = album.ReleaseDate.HasValue
                 ? m => album.ReleaseDate.Value.Year.ToString()
                 : m => "Unknown";
+
+            tokenHandlers["{Release Date}"] = album.ReleaseDate.HasValue
+                ? m => album.ReleaseDate.Value.ToString("yyyy-MM-dd")
+                : m => "Unknown";
         }
 
         private void AddMediumTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, Medium medium)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Add `{Release Date}` token (mentioned in https://github.com/Lidarr/Lidarr/issues/551)

#### Screenshots:
`{Release Date}` token in `/settings/mediamanagement`:
<img width="509" height="215" alt="Release Date token in Media Management" src="https://github.com/user-attachments/assets/fa7d1e5f-b542-41e6-8feb-6c6a8109c4bc" />
<img width="509" height="215" alt="Release Date token in Media Management" src="https://github.com/user-attachments/assets/3426d8f1-a8f0-408c-9227-b209cf961680" />

`{Release Date}` token in the "Organize & Rename" modal:
<img width="461" height="166" alt="Release Date token in Organize and Rename modal" src="https://github.com/user-attachments/assets/080ce371-6ec7-412e-bf63-056f14769fa1" />

