### PR TITLE
Disk scan/import fixes, Dockerfile, and match-threshold tweak

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+_output
+_output*
+_tests
+_temp
+node_modules
+Logs
+*.log
+distribution
+docs
+frontend/build/coverage

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,38 @@
+name: Docker Build
+
+on:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/lidarr:latest
+            ghcr.io/${{ github.repository_owner }}/lidarr:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+CLAUDE.md
+
 # Build Folders (you can keep bin if you'd like, to store dlls and pdbs)
 src/**/[Bb]in/
 src/**/[Oo]bj/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+Local, unreleased changes on `develop` (not yet pushed upstream).
+
+## Unreleased
+
+### Changed
+- Album match acceptance threshold loosened from 80% to 75% confidence
+  (`CloseAlbumMatchSpecification._albumThreshold` 0.20 → 0.25), so a wider
+  range of identification matches are accepted for import.
+
+### Added
+- `Dockerfile` and `.dockerignore` for building Lidarr as a container from
+  source: multi-stage build (yarn/webpack frontend, .NET 8 SDK backend) into
+  a slim `aspnet:8.0` runtime image with `sqlite3` and `libchromaprint-tools`
+  (fpcalc) for fingerprint-based track identification. Exposes port 8686
+  with `/config` and `/music` volumes. Verified end-to-end on a real Unraid
+  host, including fixes for a missing `Logo/` resource copy and disabling
+  StyleCop/analyzer enforcement during the Release build.
+
+### Performance
+- Disk scan (`DiskScanService.Scan`) now processes files in batches of 500
+  instead of one pass over the entire scanned file list, so large libraries
+  fill in incrementally in the UI/database during a rescan instead of
+  staying empty until every file has been read and matched.
+- Fixed an N+1 query in `ImportApprovedTracks`: existing-file lookups during
+  a rescan were issued one at a time; now batched up front.
+
+### Fixed
+- `DiskScanService.Scan` no longer aborts scanning of all remaining folders
+  in a multi-folder batch when one folder has a missing or invalid root
+  folder — that folder is now skipped instead.

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,13 @@ RUN yarn build
 # ---- backend build ----
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS backend
 WORKDIR /src
+COPY Logo ./Logo
 COPY src ./src
-RUN dotnet build src/NzbDrone.Console/Lidarr.Console.csproj -c Release \
-    && dotnet build src/NzbDrone.Mono/Lidarr.Mono.csproj -c Release
+# StyleCop/analyzer findings are treated as build errors across most of the
+# codebase in Release config; disabled here since this is a plain compile,
+# not a lint pass.
+RUN dotnet build src/NzbDrone.Console/Lidarr.Console.csproj -c Release -p:RunAnalyzersDuringBuild=false -p:EnforceCodeStyleInBuild=false \
+    && dotnet build src/NzbDrone.Mono/Lidarr.Mono.csproj -c Release -p:RunAnalyzersDuringBuild=false -p:EnforceCodeStyleInBuild=false
 
 # ---- runtime ----
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1
+
+# ---- frontend build ----
+FROM node:20-bookworm-slim AS frontend
+WORKDIR /src
+COPY package.json yarn.lock tsconfig.json ./
+RUN yarn install --frozen-lockfile
+COPY frontend ./frontend
+RUN yarn build
+
+# ---- backend build ----
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS backend
+WORKDIR /src
+COPY src ./src
+RUN dotnet build src/NzbDrone.Console/Lidarr.Console.csproj -c Release \
+    && dotnet build src/NzbDrone.Mono/Lidarr.Mono.csproj -c Release
+
+# ---- runtime ----
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends sqlite3 libchromaprint-tools \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=backend /src/_output/net8.0 ./
+COPY --from=frontend /src/_output/UI ./UI
+
+ENV XDG_CONFIG_HOME=/config \
+    LIDARR_DATA=/config
+
+VOLUME /config
+VOLUME /music
+
+EXPOSE 8686
+
+ENTRYPOINT ["dotnet", "Lidarr.dll", "-nobrowser", "-data=/config"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,9 @@ COPY src ./src
 # StyleCop/analyzer findings are treated as build errors across most of the
 # codebase in Release config; disabled here since this is a plain compile,
 # not a lint pass.
-RUN dotnet build src/NzbDrone.Console/Lidarr.Console.csproj -c Release -p:RunAnalyzersDuringBuild=false -p:EnforceCodeStyleInBuild=false \
-    && dotnet build src/NzbDrone.Mono/Lidarr.Mono.csproj -c Release -p:RunAnalyzersDuringBuild=false -p:EnforceCodeStyleInBuild=false
+ENV NO_ANALYZERS="-p:RunAnalyzersDuringBuild=false -p:EnforceCodeStyleInBuild=false"
+RUN dotnet build src/NzbDrone.Console/Lidarr.Console.csproj -c Release $NO_ANALYZERS \
+    && dotnet build src/NzbDrone.Mono/Lidarr.Mono.csproj -c Release $NO_ANALYZERS
 
 # ---- runtime ----
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime

--- a/src/NzbDrone.Core.Test/MediaFiles/DiskScanServiceTests/ScanFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/DiskScanServiceTests/ScanFixture.cs
@@ -61,6 +61,10 @@ namespace NzbDrone.Core.Test.MediaFiles.DiskScanServiceTests
                 .Returns(new List<TrackFile>());
 
             Mocker.GetMock<IMediaFileService>()
+                .Setup(v => v.GetFileWithPath(It.IsAny<List<string>>()))
+                .Returns(new List<TrackFile>());
+
+            Mocker.GetMock<IMediaFileService>()
                 .Setup(v => v.FilterUnchangedFiles(It.IsAny<List<IFileInfo>>(), It.IsAny<FilterFilesType>()))
                 .Returns((List<IFileInfo> files, FilterFilesType filter) => files);
         }
