### PR TITLE
New: Remember download client for imported track files

### DIFF
--- a/src/Lidarr.Api.V1/TrackFiles/TrackFileResource.cs
+++ b/src/Lidarr.Api.V1/TrackFiles/TrackFileResource.cs
@@ -25,6 +25,7 @@ namespace Lidarr.Api.V1.TrackFiles
         public List<CustomFormatResource> CustomFormats { get; set; }
         public int CustomFormatScore { get; set; }
         public int? IndexerFlags { get; set; }
+        public int DownloadClientId { get; set; }
         public MediaInfoResource MediaInfo { get; set; }
 
         public bool QualityCutoffNotMet { get; set; }
@@ -96,7 +97,8 @@ namespace Lidarr.Api.V1.TrackFiles
                 QualityCutoffNotMet = upgradableSpecification.QualityCutoffNotMet(artist.QualityProfile.Value, model.Quality),
                 CustomFormats = customFormats.ToResource(false),
                 CustomFormatScore = customFormatScore,
-                IndexerFlags = (int)model.IndexerFlags
+                IndexerFlags = (int)model.IndexerFlags,
+                DownloadClientId = model.DownloadClientId
             };
         }
     }

--- a/src/NzbDrone.Core.Test/MediaFiles/ImportApprovedTracksFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/ImportApprovedTracksFixture.cs
@@ -232,5 +232,41 @@ namespace NzbDrone.Core.Test.MediaFiles
                 .Verify(v => v.UpgradeTrackFile(It.Is<TrackFile>(e => e.SceneName == firstDecision.Item.SceneName), _approvedDecisions.First().Item, false),
                     Times.Once());
         }
+
+        [Test]
+        public void should_set_download_client_id_for_new_downloads()
+        {
+            Subject.Import(new List<ImportDecision<LocalTrack>> { _approvedDecisions.First() }, true, new DownloadClientItem { Title = "Alien.Ant.Farm-Truant", CanMoveFiles = true, DownloadClientInfo = _clientInfo });
+
+            Mocker.GetMock<IUpgradeMediaFiles>()
+                .Verify(v => v.UpgradeTrackFile(It.Is<TrackFile>(e => e.DownloadClientId == _clientInfo.Id), _approvedDecisions.First().Item, false),
+                    Times.Once());
+        }
+
+        [Test]
+        public void should_not_set_download_client_id_without_download_client_item()
+        {
+            Subject.Import(new List<ImportDecision<LocalTrack>> { _approvedDecisions.First() }, true);
+
+            Mocker.GetMock<IUpgradeMediaFiles>()
+                .Verify(v => v.UpgradeTrackFile(It.Is<TrackFile>(e => e.DownloadClientId == 0), _approvedDecisions.First().Item, false),
+                    Times.Once());
+        }
+
+        [Test]
+        public void should_keep_download_client_id_of_previous_file_when_reimporting_existing_file()
+        {
+            Mocker.GetMock<IMediaFileService>()
+                .Setup(s => s.GetFileWithPath(It.IsAny<string>()))
+                .Returns(Builder<TrackFile>.CreateNew().With(x => x.DownloadClientId = 7).Build());
+
+            var track = _approvedDecisions.First();
+            track.Item.ExistingFile = true;
+
+            Subject.Import(new List<ImportDecision<LocalTrack>> { track }, false);
+
+            Mocker.GetMock<IMediaFileService>()
+                .Verify(v => v.AddMany(It.Is<List<TrackFile>>(l => l.Single().DownloadClientId == 7)), Times.Once());
+        }
     }
 }

--- a/src/NzbDrone.Core/Datastore/Migration/082_add_download_client_id.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/082_add_download_client_id.cs
@@ -1,0 +1,14 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(082)]
+    public class add_download_client_id : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("TrackFiles").AddColumn("DownloadClientId").AsInt32().WithDefaultValue(0);
+        }
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/TrackFile.cs
+++ b/src/NzbDrone.Core/MediaFiles/TrackFile.cs
@@ -20,6 +20,7 @@ namespace NzbDrone.Core.MediaFiles
         public string ReleaseGroup { get; set; }
         public QualityModel Quality { get; set; }
         public IndexerFlags IndexerFlags { get; set; }
+        public int DownloadClientId { get; set; }
         public MediaInfoModel MediaInfo { get; set; }
         public int AlbumId { get; set; }
 

--- a/src/NzbDrone.Core/MediaFiles/TrackImport/ImportApprovedTracks.cs
+++ b/src/NzbDrone.Core/MediaFiles/TrackImport/ImportApprovedTracks.cs
@@ -201,6 +201,8 @@ namespace NzbDrone.Core.MediaFiles.TrackImport
                         Tracks = localTrack.Tracks
                     };
 
+                    trackFile.DownloadClientId = downloadClientItem?.DownloadClientInfo?.Id ?? 0;
+
                     if (downloadClientItem?.DownloadId.IsNotNullOrWhiteSpace() == true)
                     {
                         var grabHistory = _historyService.FindByDownloadId(downloadClientItem.DownloadId)
@@ -248,6 +250,12 @@ namespace NzbDrone.Core.MediaFiles.TrackImport
                         if (previousFile != null)
                         {
                             _mediaFileService.Delete(previousFile, DeleteMediaFileReason.ManualOverride);
+
+                            // Keep the recorded download client when re-importing a file that already had one
+                            if (trackFile.DownloadClientId == 0)
+                            {
+                                trackFile.DownloadClientId = previousFile.DownloadClientId;
+                            }
                         }
 
                         try


### PR DESCRIPTION
#### Database Migration
YES - 082

#### Description
Stores the download client that imported a track file on the file record.

`TrackFiles` gets a `DownloadClientId` column, set during import from the download client item that produced the file. Files that arrive without a download client (library scans, manual imports of loose files) get `0`. Re-importing a file that already had a client recorded keeps it.

No behaviour change on its own. The value is exposed on the track file API resource.

This is groundwork for per download client behaviour, such as the tag writing option in #5679.

#### Screenshot (if UI related)
N/A

#### Todos
- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Part of #5679
