### PR TITLE
Fixed: Prefer download history when identifying completed download artists

### DIFF
--- a/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceTests/ProcessFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceTests/ProcessFixture.cs
@@ -172,6 +172,28 @@ namespace NzbDrone.Core.Test.Download.CompletedDownloadServiceTests
             AssertNotReadyToImport();
         }
 
+        [Test]
+        public void should_use_artist_from_history_when_download_title_is_ambiguous()
+        {
+            var historyArtist = new Artist { Id = 42 };
+
+            Mocker.GetMock<IHistoryService>()
+                  .Setup(s => s.MostRecentForDownloadId(_trackedDownload.DownloadItem.DownloadId))
+                  .Returns(new EntityHistory { ArtistId = historyArtist.Id });
+
+            Mocker.GetMock<IArtistService>()
+                  .Setup(s => s.GetArtist(historyArtist.Id))
+                  .Returns(historyArtist);
+
+            Mocker.GetMock<IParsingService>()
+                  .Setup(s => s.GetArtist(_trackedDownload.DownloadItem.Title))
+                  .Throws(new MultipleArtistsFoundException(new List<Artist>(), "Expected one artist, but found multiple"));
+
+            Subject.Check(_trackedDownload);
+
+            AssertReadyToImport();
+        }
+
         private void AssertNotReadyToImport()
         {
             _trackedDownload.State.Should().NotBe(TrackedDownloadState.ImportPending);

--- a/src/NzbDrone.Core/Download/CompletedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/CompletedDownloadService.cs
@@ -82,22 +82,24 @@ namespace NzbDrone.Core.Download
                 return;
             }
 
-            var artist = _parsingService.GetArtist(trackedDownload.DownloadItem.Title);
+            Artist artist = null;
+
+            if (historyItem != null)
+            {
+                artist = _artistService.GetArtist(historyItem.ArtistId);
+            }
 
             if (artist == null)
             {
-                if (historyItem != null)
-                {
-                    artist = _artistService.GetArtist(historyItem.ArtistId);
-                }
+                artist = _parsingService.GetArtist(trackedDownload.DownloadItem.Title);
+            }
 
-                if (artist == null)
-                {
-                    trackedDownload.Warn("Artist name mismatch, automatic import is not possible. Check the download troubleshooting entry on the wiki for common causes.");
-                    SetStateToImportBlocked(trackedDownload);
+            if (artist == null)
+            {
+                trackedDownload.Warn("Artist name mismatch, automatic import is not possible. Check the download troubleshooting entry on the wiki for common causes.");
+                SetStateToImportBlocked(trackedDownload);
 
-                    return;
-                }
+                return;
             }
 
             trackedDownload.State = TrackedDownloadState.ImportPending;


### PR DESCRIPTION
## Summary

- prefer the exact artist recorded in download history when checking a completed download
- fall back to title parsing only when the history artist is unavailable
- add a regression test for ambiguous artist names

## Why

`CompletedDownloadService` already resolves the most recent history item by download ID, but it currently parses the download title before consulting that history. When two distinct artists share the same normalized name, title parsing throws `MultipleArtistsFoundException`, so the history fallback is never reached even though the download was grabbed by Lidarr and has an exact artist ID.

Using the history artist first makes the exact Lidarr grab authoritative while preserving title parsing for external downloads and stale or missing history records.

## Tests

- `dotnet build src/NzbDrone.Core/Lidarr.Core.csproj -c Debug -p:EnableAnalyzers=false --no-restore` — passed
- `dotnet test src/NzbDrone.Core.Test/Lidarr.Core.Test.csproj -c Debug -p:EnableAnalyzers=false --no-restore --filter 'FullyQualifiedName~NzbDrone.Core.Test.Download.CompletedDownloadServiceTests'` — 20 passed
- full Core test run — 3,091 passed, 46 skipped, 3 unrelated baseline log-expectation failures; two reproduce on clean `develop`, while the third is order-dependent