@@ -122,13 +126,19 @@ namespace NzbDrone.Core.Test.MediaFiles.DiskScanServiceTests
                 lastWrite = new DateTime(2019, 1, 1, 0, 0, 0, DateTimeKind.Utc);
             }
 
+            var knownFiles = files.Select(x => new TrackFile
+            {
+                Path = x,
+                Modified = lastWrite.Value.UtcDateTime
+            }).ToList();
+
             Mocker.GetMock<IMediaFileService>()
                 .Setup(x => x.GetFilesWithBasePath(_artist.Path))
-                .Returns(files.Select(x => new TrackFile
-                {
-                    Path = x,
-                    Modified = lastWrite.Value.UtcDateTime
-                }).ToList());
+                .Returns(knownFiles);
+
+            Mocker.GetMock<IMediaFileService>()
+                .Setup(x => x.GetFileWithPath(It.IsAny<List<string>>()))
+                .Returns((List<string> paths) => knownFiles.Where(f => paths.Contains(f.Path)).ToList());
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/MediaFiles/ImportApprovedTracksFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/ImportApprovedTracksFixture.cs
@@ -209,8 +209,8 @@ namespace NzbDrone.Core.Test.MediaFiles
         public void should_delete_existing_trackfiles_with_the_same_path()
         {
             Mocker.GetMock<IMediaFileService>()
-                .Setup(s => s.GetFileWithPath(It.IsAny<string>()))
-                .Returns(Builder<TrackFile>.CreateNew().Build());
+                .Setup(s => s.GetFileWithPath(It.IsAny<List<string>>()))
+                .Returns(new List<TrackFile> { Builder<TrackFile>.CreateNew().With(f => f.Path = _approvedDecisions.First().Item.Path).Build() });
 
             var track = _approvedDecisions.First();
             track.Item.ExistingFile = true;

--- a/src/NzbDrone.Core/Datastore/BasicRepository.cs
+++ b/src/NzbDrone.Core/Datastore/BasicRepository.cs
@@ -220,6 +220,18 @@ namespace NzbDrone.Core.Datastore
             return model;
         }
 
+        private void RunInTransaction(Action<IDbConnection, IDbTransaction> action)
+        {
+            using (var conn = _database.OpenConnection())
+            {
+                using (var tran = conn.BeginTransaction(IsolationLevel.ReadCommitted))
+                {
+                    action(conn, tran);
+                    tran.Commit();
+                }
+            }
+        }
+
         public void InsertMany(IList<TModel> models)
         {
             if (models.Any(x => x.Id != 0))
@@ -227,18 +239,13 @@ namespace NzbDrone.Core.Datastore
                 throw new InvalidOperationException("Can't insert model with existing ID != 0");
             }
 
-            using (var conn = _database.OpenConnection())
+            RunInTransaction((conn, tran) =>
             {
-                using (var tran = conn.BeginTransaction(IsolationLevel.ReadCommitted))
+                foreach (var model in models)
                 {
-                    foreach (var model in models)
-                    {
-                        Insert(conn, tran, model);
-                    }
-
-                    tran.Commit();
+                    Insert(conn, tran, model);
                 }
-            }
+            });
         }
 
         public TModel Update(TModel model)
@@ -265,14 +272,7 @@ namespace NzbDrone.Core.Datastore
                 throw new InvalidOperationException("Can't update model with ID 0");
             }
 
-            using (var conn = _database.OpenConnection())
-            {
-                using (var tran = conn.BeginTransaction(IsolationLevel.ReadCommitted))
-                {
-                    UpdateFields(conn, tran, models, _properties);
-                    tran.Commit();
-                }
-            }
+            RunInTransaction((conn, tran) => UpdateFields(conn, tran, models, _properties));
         }
 
         protected void Delete(Expression<Func<TModel, bool>> where)
@@ -374,14 +374,7 @@ namespace NzbDrone.Core.Datastore
 
             var propertiesToUpdate = properties.Select(x => x.GetMemberName()).ToList();
 
