### PR TITLE
Fixed: qBittorrent /login API success check

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
@@ -424,8 +424,8 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                 }
                 catch (HttpException ex)
                 {
-                    _logger.Debug("qbitTorrent authentication failed.");
-                    if (ex.Response.StatusCode == HttpStatusCode.Forbidden)
+                    _logger.Debug(ex, "qbitTorrent authentication failed.");
+                    if (ex.Response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
                     {
                         throw new DownloadClientAuthenticationException("Failed to authenticate with qBittorrent.", ex);
                     }
@@ -438,7 +438,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                 }
 
                 // returns "Fails." on bad login
-                if (response.Content != "Ok.")
+                if (response.Content.IsNotNullOrWhiteSpace() && response.Content != "Ok.")
                 {
                     _logger.Debug("qbitTorrent authentication failed.");
                     throw new DownloadClientAuthenticationException("Failed to authenticate with qBittorrent.");


### PR DESCRIPTION
#### Database Migration
NO

#### Description
qBittorrent has recently pushed an update to their /login API which caused Radarr authentication check to fail. This change handles both the old and the new authentication response.

More info of qBittorrent change here:
https://github.com/qbittorrent/qBittorrent/pull/23202

Discussion on this fix here:
https://github.com/Radarr/Radarr/pull/11258

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

None