### PR TITLE
New: Allow "Blu-ray" format releases.

### DIFF
--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -25,7 +25,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
         private readonly IMetadataProfileService _metadataProfileService;
         private readonly ICached<HashSet<string>> _cache;
 
-        private static readonly List<string> NonAudioMedia = new List<string> { "DVD", "DVD-Video", "Blu-ray", "HD-DVD", "VCD", "SVCD", "UMD", "VHS" };
+        private static readonly List<string> NonAudioMedia = new List<string> { "DVD", "DVD-Video", "HD-DVD", "VCD", "SVCD", "UMD", "VHS" };
         private static readonly List<string> SkippedTracks = new List<string> { "[data track]" };
 
         public SkyHookProxy(IHttpClient httpClient,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The MusicBrainz database for releases has a "video" attribute (true/false) for each track.  As far as I can tell, the Lidarr API filters out tracks that are videos, so there's no reason to skip "Blu-ray" formats since if the API returns tracks for it, they're audio.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes Blu-ray audio releases not being importable.