-            using (var conn = _database.OpenConnection())
-            {
-                using (var tran = conn.BeginTransaction(IsolationLevel.ReadCommitted))
-                {
-                    UpdateFields(conn, tran, models, propertiesToUpdate);
-                    tran.Commit();
-                }
-            }
+            RunInTransaction((conn, tran) => UpdateFields(conn, tran, models, propertiesToUpdate));
 
             foreach (var model in models)
             {

--- a/src/NzbDrone.Core/Datastore/BasicRepository.cs
+++ b/src/NzbDrone.Core/Datastore/BasicRepository.cs
@@ -267,7 +267,11 @@ namespace NzbDrone.Core.Datastore
 
             using (var conn = _database.OpenConnection())
             {
-                UpdateFields(conn, null, models, _properties);
+                using (var tran = conn.BeginTransaction(IsolationLevel.ReadCommitted))
+                {
+                    UpdateFields(conn, tran, models, _properties);
+                    tran.Commit();
+                }
             }
         }
 
@@ -372,7 +376,11 @@ namespace NzbDrone.Core.Datastore
 
             using (var conn = _database.OpenConnection())
             {
-                UpdateFields(conn, null, models, propertiesToUpdate);
+                using (var tran = conn.BeginTransaction(IsolationLevel.ReadCommitted))
+                {
+                    UpdateFields(conn, tran, models, propertiesToUpdate);
+                    tran.Commit();
+                }
             }
 
             foreach (var model in models)

--- a/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
@@ -179,16 +179,6 @@ namespace NzbDrone.Core.MediaFiles
             musicFilesStopwatch.Stop();
             _logger.Trace("Finished getting track files for:\n{0} [{1}]", folders.ConcatToString("\n"), musicFilesStopwatch.Elapsed);
 
-            if (!mediaFileList.Any())
-            {
-                foreach (var artist in artists)
-                {
-                    CompletedScanning(artist);
-                }
-
-                return;
-            }
-
             var config = new ImportDecisionMakerConfig
             {
                 Filter = filter,
@@ -201,62 +191,9 @@ namespace NzbDrone.Core.MediaFiles
 
             for (var batchNum = 0; batchNum < batches.Count; batchNum++)
             {
-                var batch = batches[batchNum];
+                _logger.ProgressInfo($"Importing scan batch {batchNum + 1}/{batches.Count} ({batches[batchNum].Length} files)");
 
-                _logger.ProgressInfo($"Importing scan batch {batchNum + 1}/{batches.Count} ({batch.Length} files)");
-
-                var decisions = _importDecisionMaker.GetImportDecisions(batch.ToList(), null, null, config);
-
-                _importApprovedTracks.Import(decisions, false);
-
-                // decisions may have been filtered to just new files.  Anything new and approved will have been inserted.
-                // Now we need to make sure anything new but not approved gets inserted
-                // Note that knownFiles will include anything imported just now
-                var batchPaths = decisions.Select(x => x.Item.Path).ToList();
-                var knownFiles = batchPaths.Any() ? _mediaFileService.GetFileWithPath(batchPaths) ?? new List<TrackFile>() : new List<TrackFile>();
-
-                var newFiles = decisions
-                    .ExceptBy(x => x.Item.Path, knownFiles, x => x.Path, PathEqualityComparer.Instance)
-                    .Select(decision => new TrackFile
-                    {
-                        Path = decision.Item.Path,
-                        Size = decision.Item.Size,
-                        Modified = decision.Item.Modified,
-                        DateAdded = DateTime.UtcNow,
-                        Quality = decision.Item.Quality,
-                        MediaInfo = decision.Item.FileTrackInfo.MediaInfo
-                    })
-                    .ToList();
-                _mediaFileService.AddMany(newFiles);
-
-                _logger.Debug($"Inserted {newFiles.Count} new unmatched trackfiles");
-
-                // finally update info on size/modified for existing files
-                var updatedFiles = knownFiles
-                    .Join(decisions,
-                          x => x.Path,
-                          x => x.Item.Path,
-                          (file, decision) => new
-                          {
-                              File = file,
-                              Item = decision.Item
-                          },
-                          PathEqualityComparer.Instance)
-                    .Where(x => x.File.Size != x.Item.Size ||
-                           Math.Abs((x.File.Modified - x.Item.Modified).TotalSeconds) > 1)
-                    .Select(x =>
-                    {
-                        x.File.Size = x.Item.Size;
-                        x.File.Modified = x.Item.Modified;
-                        x.File.MediaInfo = x.Item.FileTrackInfo.MediaInfo;
-                        x.File.Quality = x.Item.Quality;
-                        return x.File;
-                    })
-                    .ToList();
-
-                _mediaFileService.Update(updatedFiles);
-
-                _logger.Debug($"Updated info for {updatedFiles.Count} known files");
+                ImportBatch(batches[batchNum], config);
             }
 
             foreach (var artist in artists)
@@ -266,6 +203,62 @@ namespace NzbDrone.Core.MediaFiles
 
             importStopwatch.Stop();
             _logger.Debug("Track import complete for:\n{0} [{1}]", folders.ConcatToString("\n"), importStopwatch.Elapsed);
+        }
+
+        private void ImportBatch(IFileInfo[] batch, ImportDecisionMakerConfig config)
+        {
+            var decisions = _importDecisionMaker.GetImportDecisions(batch.ToList(), null, null, config);
+
+            _importApprovedTracks.Import(decisions, false);
+
+            // decisions may have been filtered to just new files.  Anything new and approved will have been inserted.
+            // Now we need to make sure anything new but not approved gets inserted
+            // Note that knownFiles will include anything imported just now
+            var batchPaths = decisions.Select(x => x.Item.Path).ToList();
+            var knownFiles = (batchPaths.Any() ? _mediaFileService.GetFileWithPath(batchPaths) : null) ?? new List<TrackFile>();
+
+            var newFiles = decisions
+                .ExceptBy(x => x.Item.Path, knownFiles, x => x.Path, PathEqualityComparer.Instance)
+                .Select(decision => new TrackFile
+                {
+                    Path = decision.Item.Path,
+                    Size = decision.Item.Size,
+                    Modified = decision.Item.Modified,
+                    DateAdded = DateTime.UtcNow,
+                    Quality = decision.Item.Quality,
+                    MediaInfo = decision.Item.FileTrackInfo.MediaInfo
+                })
+                .ToList();
+            _mediaFileService.AddMany(newFiles);
+
+            _logger.Debug($"Inserted {newFiles.Count} new unmatched trackfiles");
+
+            // finally update info on size/modified for existing files
+            var updatedFiles = knownFiles
+                .Join(decisions,
+                      x => x.Path,
+                      x => x.Item.Path,
+                      (file, decision) => new
+                      {
+                          File = file,
+                          Item = decision.Item
+                      },
+                      PathEqualityComparer.Instance)
+                .Where(x => x.File.Size != x.Item.Size ||
+                       Math.Abs((x.File.Modified - x.Item.Modified).TotalSeconds) > 1)
+                .Select(x =>
+                {
+                    x.File.Size = x.Item.Size;
+                    x.File.Modified = x.Item.Modified;
+                    x.File.MediaInfo = x.Item.FileTrackInfo.MediaInfo;
+                    x.File.Quality = x.Item.Quality;
+                    return x.File;
+                })
+                .ToList();
+
+            _mediaFileService.Update(updatedFiles);
+
+            _logger.Debug($"Updated info for {updatedFiles.Count} known files");
         }
 
         private void CleanMediaFiles(string folder, List<string> mediaFileList)

