### PR TITLE
Fixed: Don't override overview and images if empty on album endpoint

### DIFF
--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -598,7 +598,6 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
         private static ArtistMetadata MapArtistMetadata(ArtistResource resource)
         {
             var artist = new ArtistMetadata();
-
             artist.Name = resource.ArtistName;
             artist.Aliases = resource.ArtistAliases;
             artist.ForeignArtistId = resource.Id;
@@ -609,8 +608,9 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             artist.Type = resource.Type;
             artist.Status = MapArtistStatus(resource.Status);
             artist.Ratings = MapRatings(resource.Rating);
-            artist.Images = resource.Images?.Select(MapImage).ToList();
-            artist.Links = resource.Links?.Select(MapLink).ToList();
+            artist.Images = resource.Images?.Select(MapImage).ToList() ?? [];
+            artist.Links = resource.Links?.Select(MapLink).ToList() ?? [];
+
             return artist;
         }
 

--- a/src/NzbDrone.Core/Music/Model/Album.cs
+++ b/src/NzbDrone.Core/Music/Model/Album.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text.Json.Serialization;
 using Equ;
 using NzbDrone.Common.Extensions;
@@ -79,7 +78,7 @@ namespace NzbDrone.Core.Music
             Overview = other.Overview.IsNullOrWhiteSpace() ? Overview : other.Overview;
             Disambiguation = other.Disambiguation;
             ReleaseDate = other.ReleaseDate;
-            Images = other.Images.Any() ? other.Images : Images;
+            Images = other.Images;
             Links = other.Links;
             Genres = other.Genres;
             AlbumType = other.AlbumType;

--- a/src/NzbDrone.Core/Music/Model/ArtistMetadata.cs
+++ b/src/NzbDrone.Core/Music/Model/ArtistMetadata.cs
@@ -35,21 +35,11 @@ namespace NzbDrone.Core.Music
             return string.Format("[{0}][{1}]", ForeignArtistId, Name.NullSafe());
         }
 
-        public override void UseMetadataFrom(ArtistMetadata other)
+        public override void UseDbFieldsFrom(ArtistMetadata other)
         {
-            ForeignArtistId = other.ForeignArtistId;
-            OldForeignArtistIds = other.OldForeignArtistIds;
-            Name = other.Name;
-            Aliases = other.Aliases;
-            Overview = other.Overview.IsNullOrWhiteSpace() ? Overview : other.Overview;
-            Disambiguation = other.Disambiguation;
-            Type = other.Type;
-            Status = other.Status;
-            Images = other.Images.Any() ? other.Images : Images;
-            Links = other.Links;
-            Genres = other.Genres;
-            Ratings = other.Ratings;
-            Members = other.Members;
+            Id = other.Id;
+            Overview = Overview.IsNotNullOrWhiteSpace() ? Overview : other.Overview;
+            Images = Images.Any() ? Images : other.Images;
         }
     }
 }

--- a/src/NzbDrone.Core/Music/Repositories/ArtistMetadataRepository.cs
+++ b/src/NzbDrone.Core/Music/Repositories/ArtistMetadataRepository.cs
@@ -46,6 +46,7 @@ namespace NzbDrone.Core.Music
                     }
 
                     meta.UseDbFieldsFrom(existing);
+
                     if (!meta.Equals(existing))
                     {
                         updateMetadataList.Add(meta);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Prevent overriding overview and images for ArtistMetadata with empty values from album endpoint.