### PR TITLE
Fix: Unknown date was displayed as 01-01-0001 - changed it to Unknown

### DIFF
--- a/frontend/src/Album/Details/AlbumDetails.js
+++ b/frontend/src/Album/Details/AlbumDetails.js
@@ -423,7 +423,7 @@ class AlbumDetails extends Component {
                         size={17}
                       />
                       <span className={styles.releaseDate}>
-                        {releaseDate ?
+                        {releaseDate && releaseDate !== '0001-01-01T00:00:00Z' ?
                           moment(releaseDate).format(shortDateFormat) :
                           translate('Unknown')
                         }

--- a/frontend/src/Artist/Details/AlbumRow.js
+++ b/frontend/src/Artist/Details/AlbumRow.js
@@ -193,25 +193,26 @@ class AlbumRow extends Component {
             }
 
             if (name === 'releaseDate') {
-              if ( releaseDate && releaseDate !== '0001-01-01T00:00:00Z' ) {
+              if ( ! releaseDate ) {
                 return (
-                  <RelativeDateCellConnector
-                    key={name}
-                    date={releaseDate}
-                  />
+                  <TableRowCell key={name} />
                 );
               }
-              return (
-                <TableRowCell key={name}>
-                  { // This is probably a temporary thing. When the metadata server is in full health, this should not happen.
-                    // We can either delete it or add a proper translation if we decide to keep it.
-                    releaseDate ?
-                      translate('Unknown') :
-                      'No metadata'
-                  }
-                </TableRowCell>
-              );
 
+              if ( releaseDate === '0001-01-01T00:00:00Z' ) {
+                return (
+                  <TableRowCell key={name}>
+                    {translate('Unknown')}
+                  </TableRowCell>
+                );
+              }
+
+              return (
+                <RelativeDateCellConnector
+                  key={name}
+                  date={releaseDate}
+                />
+              );
             }
 
             if (name === 'size') {

--- a/frontend/src/Artist/Details/AlbumRow.js
+++ b/frontend/src/Artist/Details/AlbumRow.js
@@ -193,12 +193,25 @@ class AlbumRow extends Component {
             }
 
             if (name === 'releaseDate') {
+              if ( releaseDate && releaseDate !== '0001-01-01T00:00:00Z' ) {
+                return (
+                  <RelativeDateCellConnector
+                    key={name}
+                    date={releaseDate}
+                  />
+                );
+              }
               return (
-                <RelativeDateCellConnector
-                  key={name}
-                  date={releaseDate}
-                />
+                <TableRowCell key={name}>
+                  { // This is probably a temporary thing. When the metadata server is in full health, this should not happen.
+                    // We can either delete it or add a proper translation if we decide to keep it.
+                    releaseDate ?
+                      translate('Unknown') :
+                      'No metadata'
+                  }
+                </TableRowCell>
               );
+
             }
 
             if (name === 'size') {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Current metadata server returns unknown date as 01-01-0001, which is being displayed as a real date in UI.

This PR fixes this by checking this & displaying "Unknown" if appropriate (both artist detail & album detail).

I also added a "No metadata" info in case the album is missing metadata - this should help people identify that particular album is missing metadata & it should make it easier in support channels. This change is only in artist detail and should be only temporary until the metadata server is in full health - that's why I have not added a proper translation for this.

Sorting still works as I only changed the display value, not the actual value of 01-01-0001 that is being used internally.

#### Screenshot (if UI related)
##### Before
<img width="3302" height="480" alt="image" src="https://github.com/user-attachments/assets/ec104e88-f494-4319-970d-1c37201b7219" />

<img width="1422" height="302" alt="image" src="https://github.com/user-attachments/assets/e0e14f5a-f68a-4b39-9cdc-958a99c099a2" />

##### After
<img width="3406" height="2016" alt="image" src="https://github.com/user-attachments/assets/c9bc235d-0a2a-4283-9a37-10c5e15d1201" />

<img width="932" height="258" alt="image" src="https://github.com/user-attachments/assets/368f7470-b476-4c1f-ab5e-28e2146e5e09" />