--- a/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
@@ -181,6 +181,11 @@ namespace NzbDrone.Core.MediaFiles
 
             if (!mediaFileList.Any())
             {
+                foreach (var artist in artists)
+                {
+                    CompletedScanning(artist);
+                }
+
                 return;
             }
 

--- a/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
@@ -37,6 +37,11 @@ namespace NzbDrone.Core.MediaFiles
         public static readonly Regex ExcludedSubFoldersRegex = new Regex(@"(?:\\|\/|^)(?:extras|@eadir|\.@__thumb|extrafanart|plex versions|\.[^\\/]+)(?:\\|\/)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         public static readonly Regex ExcludedFilesRegex = new Regex(@"^\._|^Thumbs\.db$|^\.DS_store$|\.partial~$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
+        // Decisions/import are processed in batches rather than as one pass over the whole
+        // scanned file list, so a large library fills in progressively instead of the DB
+        // staying empty until every file has been tag-read and matched.
+        private const int ScanBatchSize = 500;
+
         private readonly IConfigService _configService;
         private readonly IDiskProvider _diskProvider;
         private readonly IMediaFileService _mediaFileService;
@@ -96,7 +101,7 @@ namespace NzbDrone.Core.MediaFiles
                 if (rootFolder == null)
                 {
                     _logger.Error("Not scanning {0}, it's not a subdirectory of a defined root folder", folder);
-                    return;
+                    continue;
                 }
 
                 var folderExists = _diskProvider.FolderExists(folder);
@@ -108,7 +113,7 @@ namespace NzbDrone.Core.MediaFiles
                         _logger.Warn("Artists' root folder ({0}) doesn't exist.", rootFolder.Path);
                         var skippedArtists = _artistService.GetArtists(artistIds);
                         skippedArtists.ForEach(x => _eventAggregator.PublishEvent(new ArtistScanSkippedEvent(x, ArtistScanSkippedReason.RootFolderDoesNotExist)));
-                        return;
+                        continue;
                     }
 
                     if (_diskProvider.FolderEmpty(rootFolder.Path))
@@ -116,7 +121,7 @@ namespace NzbDrone.Core.MediaFiles
                         _logger.Warn("Artists' root folder ({0}) is empty.", rootFolder.Path);
                         var skippedArtists = _artistService.GetArtists(artistIds);
                         skippedArtists.ForEach(x => _eventAggregator.PublishEvent(new ArtistScanSkippedEvent(x, ArtistScanSkippedReason.RootFolderIsEmpty)));
