### PR TITLE
Add release MBID to release selector dropdown.

### DIFF
--- a/frontend/src/Components/Form/AlbumReleaseSelectInputConnector.js
+++ b/frontend/src/Components/Form/AlbumReleaseSelectInputConnector.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import shortenList from 'Utilities/String/shortenList';
 import titleCase from 'Utilities/String/titleCase';
-import SelectInput from './SelectInput';
+import EnhancedSelectInput from './EnhancedSelectInput';
 
 function createMapStateToProps() {
   return createSelector(
@@ -29,8 +29,8 @@ function createMapStateToProps() {
             `${disambiguation ? ' (' : ''}${titleCase(disambiguation)}${disambiguation ? ')' : ''}` +
             `, ${mediumCount} med, ${trackCount} tracks` +
             `${country && country.length > 0 ? `, ${shortenList(country)}` : ''}` +
-            `${format ? `, [${format}]` : ''}` +
-            `, [...${foreignReleaseId.toString().slice(-4)}]`
+            `${format ? `, [${format}]` : ''}`,
+          hint: `MBID: ${foreignReleaseId.toString().slice(0, 8)}`
         };
       });
 
@@ -65,7 +65,7 @@ class AlbumReleaseSelectInputConnector extends Component {
   render() {
 
     return (
-      <SelectInput
+      <EnhancedSelectInput
         {...this.props}
         onChange={this.onChange}
       />

--- a/frontend/src/Components/Form/AlbumReleaseSelectInputConnector.js
+++ b/frontend/src/Components/Form/AlbumReleaseSelectInputConnector.js
@@ -1,15 +1,15 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { createSelector } from 'reselect';
+import React, {Component} from 'react';
+import {connect} from 'react-redux';
+import {createSelector} from 'reselect';
 import shortenList from 'Utilities/String/shortenList';
 import titleCase from 'Utilities/String/titleCase';
 import SelectInput from './SelectInput';
 
 function createMapStateToProps() {
   return createSelector(
-    (state, { albumReleases }) => albumReleases,
+    (state, {albumReleases}) => albumReleases,
     (albumReleases) => {
       const values = _.map(albumReleases.value, (albumRelease) => {
 
@@ -29,13 +29,14 @@ function createMapStateToProps() {
             `${disambiguation ? ' (' : ''}${titleCase(disambiguation)}${disambiguation ? ')' : ''}` +
             `, ${mediumCount} med, ${trackCount} tracks` +
             `${country && country.length > 0 ? `, ${shortenList(country)}` : ''}` +
-            `${format ? `, [${format}]` : ''}`
+            `${format ? `, [${format}]` : ''}` +
+            `, ${foreignReleaseId.toString()}`
         };
       });
 
       const sortedValues = _.orderBy(values, ['value']);
 
-      const value = _.find(albumReleases.value, { monitored: true }).foreignReleaseId;
+      const value = _.find(albumReleases.value, {monitored: true}).foreignReleaseId;
 
       return {
         values: sortedValues,
@@ -50,15 +51,15 @@ class AlbumReleaseSelectInputConnector extends Component {
   //
   // Listeners
 
-  onChange = ({ name, value }) => {
+  onChange = ({name, value}) => {
     const {
       albumReleases
     } = this.props;
 
-    const updatedReleases = _.map(albumReleases.value, (e) => ({ ...e, monitored: false }));
-    _.find(updatedReleases, { foreignReleaseId: value }).monitored = true;
+    const updatedReleases = _.map(albumReleases.value, (e) => ({...e, monitored: false}));
+    _.find(updatedReleases, {foreignReleaseId: value}).monitored = true;
 
-    this.props.onChange({ name, value: updatedReleases });
+    this.props.onChange({name, value: updatedReleases});
   };
 
   render() {

--- a/frontend/src/Components/Form/AlbumReleaseSelectInputConnector.js
+++ b/frontend/src/Components/Form/AlbumReleaseSelectInputConnector.js
@@ -30,7 +30,7 @@ function createMapStateToProps() {
             `, ${mediumCount} med, ${trackCount} tracks` +
             `${country && country.length > 0 ? `, ${shortenList(country)}` : ''}` +
             `${format ? `, [${format}]` : ''}` +
-            `, ${foreignReleaseId.toString()}`
+            `, [...${foreignReleaseId.toString().slice(-4)}]`
         };
       });
 

--- a/frontend/src/Components/Form/AlbumReleaseSelectInputConnector.js
+++ b/frontend/src/Components/Form/AlbumReleaseSelectInputConnector.js
@@ -30,7 +30,7 @@ function createMapStateToProps() {
             `, ${mediumCount} med, ${trackCount} tracks` +
             `${country && country.length > 0 ? `, ${shortenList(country)}` : ''}` +
             `${format ? `, [${format}]` : ''}`,
-          hint: `MBID: ${foreignReleaseId.toString().slice(0, 8)}`
+          hint: `MBID: ${foreignReleaseId.toString().slice(0, 8)}...`
         };
       });
 

--- a/frontend/src/Components/Form/AlbumReleaseSelectInputConnector.js
+++ b/frontend/src/Components/Form/AlbumReleaseSelectInputConnector.js
@@ -1,15 +1,15 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
-import React, {Component} from 'react';
-import {connect} from 'react-redux';
-import {createSelector} from 'reselect';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
 import shortenList from 'Utilities/String/shortenList';
 import titleCase from 'Utilities/String/titleCase';
 import SelectInput from './SelectInput';
 
 function createMapStateToProps() {
   return createSelector(
-    (state, {albumReleases}) => albumReleases,
+    (state, { albumReleases }) => albumReleases,
     (albumReleases) => {
       const values = _.map(albumReleases.value, (albumRelease) => {
 
@@ -36,7 +36,7 @@ function createMapStateToProps() {
 
       const sortedValues = _.orderBy(values, ['value']);
 
-      const value = _.find(albumReleases.value, {monitored: true}).foreignReleaseId;
+      const value = _.find(albumReleases.value, { monitored: true }).foreignReleaseId;
 
       return {
         values: sortedValues,
@@ -51,15 +51,15 @@ class AlbumReleaseSelectInputConnector extends Component {
   //
   // Listeners
 
-  onChange = ({name, value}) => {
+  onChange = ({ name, value }) => {
     const {
       albumReleases
     } = this.props;
 
-    const updatedReleases = _.map(albumReleases.value, (e) => ({...e, monitored: false}));
-    _.find(updatedReleases, {foreignReleaseId: value}).monitored = true;
+    const updatedReleases = _.map(albumReleases.value, (e) => ({ ...e, monitored: false }));
+    _.find(updatedReleases, { foreignReleaseId: value }).monitored = true;
 
-    this.props.onChange({name, value: updatedReleases});
+    this.props.onChange({ name, value: updatedReleases });
   };
 
   render() {

--- a/frontend/src/InteractiveImport/AlbumRelease/SelectAlbumReleaseRow.js
+++ b/frontend/src/InteractiveImport/AlbumRelease/SelectAlbumReleaseRow.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, {Component} from 'react';
 import SelectInput from 'Components/Form/SelectInput';
 import TableRowCell from 'Components/Table/Cells/TableRowCell';
 import TableRow from 'Components/Table/TableRow';
@@ -12,7 +12,7 @@ class SelectAlbumReleaseRow extends Component {
   //
   // Listeners
 
-  onInputChange = ({ name, value }) => {
+  onInputChange = ({name, value}) => {
     this.props.onAlbumReleaseSelect(parseInt(name), parseInt(value));
   };
 
@@ -64,7 +64,8 @@ class SelectAlbumReleaseRow extends Component {
                         `, ${r.mediumCount} med, ${r.trackCount} tracks` +
                         `${r.country.length > 0 ? ', ' : ''}${shortenList(r.country)}` +
                         `${r.format ? ', [' : ''}${r.format}${r.format ? ']' : ''}` +
-                        `${r.monitored ? ', Monitored' : ''}`
+                        `${r.monitored ? ', Monitored' : ''}` +
+                        `, ${r.id.toString()}`
                     }))}
                     value={matchedReleaseId}
                     onChange={this.onInputChange}

--- a/frontend/src/InteractiveImport/AlbumRelease/SelectAlbumReleaseRow.js
+++ b/frontend/src/InteractiveImport/AlbumRelease/SelectAlbumReleaseRow.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import SelectInput from 'Components/Form/SelectInput';
+import EnhancedSelectInput from 'Components/Form/EnhancedSelectInput';
 import TableRowCell from 'Components/Table/Cells/TableRowCell';
 import TableRow from 'Components/Table/TableRow';
 import shortenList from 'Utilities/String/shortenList';
@@ -55,7 +55,7 @@ class SelectAlbumReleaseRow extends Component {
             if (name === 'release') {
               return (
                 <TableRowCell key={name}>
-                  <SelectInput
+                  <EnhancedSelectInput
                     name={id.toString()}
                     values={_.map(releases, (r) => ({
                       key: r.id,
@@ -64,8 +64,8 @@ class SelectAlbumReleaseRow extends Component {
                         `, ${r.mediumCount} med, ${r.trackCount} tracks` +
                         `${r.country.length > 0 ? ', ' : ''}${shortenList(r.country)}` +
                         `${r.format ? ', [' : ''}${r.format}${r.format ? ']' : ''}` +
-                        `${r.monitored ? ', Monitored' : ''}` +
-                        `, [...${r.id.toString().slice(-4)}]`
+                        `${r.monitored ? ', Monitored' : ''}`,
+                      hint: `MBID: ${r.id.toString().slice(0, 8)}`
                     }))}
                     value={matchedReleaseId}
                     onChange={this.onInputChange}

--- a/frontend/src/InteractiveImport/AlbumRelease/SelectAlbumReleaseRow.js
+++ b/frontend/src/InteractiveImport/AlbumRelease/SelectAlbumReleaseRow.js
@@ -65,7 +65,7 @@ class SelectAlbumReleaseRow extends Component {
                         `${r.country.length > 0 ? ', ' : ''}${shortenList(r.country)}` +
                         `${r.format ? ', [' : ''}${r.format}${r.format ? ']' : ''}` +
                         `${r.monitored ? ', Monitored' : ''}`,
-                      hint: `MBID: ${r.id.toString().slice(0, 8)}`
+                      hint: `MBID: ${r.id.toString().slice(0, 8)}...`
                     }))}
                     value={matchedReleaseId}
                     onChange={this.onInputChange}

--- a/frontend/src/InteractiveImport/AlbumRelease/SelectAlbumReleaseRow.js
+++ b/frontend/src/InteractiveImport/AlbumRelease/SelectAlbumReleaseRow.js
@@ -65,7 +65,7 @@ class SelectAlbumReleaseRow extends Component {
                         `${r.country.length > 0 ? ', ' : ''}${shortenList(r.country)}` +
                         `${r.format ? ', [' : ''}${r.format}${r.format ? ']' : ''}` +
                         `${r.monitored ? ', Monitored' : ''}` +
-                        `, ${r.id.toString()}`
+                        `, [...${r.id.toString().slice(-4)}]`
                     }))}
                     value={matchedReleaseId}
                     onChange={this.onInputChange}

--- a/frontend/src/InteractiveImport/AlbumRelease/SelectAlbumReleaseRow.js
+++ b/frontend/src/InteractiveImport/AlbumRelease/SelectAlbumReleaseRow.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import SelectInput from 'Components/Form/SelectInput';
 import TableRowCell from 'Components/Table/Cells/TableRowCell';
 import TableRow from 'Components/Table/TableRow';
@@ -12,7 +12,7 @@ class SelectAlbumReleaseRow extends Component {
   //
   // Listeners
 
-  onInputChange = ({name, value}) => {
+  onInputChange = ({ name, value }) => {
     this.props.onAlbumReleaseSelect(parseInt(name), parseInt(value));
   };
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Append the release's MBID in the release selector when editing an album. Makes it easier to disambiguate releases with very similar / identical fields.

#### Screenshot (if UI related)
<img width="1997" height="542" alt="image" src="https://github.com/user-attachments/assets/e791c492-4c70-4f6a-9b01-859e549cc2f8" />

