### PR TITLE
New: Add AIFF as a recognized quality format

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
@@ -17,6 +17,7 @@ namespace NzbDrone.Core.Test.ParserTests
             new object[] { Quality.MP3_320 },
             new object[] { Quality.MP3_VBR_V2 },
             new object[] { Quality.WAV },
+            new object[] { Quality.AIFF },
             new object[] { Quality.WMA },
             new object[] { Quality.AAC_192 },
             new object[] { Quality.AAC_256 },
@@ -147,6 +148,17 @@ namespace NzbDrone.Core.Test.ParserTests
         public void should_parse_wav_quality(string title, string desc, int bitrate)
         {
             ParseAndVerifyQuality(title, desc, bitrate, Quality.WAV);
+        }
+
+        [TestCase("Artist - Album [AIFF]", null, 0)]
+        [TestCase("Artist - Album [WEB] [AIFF]", null, 0)]
+        [TestCase("Artist - Album (2017) AIFF", null, 0)]
+        [TestCase("Artist-Album-WEB-AIFF-2022-GROUP", null, 0)]
+        [TestCase("Artist - Album [AIF]", null, 0)]
+        [TestCase("Artist - Album [AIFC]", null, 0)]
+        public void should_parse_aiff_quality(string title, string desc, int bitrate)
+        {
+            ParseAndVerifyQuality(title, desc, bitrate, Quality.AIFF);
         }
 
         [TestCase("Chuck Berry Discography ALAC", null, 0)]

--- a/src/NzbDrone.Core/Datastore/Migration/081_add_aiff_quality_in_profiles.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/081_add_aiff_quality_in_profiles.cs
@@ -1,0 +1,146 @@
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using Dapper;
+using FluentMigrator;
+using Newtonsoft.Json;
+using NzbDrone.Common.Serializer;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(081)]
+    public class add_aiff_quality_in_profiles : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Execute.WithConnection(ConvertProfile);
+        }
+
+        private void ConvertProfile(IDbConnection conn, IDbTransaction tran)
+        {
+            var updater = new QualityProfileUpdater81(conn, tran);
+
+            updater.SplitQualityAppend(13, 38);  // AIFF (38) after WAV (13)
+
+            updater.Commit();
+        }
+    }
+
+    public class QualityProfile81
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public int Cutoff { get; set; }
+        public List<QualityProfileItem81> Items { get; set; }
+    }
+
+    public class QualityProfileItem81
+    {
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public int? Quality { get; set; }
+        public bool Allowed { get; set; }
+        public List<QualityProfileItem81> Items { get; set; }
+    }
+
+    public class QualityProfileUpdater81
+    {
+        private readonly IDbConnection _connection;
+        private readonly IDbTransaction _transaction;
+
+        private List<QualityProfile81> _profiles;
+        private HashSet<QualityProfile81> _changedProfiles = new ();
+
+        public QualityProfileUpdater81(IDbConnection conn, IDbTransaction tran)
+        {
+            _connection = conn;
+            _transaction = tran;
+
+            _profiles = GetProfiles();
+        }
+
+        public void Commit()
+        {
+            var profilesToUpdate = _changedProfiles.Select(p => new
+            {
+                p.Id,
+                p.Name,
+                p.Cutoff,
+                Items = p.Items.ToJson()
+            });
+
+            var updateSql = "UPDATE \"QualityProfiles\" SET \"Name\" = @Name, \"Cutoff\" = @Cutoff, \"Items\" = @Items WHERE \"Id\" = @Id";
+            _connection.Execute(updateSql, profilesToUpdate, transaction: _transaction);
+
+            _changedProfiles.Clear();
+        }
+
+        public void SplitQualityAppend(int find, int quality)
+        {
+            foreach (var profile in _profiles)
+            {
+                if (profile.Items.Any(v => v.Quality == quality) ||
+                    profile.Items.Any(v => v.Items != null && v.Items.Any(b => b.Quality == quality)))
+                {
+                    continue;
+                }
+
+                foreach (var item in profile.Items.Where(x => x.Items != null))
+                {
+                    var findIndex = item.Items.FindIndex(v => v.Quality == find);
+
+                    if (findIndex == -1)
+                    {
+                        continue;
+                    }
+
+                    item.Items.Insert(findIndex + 1, new QualityProfileItem81
+                    {
+                        Quality = quality,
+                        Allowed = true
+                    });
+                }
+
+                if (!profile.Items.Any(v => v.Items != null && v.Items.Any(b => b.Quality == quality)))
+                {
+                    profile.Items.Add(new QualityProfileItem81
+                    {
+                        Quality = quality,
+                        Allowed = false
+                    });
+                }
+
+                _changedProfiles.Add(profile);
+            }
+        }
+
+        private List<QualityProfile81> GetProfiles()
+        {
+            var profiles = new List<QualityProfile81>();
+
+            using (var getProfilesCmd = _connection.CreateCommand())
+            {
+                getProfilesCmd.Transaction = _transaction;
+                getProfilesCmd.CommandText = "SELECT \"Id\", \"Name\", \"Cutoff\", \"Items\" FROM \"QualityProfiles\"";
+
+                using (var profileReader = getProfilesCmd.ExecuteReader())
+                {
+                    while (profileReader.Read())
+                    {
+                        profiles.Add(new QualityProfile81
+                        {
+                            Id = profileReader.GetInt32(0),
+                            Name = profileReader.GetString(1),
+                            Cutoff = profileReader.GetInt32(2),
+                            Items = Json.Deserialize<List<QualityProfileItem81>>(profileReader.GetString(3))
+                        });
+                    }
+                }
+            }
+
+            return profiles;
+        }
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/MediaFileExtensions.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileExtensions.cs
@@ -25,9 +25,9 @@ namespace NzbDrone.Core.MediaFiles
                 { ".wv", Quality.WAVPACK },
                 { ".flac", Quality.FLAC },
                 { ".ape", Quality.APE },
-                { ".aif", Quality.Unknown },
-                { ".aiff", Quality.Unknown },
-                { ".aifc", Quality.Unknown }
+                { ".aif", Quality.AIFF },
+                { ".aiff", Quality.AIFF },
+                { ".aifc", Quality.AIFF }
             };
         }
 

