### PR TITLE
fix(plugins): keep PluginLoadContext alive

### DIFF
--- a/src/NzbDrone.Common/Composition/PluginLoader.cs
+++ b/src/NzbDrone.Common/Composition/PluginLoader.cs
@@ -12,6 +12,7 @@ namespace NzbDrone.Common.Composition
     public static class PluginLoader
     {
         private static readonly Logger Logger = NzbDroneLogger.GetLogger(typeof(PluginLoader));
+        private static readonly List<PluginLoadContext> PluginContexts = new ();
 
         public static (List<Assembly>, List<WeakReference>) LoadPlugins(IEnumerable<string> pluginPaths)
         {
@@ -38,6 +39,7 @@ namespace NzbDrone.Common.Composition
         private static (Assembly, WeakReference) LoadPlugin(string path)
         {
             var context = new PluginLoadContext(path);
+            PluginContexts.Add(context);
             var weakRef = new WeakReference(context, trackResurrection: true);
 
             // load from stream to avoid locking on windows
@@ -53,7 +55,9 @@ namespace NzbDrone.Common.Composition
             {
                 if (pluginRef?.Target != null)
                 {
-                    ((PluginLoadContext)pluginRef.Target).Unload();
+                    var context = (PluginLoadContext)pluginRef.Target;
+                    PluginContexts.Remove(context);
+                    context.Unload();
                 }
             }
         }


### PR DESCRIPTION
Fixes multi-plugin load failures where PluginLoadContext is GC-collected/unloading during type discovery because PluginLoader only keeps weak references.

Change: keep strong references to PluginLoadContext instances in PluginLoader until UnloadPlugins is called (then remove references before Unload()).

Repro: running Lidarr plugins branch with 2 plugin assemblies present triggers FileLoadException/InvalidOperationException: 'AssemblyLoadContext is unloading or was already unloaded' while loading Lidarr.Plugin.Abstractions during reflection.

This change keeps contexts alive for the duration of plugin discovery/registration and preserves existing public API (still returns WeakReference list for unload tracking).