### PR TITLE
Fix invalid spelling of "Latest"

### DIFF
--- a/frontend/src/Utilities/Artist/monitorOptions.js
+++ b/frontend/src/Utilities/Artist/monitorOptions.js
@@ -34,7 +34,7 @@ const monitorOptions = [
   {
     key: 'latest',
     get value() {
-      return translate('MonitorLastestAlbum');
+      return translate('MonitorLatestAlbum');
     }
   },
   {

--- a/src/NzbDrone.Core/Localization/Core/ca.json
+++ b/src/NzbDrone.Core/Localization/Core/ca.json
@@ -1184,7 +1184,7 @@
     "MonitorAlbumExistingOnlyWarning": "Aquest és un ajust ajustat de la configuració monitoritzada per a cada àlbum.  Utilitzeu l'opció Artist/Edit per controlar què passa amb els àlbums nous",
     "MonitorAllAlbums": "Tots els àlbums",
     "MonitorArtist": "Monitora l’artista",
-    "MonitorLastestAlbum": "Últim àlbum",
+    "MonitorLatestAlbum": "Últim àlbum",
     "MonitorNewItems": "Monitora els àlbums nous",
     "MonitorNewItemsHelpText": "Quins àlbums nous s'han de controlar",
     "MonitoredHelpText": "Baixa els àlbums monitoritzats d'aquest artista",

--- a/src/NzbDrone.Core/Localization/Core/cs.json
+++ b/src/NzbDrone.Core/Localization/Core/cs.json
@@ -1269,7 +1269,7 @@
     "MonitorArtist": "Monitorovat umělce",
     "MonitorArtists": "Monitorovat umělce",
     "MonitorExistingAlbums": "Stávající alba",
-    "MonitorLastestAlbum": "Poslední album",
+    "MonitorLatestAlbum": "Poslední album",
     "MonitorNewAlbums": "Nová alba",
     "MonitorNewItems": "Monitorovat nová alba",
     "NoHistoryBlocklist": "Žádná historie blacklistu",

--- a/src/NzbDrone.Core/Localization/Core/de.json
+++ b/src/NzbDrone.Core/Localization/Core/de.json
@@ -1048,7 +1048,7 @@
     "Enabled": "Aktiviert",
     "KeyboardShortcuts": "Tastenkürzel",
     "MonitorArtists": "Beobachte Künstler",
-    "MonitorLastestAlbum": "Neuestes Album",
+    "MonitorLatestAlbum": "Neuestes Album",
     "MonitorNoAlbums": "Keine",
     "PosterOptions": "Poster-Optionen",
     "Posters": "Poster",

--- a/src/NzbDrone.Core/Localization/Core/el.json
+++ b/src/NzbDrone.Core/Localization/Core/el.json
@@ -1091,7 +1091,7 @@
     "MonitorAllAlbums": "Όλα Τα Άλμπουμ",
     "MonitorFirstAlbum": "Πρώτο άλμπουμ",
     "MonitorFutureAlbums": "Μελλοντικά άλμπουμ",
-    "MonitorLastestAlbum": "Τελευταίο άλμπουμ",
+    "MonitorLatestAlbum": "Τελευταίο άλμπουμ",
     "MonitorMissingAlbums": "Λείπουν άλμπουμ",
     "MonitorNoAlbums": "Κανένας",
     "AddToDownloadQueue": "Προστέθηκε για λήψη ουράς",

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -773,7 +773,7 @@
   "MonitorExistingAlbums": "Existing Albums",
   "MonitorFirstAlbum": "First Album",
   "MonitorFutureAlbums": "Future Albums",
-  "MonitorLastestAlbum": "Lastest Album",
+  "MonitorLatestAlbum": "Latest Album",
   "MonitorMissingAlbums": "Missing Albums",
   "MonitorNewAlbums": "New Albums",
   "MonitorNewAlbumsData": "Monitor albums added to database in future with a release date after the latest album",

--- a/src/NzbDrone.Core/Localization/Core/es.json
+++ b/src/NzbDrone.Core/Localization/Core/es.json
@@ -1182,7 +1182,7 @@
     "FormatRuntimeHours": "{hours}h",
     "FormatRuntimeMinutes": "{minutes}m",
     "FormatShortTimeSpanHours": "{hours} hora(s)",
-    "MonitorLastestAlbum": "El último álbum",
+    "MonitorLatestAlbum": "El último álbum",
     "MonitorMissingAlbums": "Álbumes faltantes",
     "MonitorFutureAlbums": "Álbumes futuros",
     "MonitorNoAlbums": "Ninguno",

--- a/src/NzbDrone.Core/Localization/Core/fi.json
+++ b/src/NzbDrone.Core/Localization/Core/fi.json
@@ -1212,7 +1212,7 @@
     "MetadataSettingsArtistSummary": "Luo metatietotiedostot kun kappaleita tuodaan tai artistien tietoja päivitetään.",
     "MonitorFirstAlbum": "Ensimmäinen albumi",
     "MonitorFutureAlbums": "Tulevat albumit",
-    "MonitorLastestAlbum": "Uusin albumi",
+    "MonitorLatestAlbum": "Uusin albumi",
     "MonitorMissingAlbums": "Puuttuvat albumit",
     "ProfilesSettingsArtistSummary": "Laatu-, metatieto-, viive- ja julkaisuprofiilit.",
     "UiSettingsSummary": "Kalenterin, päiväyksen ja kellonajan, sekä kielen ja heikentyneelle värinäölle sopivan tilan asetukset.",

--- a/src/NzbDrone.Core/Localization/Core/fr.json
+++ b/src/NzbDrone.Core/Localization/Core/fr.json
@@ -1265,7 +1265,7 @@
     "FormatTimeSpanDays": "{days} j {time}",
     "KeyboardShortcuts": "Raccourcis clavier",
     "MonitorAllAlbums": "Tous les albums",
-    "MonitorLastestAlbum": "Dernier album",
+    "MonitorLatestAlbum": "Dernier album",
     "MonitorMissingAlbums": "Albums manquants",
     "MonitorNoAlbums": "Aucun",
     "MonitorNoNewAlbums": "Aucun nouvel album",

--- a/src/NzbDrone.Core/Localization/Core/hu.json
+++ b/src/NzbDrone.Core/Localization/Core/hu.json
@@ -1175,7 +1175,7 @@
     "FormatAgeMinutes": "percek",
     "MediaManagementSettingsSummary": "Elnevezések, fájlkezelési beállítások és gyökérmappák",
     "MonitorAllAlbums": "Összes album",
-    "MonitorLastestAlbum": "Legújabb album",
+    "MonitorLatestAlbum": "Legújabb album",
     "MonitorMissingAlbums": "Hiányzó Albumok",
     "MonitorNoAlbums": "Egyik sem",
     "Tomorrow": "Holnap",

--- a/src/NzbDrone.Core/Localization/Core/pt_BR.json
+++ b/src/NzbDrone.Core/Localization/Core/pt_BR.json
@@ -1230,7 +1230,7 @@
     "FormatShortTimeSpanHours": "{hours} hora(s)",
     "MonitorFirstAlbum": "Primeiro Álbum",
     "MonitorFutureAlbums": "Álbuns Futuros",
-    "MonitorLastestAlbum": "Último Álbum",
+    "MonitorLatestAlbum": "Último Álbum",
     "MonitorNoAlbums": "Nenhum",
     "MonitorNoNewAlbums": "Sem Novos Álbuns",
     "Yesterday": "Ontem",

--- a/src/NzbDrone.Core/Localization/Core/uk.json
+++ b/src/NzbDrone.Core/Localization/Core/uk.json
@@ -996,7 +996,7 @@
     "MissingAlbums": "Відсутні альбоми",
     "DeleteTrackFile": "Видалити файл треку",
     "MonitorFutureAlbums": "Майбутні альбоми",
-    "MonitorLastestAlbum": "Останній альбом",
+    "MonitorLatestAlbum": "Останній альбом",
     "MonitorMissingAlbums": "Відсутні альбоми",
     "MonitorNewAlbums": "Нові альбоми",
     "MonitorNewItemsHelpText": "Які нові альбоми слід відстежувати",

--- a/src/NzbDrone.Core/Localization/Core/zh_CN.json
+++ b/src/NzbDrone.Core/Localization/Core/zh_CN.json
@@ -1222,7 +1222,7 @@
     "MonitorAllAlbums": "全部专辑",
     "MonitorFirstAlbum": "第一张专辑",
     "MonitorFutureAlbums": "未来的专辑",
-    "MonitorLastestAlbum": "最新的专辑",
+    "MonitorLatestAlbum": "最新的专辑",
     "MonitorMissingAlbums": "缺失的专辑",
     "MonitorNoAlbums": "无",
     "MonitorNoNewAlbums": "没有新专辑",


### PR DESCRIPTION
#### Database Migration
NO

#### Description
"Lastest" is not a word. This replaces "Lastest Album" with "Latest Album" everywhere.

#### Screenshot (if UI related)
<img width="200" height="289" alt="image" src="https://github.com/user-attachments/assets/4b6aee4b-2635-4c05-ad9e-e239bd6ee272" />

#### Todos
- [X] Translation Keys (All - primary key and all references to it across all translations)