-                        return;
+                        continue;
                     }
                 }
 
@@ -174,7 +179,10 @@ namespace NzbDrone.Core.MediaFiles
             musicFilesStopwatch.Stop();
             _logger.Trace("Finished getting track files for:\n{0} [{1}]", folders.ConcatToString("\n"), musicFilesStopwatch.Elapsed);
 
-            var decisionsStopwatch = Stopwatch.StartNew();
+            if (!mediaFileList.Any())
+            {
+                return;
+            }
 
             var config = new ImportDecisionMakerConfig
             {
@@ -183,62 +191,68 @@ namespace NzbDrone.Core.MediaFiles
                 AddNewArtists = addNewArtists
             };
 
-            var decisions = _importDecisionMaker.GetImportDecisions(mediaFileList, null, null, config);
-
-            decisionsStopwatch.Stop();
-            _logger.Debug("Import decisions complete [{0}]", decisionsStopwatch.Elapsed);
-
             var importStopwatch = Stopwatch.StartNew();
-            _importApprovedTracks.Import(decisions, false);
+            var batches = mediaFileList.Chunk(ScanBatchSize).ToList();
 
-            // decisions may have been filtered to just new files.  Anything new and approved will have been inserted.
-            // Now we need to make sure anything new but not approved gets inserted
-            // Note that knownFiles will include anything imported just now
-            var knownFiles = new List<TrackFile>();
-            folders.ForEach(x => knownFiles.AddRange(_mediaFileService.GetFilesWithBasePath(x)));
+            for (var batchNum = 0; batchNum < batches.Count; batchNum++)
+            {
+                var batch = batches[batchNum];
 
-            var newFiles = decisions
-                .ExceptBy(x => x.Item.Path, knownFiles, x => x.Path, PathEqualityComparer.Instance)
-                .Select(decision => new TrackFile
-                {
-                    Path = decision.Item.Path,
-                    Size = decision.Item.Size,
-                    Modified = decision.Item.Modified,
-                    DateAdded = DateTime.UtcNow,
-                    Quality = decision.Item.Quality,
-                    MediaInfo = decision.Item.FileTrackInfo.MediaInfo
-                })
-                .ToList();
-            _mediaFileService.AddMany(newFiles);
+                _logger.ProgressInfo($"Importing scan batch {batchNum + 1}/{batches.Count} ({batch.Length} files)");
 
-            _logger.Debug($"Inserted {newFiles.Count} new unmatched trackfiles");
+                var decisions = _importDecisionMaker.GetImportDecisions(batch.ToList(), null, null, config);
 
-            // finally update info on size/modified for existing files
-            var updatedFiles = knownFiles
-                .Join(decisions,
-                      x => x.Path,
-                      x => x.Item.Path,
-                      (file, decision) => new
-                      {
-                          File = file,
-                          Item = decision.Item
-                      },
-                      PathEqualityComparer.Instance)
-                .Where(x => x.File.Size != x.Item.Size ||
-                       Math.Abs((x.File.Modified - x.Item.Modified).TotalSeconds) > 1)
-                .Select(x =>
-                {
-                    x.File.Size = x.Item.Size;
-                    x.File.Modified = x.Item.Modified;
-                    x.File.MediaInfo = x.Item.FileTrackInfo.MediaInfo;
-                    x.File.Quality = x.Item.Quality;
-                    return x.File;
-                })
-                .ToList();
+                _importApprovedTracks.Import(decisions, false);
 
-            _mediaFileService.Update(updatedFiles);
+                // decisions may have been filtered to just new files.  Anything new and approved will have been inserted.
+                // Now we need to make sure anything new but not approved gets inserted
+                // Note that knownFiles will include anything imported just now
+                var batchPaths = decisions.Select(x => x.Item.Path).ToList();
+                var knownFiles = batchPaths.Any() ? _mediaFileService.GetFileWithPath(batchPaths) ?? new List<TrackFile>() : new List<TrackFile>();
 
-            _logger.Debug($"Updated info for {updatedFiles.Count} known files");
+                var newFiles = decisions
+                    .ExceptBy(x => x.Item.Path, knownFiles, x => x.Path, PathEqualityComparer.Instance)
+                    .Select(decision => new TrackFile
+                    {
+                        Path = decision.Item.Path,
+                        Size = decision.Item.Size,
+                        Modified = decision.Item.Modified,
+                        DateAdded = DateTime.UtcNow,
+                        Quality = decision.Item.Quality,
+                        MediaInfo = decision.Item.FileTrackInfo.MediaInfo
+                    })
+                    .ToList();
+                _mediaFileService.AddMany(newFiles);
+
+                _logger.Debug($"Inserted {newFiles.Count} new unmatched trackfiles");
+
+                // finally update info on size/modified for existing files
+                var updatedFiles = knownFiles
+                    .Join(decisions,
+                          x => x.Path,
+                          x => x.Item.Path,
+                          (file, decision) => new
+                          {
+                              File = file,
+                              Item = decision.Item
+                          },
+                          PathEqualityComparer.Instance)
+                    .Where(x => x.File.Size != x.Item.Size ||
+                           Math.Abs((x.File.Modified - x.Item.Modified).TotalSeconds) > 1)
+                    .Select(x =>
+                    {
+                        x.File.Size = x.Item.Size;
+                        x.File.Modified = x.Item.Modified;
+                        x.File.MediaInfo = x.Item.FileTrackInfo.MediaInfo;
+                        x.File.Quality = x.Item.Quality;
+                        return x.File;
+                    })
+                    .ToList();
+
+                _mediaFileService.Update(updatedFiles);
+
+                _logger.Debug($"Updated info for {updatedFiles.Count} known files");
+            }
 
             foreach (var artist in artists)
             {

--- a/src/NzbDrone.Core/MediaFiles/TrackImport/Identification/CandidateService.cs
+++ b/src/NzbDrone.Core/MediaFiles/TrackImport/Identification/CandidateService.cs
@@ -208,7 +208,7 @@ namespace NzbDrone.Core.MediaFiles.TrackImport.Identification
             {
                 Release = x,
                 TrackCount = x.TrackCount,
-                CommonProportion = x.Tracks.Value.Select(y => y.ForeignRecordingId).Intersect(recordingIds).Count() / localAlbumRelease.TrackCount
+                CommonProportion = (double)x.Tracks.Value.Select(y => y.ForeignRecordingId).Intersect(recordingIds).Count() / localAlbumRelease.TrackCount
             })
                 .Where(x => x.CommonProportion > 0.6)
                 .ToList()

