### PR TITLE
Fixed: Handle Artist Metadata Inconsistent Responses

### DIFF
--- a/src/NzbDrone.Core/Music/Repositories/ArtistMetadataRepository.cs
+++ b/src/NzbDrone.Core/Music/Repositories/ArtistMetadataRepository.cs
@@ -39,6 +39,12 @@ namespace NzbDrone.Core.Music
                 var existing = existingMetadata.SingleOrDefault(x => x.ForeignArtistId == meta.ForeignArtistId);
                 if (existing != null)
                 {
+                    if (IsPlaceholderData(meta) && !IsPlaceholderData(existing))
+                    {
+                        _logger.Warn($"Skipping metadata downgrade: {existing.Name} -> {meta.Name}, for artist {meta.ForeignArtistId}");
+                        continue;
+                    }
+
                     meta.UseDbFieldsFrom(existing);
                     if (!meta.Equals(existing))
                     {
@@ -62,5 +68,10 @@ namespace NzbDrone.Core.Music
 
             return updateMetadataList.Count > 0 || addMetadataList.Count > 0;
         }
+
+        private static bool IsPlaceholderData(ArtistMetadata metadata) =>
+          metadata.Name?.StartsWith("Unknown Artist", System.StringComparison.OrdinalIgnoreCase) != false ||
+          metadata.Disambiguation == "Artist not found in database" ||
+          metadata.Type == "Unknown";
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description

The metadata server sometimes returns placeholder "Unknown Artist" data for uncached albums due to inconsistent responses, which would overwrite previously fetched valid artist metadata in the database. This change adds protection against metadata degradation.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)
