### PR TITLE
perf: Fix trace logging of HttpClient responses from blocking the UI

### DIFF
--- a/src/NzbDrone.Common/Http/HttpClient.cs
+++ b/src/NzbDrone.Common/Http/HttpClient.cs
@@ -169,7 +169,13 @@ namespace NzbDrone.Common.Http
 
             if (request.LogResponseContent && response.ResponseData != null)
             {
-                _logger.Trace("Response content ({0} bytes): {1}", response.ResponseData.Length, response.Content);
+                // Logging large response.Content is time consuming, pegs the CPU, and blocks the UI.
+                // Only evaluate the Trace call when tracing is actually enabled.
+                // Datapoint: NZBGet history endpoint with 500 items is about 1MB and takes 2m30s to log.
+                if (_logger.IsTraceEnabled)
+                {
+                    _logger.Trace("Response content ({0} bytes): {1}", response.ResponseData.Length, response.Content);
+                }
             }
 
             return response;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
For months now, my Lidarr instance has been sputtering along and randomly freezing for minutes at a time and pegging the CPU. 

Further inspection showed that a single `_logger.Trace(...)` in `HttpClient.cs` is the responsible. It attempts to evaluate the trace call for every single HTTP response's content regardless of whether trace logging is enabled or not. 

Specifically, a call to NZBGet's history endpoint with 500 items results in an uncompressed json payload of about 1MB. This content takes approximately 2m30s to evaluate for trace logging on my server.  During this time, the CPU is pegged and the web UI is frozen.

Tested on my instance and Lidarr is back to being zippy with no dreaded frozen UI or pegged CPU.

Even with trace logging enabled, this still may not be ideal. Maybe having a cutoff for content size would be a good compromise. In any case, I'm not a C# dev so do with this what you will.