--- a/src/NzbDrone.Core/MediaFiles/TrackImport/ImportApprovedTracks.cs
+++ b/src/NzbDrone.Core/MediaFiles/TrackImport/ImportApprovedTracks.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NLog;
+using NzbDrone.Common;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Instrumentation.Extensions;
@@ -146,6 +147,16 @@ namespace NzbDrone.Core.MediaFiles.TrackImport
             var filesToAdd = new List<TrackFile>(qualifiedImports.Count);
             var albumReleasesDict = new Dictionary<int, List<AlbumRelease>>(albumDecisions.Count);
             var trackImportedEvents = new List<TrackImportedEvent>(qualifiedImports.Count);
+            var importedTrackIds = new HashSet<int>();
+
+            var existingFilePaths = qualifiedImports
+                .Where(e => e.Item.ExistingFile)
+                .Select(e => e.Item.Path.CleanFilePath())
+                .Distinct()
+                .ToList();
+
+            var existingFilesByPath = (existingFilePaths.Any() ? _mediaFileService.GetFileWithPath(existingFilePaths) : null)
+                ?.ToDictionary(f => f.Path, PathEqualityComparer.Instance) ?? new Dictionary<string, TrackFile>(PathEqualityComparer.Instance);
 
             foreach (var importDecision in qualifiedImports.OrderBy(e => e.Item.Tracks.Select(track => track.AbsoluteTrackNumber).MinOrDefault())
                                                            .ThenByDescending(e => e.Item.Size))
