### PR TITLE
Persist page size for Import List Exclusions

### DIFF
--- a/frontend/src/Store/Actions/settingsActions.js
+++ b/frontend/src/Store/Actions/settingsActions.js
@@ -97,7 +97,8 @@ export const defaultState = {
 };
 
 export const persistState = [
-  'settings.advancedSettings'
+  'settings.advancedSettings',
+  'settings.importListExclusions.pageSize'
 ];
 
 //


### PR DESCRIPTION
Fixes [#4643
](https://github.com/Lidarr/Lidarr/issues/4643)

Cherry-picked from Sonarr commit e81bb3b993adac705fd61dc9e281b040ca2338f5

## Changes
- Persists the page size setting for Import List Exclusions page

## Testing
- Built successfully with no errors
- Linting passed