### PR TITLE
Fixed: Empty mediums in UI after running refresh album command

### DIFF
--- a/src/Lidarr.Api.V1/Albums/AlbumReleaseResource.cs
+++ b/src/Lidarr.Api.V1/Albums/AlbumReleaseResource.cs
@@ -13,20 +13,8 @@ namespace Lidarr.Api.V1.Albums
         public string Status { get; set; }
         public int Duration { get; set; }
         public int TrackCount { get; set; }
+        public int MediumCount => Media?.Count(s => s.MediumNumber > 0) ?? 0;
         public List<MediumResource> Media { get; set; }
-        public int MediumCount
-        {
-            get
-            {
-                if (Media == null)
-                {
-                    return 0;
-                }
-
-                return Media.Where(s => s.MediumNumber > 0).Count();
-            }
-        }
-
         public string Disambiguation { get; set; }
         public List<string> Country { get; set; }
         public List<string> Label { get; set; }

--- a/src/Lidarr.Api.V1/Albums/AlbumResource.cs
+++ b/src/Lidarr.Api.V1/Albums/AlbumResource.cs
@@ -24,23 +24,11 @@ namespace Lidarr.Api.V1.Albums
         public int Duration { get; set; }
         public string AlbumType { get; set; }
         public List<string> SecondaryTypes { get; set; }
-        public int MediumCount
-        {
-            get
-            {
-                if (Media == null)
-                {
-                    return 0;
-                }
-
-                return Media.Where(s => s.MediumNumber > 0).Count();
-            }
-        }
-
         public Ratings Ratings { get; set; }
         public DateTime? ReleaseDate { get; set; }
         public List<AlbumReleaseResource> Releases { get; set; }
         public List<string> Genres { get; set; }
+        public int MediumCount => Media?.Count(s => s.MediumNumber > 0) ?? 0;
         public List<MediumResource> Media { get; set; }
         public ArtistResource Artist { get; set; }
         public List<MediaCover> Images { get; set; }
@@ -65,7 +53,7 @@ namespace Lidarr.Api.V1.Albums
                 return null;
             }
 
-            var selectedRelease = model.AlbumReleases?.Value.Where(x => x.Monitored).SingleOrDefault();
+            var selectedRelease = model.AlbumReleases?.Value.SingleOrDefault(x => x.Monitored);
 
             return new AlbumResource
             {

--- a/src/NzbDrone.Core/Music/Services/RefreshAlbumService.cs
+++ b/src/NzbDrone.Core/Music/Services/RefreshAlbumService.cs
@@ -370,10 +370,10 @@ namespace NzbDrone.Core.Music
                 var album = _albumService.GetAlbum(message.AlbumId.Value);
                 var artist = _artistService.GetArtistByMetadataId(album.ArtistMetadataId);
                 var updated = RefreshAlbumInfo(album, null, false);
+
                 if (updated)
                 {
                     _eventAggregator.PublishEvent(new ArtistUpdatedEvent(artist));
-                    _eventAggregator.PublishEvent(new AlbumUpdatedEvent(album));
                 }
 
                 if (message.IsNewAlbum)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
AlbumUpdatedEvent is already triggered by RefreshEntityInfo with all the lazy loaded relationships loaded, as `PublishEvent(new AlbumUpdatedEvent(album))` in this triggers and event with the previous data pre-refresh, returning empty mediums breaking the UI.