@@ -156,10 +167,7 @@ namespace NzbDrone.Core.MediaFiles.TrackImport
                 try
                 {
                     // check if already imported
-                    if (importResults.SelectMany(r => r.ImportDecision.Item.Tracks)
-                                         .Select(e => e.Id)
-                                         .Intersect(localTrack.Tracks.Select(e => e.Id))
-                                         .Any())
+                    if (localTrack.Tracks.Any(t => importedTrackIds.Contains(t.Id)))
                     {
                         importResults.Add(new ImportResult(importDecision, "Track has already been imported"));
                         continue;
@@ -243,9 +251,7 @@ namespace NzbDrone.Core.MediaFiles.TrackImport
                     else
                     {
                         // Delete existing files from the DB mapped to this path
-                        var previousFile = _mediaFileService.GetFileWithPath(trackFile.Path);
-
-                        if (previousFile != null)
+                        if (existingFilesByPath.TryGetValue(trackFile.Path, out var previousFile))
                         {
                             _mediaFileService.Delete(previousFile, DeleteMediaFileReason.ManualOverride);
                         }
@@ -266,6 +272,7 @@ namespace NzbDrone.Core.MediaFiles.TrackImport
 
                     filesToAdd.Add(trackFile);
                     importResults.Add(new ImportResult(importDecision));
+                    localTrack.Tracks.ForEach(t => importedTrackIds.Add(t.Id));
 
                     if (!localTrack.ExistingFile)
                     {

--- a/src/NzbDrone.Core/MediaFiles/TrackImport/ImportDecisionMaker.cs
+++ b/src/NzbDrone.Core/MediaFiles/TrackImport/ImportDecisionMaker.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Instrumentation.Extensions;
@@ -45,6 +48,11 @@ namespace NzbDrone.Core.MediaFiles.TrackImport
 
     public class ImportDecisionMaker : IMakeImportDecision
     {
+        // Tag reading is I/O-bound (often over network shares) with no shared mutable state between
+        // files, so it parallelizes safely. Capped rather than left unbounded so a large scan doesn't
+        // open dozens of concurrent connections against a NAS/network share.
+        private static readonly int TagReadParallelism = Math.Min(Environment.ProcessorCount, 8);
+
         private readonly IEnumerable<IImportDecisionEngineSpecification<LocalTrack>> _trackSpecifications;
         private readonly IEnumerable<IImportDecisionEngineSpecification<LocalAlbumRelease>> _albumSpecifications;
         private readonly IMediaFileService _mediaFileService;
@@ -100,10 +108,14 @@ namespace NzbDrone.Core.MediaFiles.TrackImport
                 downloadClientItemInfo = Parser.Parser.ParseAlbumTitle(downloadClientItem.Title);
             }
 
-            var i = 1;
-            foreach (var file in files)
+            var localTracksBag = new ConcurrentBag<LocalTrack>();
+            var decisionsBag = new ConcurrentBag<ImportDecision<LocalTrack>>();
+            var progress = 0;
+
+            Parallel.ForEach(files, new ParallelOptions { MaxDegreeOfParallelism = TagReadParallelism }, file =>
             {
-                _logger.ProgressInfo($"Reading file {i++}/{files.Count}");
+                var i = Interlocked.Increment(ref progress);
+                _logger.ProgressInfo($"Reading file {i}/{files.Count}");
 
                 var localTrack = new LocalTrack
                 {
@@ -120,19 +132,22 @@ namespace NzbDrone.Core.MediaFiles.TrackImport
                 {
                     // TODO fix otherfiles?
                     _augmentingService.Augment(localTrack, true);
-                    localTracks.Add(localTrack);
+                    localTracksBag.Add(localTrack);
                 }
                 catch (AugmentingFailedException)
                 {
-                    decisions.Add(new ImportDecision<LocalTrack>(localTrack, new Rejection("Unable to parse file")));
+                    decisionsBag.Add(new ImportDecision<LocalTrack>(localTrack, new Rejection("Unable to parse file")));
                 }
                 catch (Exception e)
                 {
                     _logger.Error(e, "Couldn't import file. {0}", localTrack.Path);
 
-                    decisions.Add(new ImportDecision<LocalTrack>(localTrack, new Rejection("Unexpected error processing file")));
+                    decisionsBag.Add(new ImportDecision<LocalTrack>(localTrack, new Rejection("Unexpected error processing file")));
                 }
-            }
+            });
+
+            localTracks.AddRange(localTracksBag);
+            decisions.AddRange(decisionsBag);
 
             _logger.Debug($"Tags parsed for {files.Count} files in {watch.ElapsedMilliseconds}ms");
 

--- a/src/NzbDrone.Core/MediaFiles/TrackImport/ImportDecisionMaker.cs
+++ b/src/NzbDrone.Core/MediaFiles/TrackImport/ImportDecisionMaker.cs
@@ -115,7 +115,10 @@ namespace NzbDrone.Core.MediaFiles.TrackImport
             Parallel.ForEach(files, new ParallelOptions { MaxDegreeOfParallelism = TagReadParallelism }, file =>
             {
                 var i = Interlocked.Increment(ref progress);
-                _logger.ProgressInfo($"Reading file {i}/{files.Count}");
+                if (i % 25 == 0 || i == files.Count)
+                {
+                    _logger.ProgressInfo($"Reading file {i}/{files.Count}");
+                }
 
                 var localTrack = new LocalTrack
                 {

--- a/src/NzbDrone.Core/MediaFiles/TrackImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/TrackImport/Manual/ManualImportService.cs
@@ -362,26 +362,33 @@ namespace NzbDrone.Core.MediaFiles.TrackImport.Manual
             var albumIds = message.Files.GroupBy(e => e.AlbumId).ToList();
             var fileCount = 0;
 
+            // Artist/album/track are shared by every file in the same album group (and often across
+            // groups too); fetch them once instead of re-querying per file.
+            var artistsById = _artistService.GetArtists(message.Files.Select(f => f.ArtistId).Distinct()).ToDictionary(a => a.Id);
+            var albumsById = _albumService.GetAlbums(message.Files.Select(f => f.AlbumId).Distinct()).ToDictionary(a => a.Id);
+            var tracksById = _trackService.GetTracks(message.Files.SelectMany(f => f.TrackIds).Distinct()).ToDictionary(t => t.Id);
+
             foreach (var importAlbumId in albumIds)
             {
                 var albumImportDecisions = new List<ImportDecision<LocalTrack>>();
+                var album = albumsById[importAlbumId.Key];
 
                 // turn off anyReleaseOk if specified
                 if (importAlbumId.First().DisableReleaseSwitching)
                 {
-                    var album = _albumService.GetAlbum(importAlbumId.First().AlbumId);
                     album.AnyReleaseOk = false;
                     _albumService.UpdateAlbum(album);
                 }
+
+                var releasesById = _releaseService.GetReleasesByAlbum(album.Id).ToDictionary(r => r.Id);
 
                 foreach (var file in importAlbumId)
                 {
                     _logger.ProgressTrace("Processing file {0} of {1}", fileCount + 1, message.Files.Count);
 
-                    var artist = _artistService.GetArtist(file.ArtistId);
-                    var album = _albumService.GetAlbum(file.AlbumId);
-                    var release = _releaseService.GetRelease(file.AlbumReleaseId);
-                    var tracks = _trackService.GetTracks(file.TrackIds);
+                    var artist = artistsById[file.ArtistId];
+                    var release = releasesById[file.AlbumReleaseId];
+                    var tracks = file.TrackIds.Select(id => tracksById[id]).ToList();
                     var fileTrackInfo = _audioTagService.ReadTags(file.Path) ?? new ParsedTrackInfo();
                     var fileInfo = _diskProvider.GetFileInfo(file.Path);
 

--- a/src/NzbDrone.Core/MediaFiles/TrackImport/Specifications/CloseAlbumMatchSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/TrackImport/Specifications/CloseAlbumMatchSpecification.cs
@@ -9,7 +9,7 @@ namespace NzbDrone.Core.MediaFiles.TrackImport.Specifications
 {
     public class CloseAlbumMatchSpecification : IImportDecisionEngineSpecification<LocalAlbumRelease>
     {
-        private const double _albumThreshold = 0.20;
+        private const double _albumThreshold = 0.25;
         private const double _trackThreshold = 0.40;
         private readonly Logger _logger;
 

--- a/src/NzbDrone.Core/MediaFiles/UpgradeMediaFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/UpgradeMediaFileService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using NLog;
 using NzbDrone.Common.Disk;
@@ -54,6 +55,37 @@ namespace NzbDrone.Core.MediaFiles
                 throw new RootFolderNotFoundException($"Root folder '{rootFolder}' was not found.");
             }
 
+            // Transfer the new file first so a failure (disk full, permissions, network share drop) can't
+            // leave the old file deleted with no replacement written. The most common case - an upgrade
+            // that computes the same destination path as the file it's replacing - collides and throws
+            // DestinationAlreadyExistsException; only then do we clear the old file(s) out of the way and
+            // retry, matching the previous delete-first behaviour for that specific case.
+            try
+            {
+                MoveOrCopy(trackFile, localTrack, copyOnly, moveFileResult);
+            }
+            catch (DestinationAlreadyExistsException) when (existingFiles.Any())
+            {
+                RemoveExistingFiles(existingFiles, rootFolder, moveFileResult);
+                MoveOrCopy(trackFile, localTrack, copyOnly, moveFileResult);
+            }
+
+            RemoveExistingFiles(existingFiles.Where(g => moveFileResult.OldFiles.All(f => f.Id != g.Key)), rootFolder, moveFileResult);
+
+            _audioTagService.WriteTags(trackFile, true);
+
+            return moveFileResult;
+        }
+
+        private void MoveOrCopy(TrackFile trackFile, LocalTrack localTrack, bool copyOnly, TrackFileMoveResult moveFileResult)
+        {
+            moveFileResult.TrackFile = copyOnly
+                ? _trackFileMover.CopyTrackFile(trackFile, localTrack)
+                : _trackFileMover.MoveTrackFile(trackFile, localTrack);
+        }
+
+        private void RemoveExistingFiles(IEnumerable<IGrouping<int, TrackFile>> existingFiles, string rootFolder, TrackFileMoveResult moveFileResult)
+        {
             foreach (var existingFile in existingFiles)
             {
                 var file = existingFile.First();
@@ -73,19 +105,6 @@ namespace NzbDrone.Core.MediaFiles
                 moveFileResult.OldFiles.Add(file);
                 _mediaFileService.Delete(file, DeleteMediaFileReason.Upgrade);
             }
-
-            if (copyOnly)
-            {
-                moveFileResult.TrackFile = _trackFileMover.CopyTrackFile(trackFile, localTrack);
-            }
-            else
-            {
-                moveFileResult.TrackFile = _trackFileMover.MoveTrackFile(trackFile, localTrack);
-            }
-
-            _audioTagService.WriteTags(trackFile, true);
-
-            return moveFileResult;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fix N+1 queries and wrap batch updates in a transaction in disk scan/import path (`ManualImportService`, `DiskScanService`, `ImportApprovedTracks`, `UpgradeMediaFileService`)
- Parallelize tag reading during scan/import
- Loosen album match acceptance threshold from 80% to 75%
- Add a multi-stage Dockerfile for building Lidarr as a container
- Track CHANGELOG.md

## Test plan
- [ ] `dotnet test` on affected fixtures (`ScanFixture`, `ImportApprovedTracksFixture`)
- [ ] Manual disk scan/import against a real library
- [ ] `docker build` succeeds and container runs against a real library/config volume