### PR TITLE
Fixed: Replace illegal characters even when renaming is disabled

### DIFF
--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
@@ -563,6 +563,20 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
         }
 
         [Test]
+        public void should_replace_illegal_characters_when_renaming_is_disabled()
+        {
+            _namingConfig.RenameTracks = false;
+            _namingConfig.ReplaceIllegalCharacters = true;
+            _namingConfig.ColonReplacementFormat = ColonReplacementFormat.Smart;
+
+            _trackFile.SceneName = "Linkin.Park.06.FLAC:LOL";
+            _trackFile.Path = "Linkin Park - 06 - Test";
+
+            Subject.BuildTrackFileName(new List<Track> { _track1 }, _artist, _album, _trackFile)
+                .Should().Be("Linkin.Park.06.FLAC-LOL");
+        }
+
+        [Test]
         public void should_not_clean_track_title_if_there_is_only_one()
         {
             var title = "City Sushi (1)";

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -661,10 +661,10 @@ namespace NzbDrone.Core.Organizer
         {
             if (trackFile.SceneName.IsNullOrWhiteSpace())
             {
-                return GetOriginalFileName(trackFile);
+                return CleanFileName(GetOriginalFileName(trackFile));
             }
 
-            return trackFile.SceneName;
+            return CleanFileName(trackFile.SceneName);
         }
 
         private string GetOriginalFileName(TrackFile trackFile)


### PR DESCRIPTION
(cherry picked from commit 4d8a4436810828494e99f0854cf6de3269668fe4)

Closes #5094