--- a/src/NzbDrone.Core/Parser/QualityParser.cs
+++ b/src/NzbDrone.Core/Parser/QualityParser.cs
@@ -38,7 +38,7 @@ namespace NzbDrone.Core.Parser
 
         private static readonly Regex SampleSizeRegex = new (@"\b(?:(?<S24>24[-._ ]?bit|flac24(?:[-._ ]?bit)?|tr24|24-(?:44|48|96|192)|[\[\(].*24bit.*[\]\)]))\b", RegexOptions.Compiled);
 
-        private static readonly Regex CodecRegex = new (@"\b(?:(?<MP1>MPEG Version \d(.5)? Audio, Layer 1|MP1)|(?<MP2>MPEG Version \d(.5)? Audio, Layer 2|MP2)|(?<MP3VBR>MP3.*VBR|MPEG Version \d(.5)? Audio, Layer 3 vbr)|(?<MP3CBR>MP3|MPEG Version \d(.5)? Audio, Layer 3)|(?<FLAC>(web)?flac(?:24(?:[-._ ]?bit)?)?|TR24)|(?<WAVPACK>wavpack|wv)|(?<ALAC>alac)|(?<WMA>WMA\d?)|(?<WAV>WAV|PCM)|(?<AAC>M4A|M4P|M4B|AAC|mp4a|MPEG-4 Audio(?!.*alac))|(?<OGG>OGG|OGA|Vorbis))\b|(?<APE>monkey's audio|[\[|\(].*\bape\b.*[\]|\)])|(?<OPUS>Opus Version \d(.5)? Audio|[\[|\(].*\bopus\b.*[\]|\)])",
+        private static readonly Regex CodecRegex = new (@"\b(?:(?<MP1>MPEG Version \d(.5)? Audio, Layer 1|MP1)|(?<MP2>MPEG Version \d(.5)? Audio, Layer 2|MP2)|(?<MP3VBR>MP3.*VBR|MPEG Version \d(.5)? Audio, Layer 3 vbr)|(?<MP3CBR>MP3|MPEG Version \d(.5)? Audio, Layer 3)|(?<FLAC>(web)?flac(?:24(?:[-._ ]?bit)?)?|TR24)|(?<WAVPACK>wavpack|wv)|(?<ALAC>alac)|(?<WMA>WMA\d?)|(?<AIFF>AIFF|AIF|AIFC)|(?<WAV>WAV|PCM)|(?<AAC>M4A|M4P|M4B|AAC|mp4a|MPEG-4 Audio(?!.*alac))|(?<OGG>OGG|OGA|Vorbis))\b|(?<APE>monkey's audio|[\[|\(].*\bape\b.*[\]|\)])|(?<OPUS>Opus Version \d(.5)? Audio|[\[|\(].*\bopus\b.*[\]|\)])",
                                                                   RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly Regex WebRegex = new (@"\b(?<web>WEB)(?:\b|$|[ .])",
@@ -143,6 +143,9 @@ namespace NzbDrone.Core.Parser
                     break;
                 case Codec.WAV:
                     result.Quality = Quality.WAV;
+                    break;
+                case Codec.AIFF:
+                    result.Quality = Quality.AIFF;
                     break;
                 case Codec.AAC:
                     if (bitrate == BitRate.B192)
@@ -283,6 +286,11 @@ namespace NzbDrone.Core.Parser
             if (match.Groups["WAV"].Success)
             {
                 return Codec.WAV;
+            }
+
+            if (match.Groups["AIFF"].Success)
+            {
+                return Codec.AIFF;
             }
 
             if (match.Groups["AAC"].Success)
@@ -526,6 +534,8 @@ namespace NzbDrone.Core.Parser
                     return Quality.WMA;
                 case Codec.WAV:
                     return Quality.WAV;
+                case Codec.AIFF:
+                    return Quality.AIFF;
                 case Codec.AAC:
                     if (bitrate == 192)
                     {
@@ -666,6 +676,7 @@ namespace NzbDrone.Core.Parser
         OGG,
         OPUS,
         WAV,
+        AIFF,
         Unknown
     }
 

--- a/src/NzbDrone.Core/Qualities/Quality.cs
+++ b/src/NzbDrone.Core/Qualities/Quality.cs
@@ -108,6 +108,7 @@ namespace NzbDrone.Core.Qualities
         public static Quality APE => new Quality(35, "APE");
         public static Quality WAVPACK => new Quality(36, "WavPack");
         public static Quality ALAC_24 => new Quality(37, "ALAC 24bit");
+        public static Quality AIFF => new Quality(38, "AIFF");
 
         static Quality()
         {
@@ -150,6 +151,7 @@ namespace NzbDrone.Core.Qualities
                 WAVPACK,
                 FLAC_24,
                 ALAC_24,
+                AIFF,
                 WAV
             };
 
@@ -198,6 +200,7 @@ namespace NzbDrone.Core.Qualities
                 new QualityDefinition(Quality.WAVPACK)     { Weight = 22, MinSize = 0, MaxSize = null, PreferredSize = 895, GroupName = "Lossless", GroupWeight = 7 },
                 new QualityDefinition(Quality.FLAC_24)     { Weight = 23, MinSize = 0, MaxSize = null, PreferredSize = 895, GroupName = "Lossless", GroupWeight = 7 },
                 new QualityDefinition(Quality.ALAC_24)     { Weight = 23, MinSize = 0, MaxSize = null, PreferredSize = 895, GroupName = "Lossless", GroupWeight = 7 },
+                new QualityDefinition(Quality.AIFF)         { Weight = 24, MinSize = 0, MaxSize = null, PreferredSize = 895, GroupName = "Lossless", GroupWeight = 7 },
                 new QualityDefinition(Quality.WAV)         { Weight = 24, MinSize = 0, MaxSize = null, PreferredSize = 895, GroupWeight = 8 }
             };
         }


### PR DESCRIPTION
## Summary

Add AIFF (Audio Interchange File Format) as a first-class quality in Lidarr, alongside existing lossless formats FLAC, ALAC, WAV, and APE.

Issue #4102 was partially addressed by commit `6e43d8a`, which added `.aiff` as an importable file extension mapped to `Quality.Unknown`. However, this means AIFF files are never properly classified. During search/indexing, titles containing `[AIFF]` are unrecognized by `QualityParser` and fall through to bitrate based guessing (often misclassified as MP3-320).

## Changes

| File | Change |
|------|--------|
| `Qualities/Quality.cs` | Add `Quality.AIFF` (ID 38) and `QualityDefinition` in Lossless group |
| `Parser/QualityParser.cs` | Add `(?<AIFF>AIFF\|AIF\|AIFC)` to `CodecRegex`, `Codec.AIFF` enum, handle in `ParseQuality`/`FindQuality`/`ParseCodec` |
| `MediaFiles/MediaFileExtensions.cs` | Map `.aiff`/`.aif`/`.aifc` to `Quality.AIFF` (was `Quality.Unknown`) |
| `Datastore/Migration/081_add_aiff_quality_in_profiles.cs` | Insert AIFF into existing quality profiles after WAV |

## Notes

- AIFF is uncompressed PCM audio, functionally equivalent to WAV
- Placed at Weight 24 in the Lossless group alongside WAV
- DB migration follows the exact pattern from migration 072 (`add_alac_24_quality_in_profiles`)
- The `CodecRegex` places AIFF before WAV to ensure `AIF`/`AIFC` variants are caught before the broader WAV pattern

## Testing

- AIFF files will now import with `Quality.AIFF` instead of `Quality.Unknown`
- Release titles containing `[AIFF]`, `[AIF]`, or `[AIFC]` will be parsed correctly during search
- Existing quality profiles will have AIFF auto inserted after WAV (allowed by default)
- All 171 QualityParser tests pass (6 new AIFF specific tests added)