### PR TITLE
Upgrade StyleCop.Analyzers to Unstable 1.2.0.556

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -138,9 +138,9 @@
   <!-- Set up stylecop -->
   <ItemGroup Condition="'$(LidarrProject)'=='true' and '$(EnableAnalyzers)'!='false'">
     <!-- StyleCop analysis -->
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <AdditionalFiles Include="$(SolutionDir)stylecop.json" />
   </ItemGroup>

--- a/src/Lidarr.Api.V1/Artist/ArtistController.cs
+++ b/src/Lidarr.Api.V1/Artist/ArtistController.cs
@@ -180,7 +180,8 @@ namespace Lidarr.Api.V1.Artist
                 SourcePath = sourcePath,
                 DestinationPath = destinationPath,
                 MoveFiles = moveFiles
-            }, trigger: CommandTrigger.Manual);
+            },
+                trigger: CommandTrigger.Manual);
 
             var model = artistResource.ToModel(artist);
 

--- a/src/Lidarr.Api.V1/CustomFormats/CustomFormatBulkResource.cs
+++ b/src/Lidarr.Api.V1/CustomFormats/CustomFormatBulkResource.cs
@@ -4,7 +4,7 @@ namespace Lidarr.Api.V1.CustomFormats
 {
     public class CustomFormatBulkResource
     {
-        public HashSet<int> Ids { get; set; } = new ();
+        public HashSet<int> Ids { get; set; } = new();
         public bool? IncludeCustomFormatWhenRenaming { get; set; }
     }
 }

--- a/src/Lidarr.Api.V1/DownloadClient/DownloadClientController.cs
+++ b/src/Lidarr.Api.V1/DownloadClient/DownloadClientController.cs
@@ -8,8 +8,8 @@ namespace Lidarr.Api.V1.DownloadClient
     [V1ApiController]
     public class DownloadClientController : ProviderControllerBase<DownloadClientResource, DownloadClientBulkResource, IDownloadClient, DownloadClientDefinition>
     {
-        public static readonly DownloadClientResourceMapper ResourceMapper = new ();
-        public static readonly DownloadClientBulkResourceMapper BulkResourceMapper = new ();
+        public static readonly DownloadClientResourceMapper ResourceMapper = new();
+        public static readonly DownloadClientBulkResourceMapper BulkResourceMapper = new();
 
         public DownloadClientController(IBroadcastSignalRMessage signalRBroadcaster, IDownloadClientFactory downloadClientFactory)
             : base(signalRBroadcaster, downloadClientFactory, "downloadclient", ResourceMapper, BulkResourceMapper)

--- a/src/Lidarr.Api.V1/ImportLists/ImportListController.cs
+++ b/src/Lidarr.Api.V1/ImportLists/ImportListController.cs
@@ -10,8 +10,8 @@ namespace Lidarr.Api.V1.ImportLists
     [V1ApiController]
     public class ImportListController : ProviderControllerBase<ImportListResource, ImportListBulkResource, IImportList, ImportListDefinition>
     {
-        public static readonly ImportListResourceMapper ResourceMapper = new ();
-        public static readonly ImportListBulkResourceMapper BulkResourceMapper = new ();
+        public static readonly ImportListResourceMapper ResourceMapper = new();
+        public static readonly ImportListBulkResourceMapper BulkResourceMapper = new();
 
         public ImportListController(IBroadcastSignalRMessage signalRBroadcaster,
             IImportListFactory importListFactory,

--- a/src/Lidarr.Api.V1/Indexers/IndexerController.cs
+++ b/src/Lidarr.Api.V1/Indexers/IndexerController.cs
@@ -9,8 +9,8 @@ namespace Lidarr.Api.V1.Indexers
     [V1ApiController]
     public class IndexerController : ProviderControllerBase<IndexerResource, IndexerBulkResource, IIndexer, IndexerDefinition>
     {
-        public static readonly IndexerResourceMapper ResourceMapper = new ();
-        public static readonly IndexerBulkResourceMapper BulkResourceMapper = new ();
+        public static readonly IndexerResourceMapper ResourceMapper = new();
+        public static readonly IndexerBulkResourceMapper BulkResourceMapper = new();
 
         public IndexerController(IBroadcastSignalRMessage signalRBroadcaster,
             IndexerFactory indexerFactory,

--- a/src/Lidarr.Api.V1/Indexers/ReleasePushController.cs
+++ b/src/Lidarr.Api.V1/Indexers/ReleasePushController.cs
@@ -82,7 +82,7 @@ namespace Lidarr.Api.V1.Indexers
 
             if (decision?.RemoteAlbum.ParsedAlbumInfo == null)
             {
-                throw new ValidationException(new List<ValidationFailure> { new ("Title", "Unable to parse", release.Title) });
+                throw new ValidationException(new List<ValidationFailure> { new("Title", "Unable to parse", release.Title) });
             }
 
             return MapDecisions(new[] { decision }).First();

--- a/src/Lidarr.Api.V1/Metadata/MetadataController.cs
+++ b/src/Lidarr.Api.V1/Metadata/MetadataController.cs
@@ -9,8 +9,8 @@ namespace Lidarr.Api.V1.Metadata
     [V1ApiController]
     public class MetadataController : ProviderControllerBase<MetadataResource, MetadataBulkResource, IMetadata, MetadataDefinition>
     {
-        public static readonly MetadataResourceMapper ResourceMapper = new ();
-        public static readonly MetadataBulkResourceMapper BulkResourceMapper = new ();
+        public static readonly MetadataResourceMapper ResourceMapper = new();
+        public static readonly MetadataBulkResourceMapper BulkResourceMapper = new();
 
         public MetadataController(IBroadcastSignalRMessage signalRBroadcaster, IMetadataFactory metadataFactory)
             : base(signalRBroadcaster, metadataFactory, "metadata", ResourceMapper, BulkResourceMapper)

--- a/src/Lidarr.Api.V1/Notifications/NotificationController.cs
+++ b/src/Lidarr.Api.V1/Notifications/NotificationController.cs
@@ -9,8 +9,8 @@ namespace Lidarr.Api.V1.Notifications
     [V1ApiController]
     public class NotificationController : ProviderControllerBase<NotificationResource, NotificationBulkResource, INotification, NotificationDefinition>
     {
-        public static readonly NotificationResourceMapper ResourceMapper = new ();
-        public static readonly NotificationBulkResourceMapper BulkResourceMapper = new ();
+        public static readonly NotificationResourceMapper ResourceMapper = new();
+        public static readonly NotificationBulkResourceMapper BulkResourceMapper = new();
 
         public NotificationController(IBroadcastSignalRMessage signalRBroadcaster, NotificationFactory notificationFactory)
             : base(signalRBroadcaster, notificationFactory, "notification", ResourceMapper, BulkResourceMapper)

--- a/src/Lidarr.Api.V1/System/Backup/BackupController.cs
+++ b/src/Lidarr.Api.V1/System/Backup/BackupController.cs
@@ -20,7 +20,7 @@ namespace Lidarr.Api.V1.System.Backup
         private readonly IAppFolderInfo _appFolderInfo;
         private readonly IDiskProvider _diskProvider;
 
-        private static readonly List<string> ValidExtensions = new () { ".zip", ".db", ".xml" };
+        private static readonly List<string> ValidExtensions = new() { ".zip", ".db", ".xml" };
 
         public BackupController(IBackupService backupService,
                             IAppFolderInfo appFolderInfo,

--- a/src/Lidarr.Http/Frontend/Mappers/MediaCoverProxyMapper.cs
+++ b/src/Lidarr.Http/Frontend/Mappers/MediaCoverProxyMapper.cs
@@ -10,7 +10,7 @@ namespace Lidarr.Http.Frontend.Mappers
 {
     public class MediaCoverProxyMapper : IMapHttpRequestsToDisk
     {
-        private readonly Regex _regex = new (@"/MediaCoverProxy/(?<hash>\w+)/(?<filename>(.+)\.(jpg|png|gif))");
+        private readonly Regex _regex = new(@"/MediaCoverProxy/(?<hash>\w+)/(?<filename>(.+)\.(jpg|png|gif))");
 
         private readonly IMediaCoverProxy _mediaCoverProxy;
         private readonly IContentTypeProvider _mimeTypeProvider;

--- a/src/Lidarr.Http/Frontend/StaticResourceController.cs
+++ b/src/Lidarr.Http/Frontend/StaticResourceController.cs
@@ -17,7 +17,7 @@ namespace Lidarr.Http.Frontend
     {
         private readonly IEnumerable<IMapHttpRequestsToDisk> _requestMappers;
         private readonly Logger _logger;
-        private static readonly Regex InvalidPathRegex = new (@"([\/\\]|%2f|%5c)\.\.|\.\.([\/\\]|%2f|%5c)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex InvalidPathRegex = new(@"([\/\\]|%2f|%5c)\.\.|\.\.([\/\\]|%2f|%5c)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         public StaticResourceController(IEnumerable<IMapHttpRequestsToDisk> requestMappers,
             Logger logger)

--- a/src/Lidarr.Http/PagingResource.cs
+++ b/src/Lidarr.Http/PagingResource.cs
@@ -21,7 +21,7 @@ namespace Lidarr.Http
         public string SortKey { get; set; }
         public SortDirection SortDirection { get; set; }
         public int TotalRecords { get; set; }
-        public List<TResource> Records { get; set; } = new ();
+        public List<TResource> Records { get; set; } = new();
 
         public PagingResource()
         {

--- a/src/NzbDrone.Common.Test/Http/HttpClientFixture.cs
+++ b/src/NzbDrone.Common.Test/Http/HttpClientFixture.cs
@@ -36,7 +36,7 @@ namespace NzbDrone.Common.Test.Http
         private string _httpBinHost;
         private string _httpBinHost2;
 
-        private System.Net.Http.HttpClient _httpClient = new ();
+        private System.Net.Http.HttpClient _httpClient = new();
 
         [OneTimeSetUp]
         public void FixtureSetUp()

--- a/src/NzbDrone.Common/Composition/PluginLoader.cs
+++ b/src/NzbDrone.Common/Composition/PluginLoader.cs
@@ -13,14 +13,14 @@ namespace NzbDrone.Common.Composition
     {
         private static readonly Logger Logger = NzbDroneLogger.GetLogger(typeof(PluginLoader));
 
-        public static (List<Assembly>, List<WeakReference>) LoadPlugins(IEnumerable<string> pluginPaths)
+        public static (List<Assembly> Plugins, List<WeakReference> PluginReferences) LoadPlugins(IEnumerable<string> pluginPaths)
         {
             var assemblies = new List<Assembly>();
             var pluginRefs = new List<WeakReference>();
 
             foreach (var pluginPath in pluginPaths)
             {
-                (var plugin, var pluginRef) = LoadPlugin(pluginPath);
+                var (plugin, pluginRef) = LoadPlugin(pluginPath);
                 pluginRefs.Add(pluginRef);
                 assemblies.Add(plugin);
             }
@@ -35,12 +35,12 @@ namespace NzbDrone.Common.Composition
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static (Assembly, WeakReference) LoadPlugin(string path)
+        private static (Assembly Plugin, WeakReference PluginRefeence) LoadPlugin(string path)
         {
             var context = new PluginLoadContext(path);
             var weakRef = new WeakReference(context, trackResurrection: true);
 
-            // load from stream to avoid locking on windows
+            // load from stream to avoid locking on Windows
             using var fs = new FileStream(path, FileMode.Open, FileAccess.Read);
             var assembly = context.LoadFromStream(fs);
 
@@ -51,10 +51,7 @@ namespace NzbDrone.Common.Composition
         {
             foreach (var pluginRef in pluginRefs)
             {
-                if (pluginRef?.Target != null)
-                {
-                    ((PluginLoadContext)pluginRef.Target).Unload();
-                }
+                ((PluginLoadContext)pluginRef?.Target)?.Unload();
             }
         }
 

--- a/src/NzbDrone.Common/Http/HttpResponse.cs
+++ b/src/NzbDrone.Common/Http/HttpResponse.cs
@@ -9,7 +9,7 @@ namespace NzbDrone.Common.Http
 {
     public class HttpResponse
     {
-        private static readonly Regex RegexSetCookie = new ("^(.*?)=(.*?)(?:;|$)", RegexOptions.Compiled);
+        private static readonly Regex RegexSetCookie = new("^(.*?)=(.*?)(?:;|$)", RegexOptions.Compiled);
 
         public HttpResponse(HttpRequest request, HttpHeader headers, byte[] binaryData, HttpStatusCode statusCode = HttpStatusCode.OK, Version version = null)
         {

--- a/src/NzbDrone.Common/Instrumentation/CleanseLogMessage.cs
+++ b/src/NzbDrone.Common/Instrumentation/CleanseLogMessage.cs
@@ -10,66 +10,66 @@ namespace NzbDrone.Common.Instrumentation
         private static readonly Regex[] CleansingRules =
         {
             // Url
-            new (@"(?<=[?&: ;])((?:api|auth|pass)?key|(?:access[-_]?|refresh_)?token|auth|user|u?id|api|[a-z_]*apikey|account|passwd|pwd)=(?<secret>[^&=""]+?)(?=[ ""&=]|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"(?<=[?& ])[^=]*?(username|passwo?rd)=(?<secret>[^&=]+?)(?= |&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"rss(24h)?\.torrentleech\.org/(?!rss)(?<secret>[0-9a-z]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"torrentleech\.org/rss/download/[0-9]+/(?<secret>[0-9a-z]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"iptorrents\.com/[/a-z0-9?&;]*?(?:[?&;](u|tp)=(?<secret>[^&=;]+?))+(?= |;|&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"/fetch/[a-z0-9]{32}/(?<secret>[a-z0-9]{32})", RegexOptions.Compiled),
-            new (@"getnzb.*?(?<=\?|&)(r)=(?<secret>[^&=]+?)(?= |&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"\b(\w*)?(_?(?<!use|get_)token|username|passwo?rd)=(?<secret>[^&=]+?)(?= |&|$|;)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"-hd.me/torrent/[a-z0-9-]\.[0-9]+\.(?<secret>[0-9a-z]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"(?<=[?&: ;])((?:api|auth|pass)?key|(?:access[-_]?|refresh_)?token|auth|user|u?id|api|[a-z_]*apikey|account|passwd|pwd)=(?<secret>[^&=""]+?)(?=[ ""&=]|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"(?<=[?& ])[^=]*?(username|passwo?rd)=(?<secret>[^&=]+?)(?= |&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"rss(24h)?\.torrentleech\.org/(?!rss)(?<secret>[0-9a-z]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"torrentleech\.org/rss/download/[0-9]+/(?<secret>[0-9a-z]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"iptorrents\.com/[/a-z0-9?&;]*?(?:[?&;](u|tp)=(?<secret>[^&=;]+?))+(?= |;|&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"/fetch/[a-z0-9]{32}/(?<secret>[a-z0-9]{32})", RegexOptions.Compiled),
+            new(@"getnzb.*?(?<=\?|&)(r)=(?<secret>[^&=]+?)(?= |&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"\b(\w*)?(_?(?<!use|get_)token|username|passwo?rd)=(?<secret>[^&=]+?)(?= |&|$|;)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"-hd.me/torrent/[a-z0-9-]\.[0-9]+\.(?<secret>[0-9a-z]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // Trackers Announce Keys; Designed for Qbit Json; should work for all in theory
-            new (@"announce(\.php)?(/|%2f|%3fpasskey%3d)(?<secret>[a-z0-9]{16,})|(?<secret>[a-z0-9]{16,})(/|%2f)announce", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"announce(\.php)?(/|%2f|%3fpasskey%3d)(?<secret>[a-z0-9]{16,})|(?<secret>[a-z0-9]{16,})(/|%2f)announce", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // Path
-            new (@"C:\\Users\\(?<secret>[^\""]+?)(\\|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"/(home|Users)/(?<secret>[^/""]+?)(/|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"C:\\Users\\(?<secret>[^\""]+?)(\\|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"/(home|Users)/(?<secret>[^/""]+?)(/|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // Trackers Announce Keys; Designed for Qbit Json; should work for all in theory
-            new (@"announce(\.php)?(/|%2f|%3fpasskey%3d)(?<secret>[a-z0-9]{16,})|(?<secret>[a-z0-9]{16,})(/|%2f)announce"),
+            new(@"announce(\.php)?(/|%2f|%3fpasskey%3d)(?<secret>[a-z0-9]{16,})|(?<secret>[a-z0-9]{16,})(/|%2f)announce"),
 
             // NzbGet
-            new (@"""Name""\s*:\s*""[^""]*(username|password)""\s*,\s*""Value""\s*:\s*""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"""Name""\s*:\s*""[^""]*(username|password)""\s*,\s*""Value""\s*:\s*""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // Sabnzbd
-            new (@"""[^""]*(username|password|api_?key|nzb_key)""\s*:\s*""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"""email_(account|to|from|pwd)""\s*:\s*""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"""[^""]*(username|password|api_?key|nzb_key)""\s*:\s*""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"""email_(account|to|from|pwd)""\s*:\s*""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // uTorrent
-            new (@"\[""[a-z._]*(username|password)"",\d,""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"\[""(boss_key|boss_key_salt|proxy\.proxy)"",\d,""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"\[""[a-z._]*(username|password)"",\d,""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"\[""(boss_key|boss_key_salt|proxy\.proxy)"",\d,""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // Deluge
-            new (@"auth.login\(""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"auth.login\(""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // BroadcastheNet
-            new (@"""?method""?\s*:\s*""(getTorrents)"",\s*""?params""?\s*:\s*\[\s*""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"getTorrents\(""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"(?<=\?|&)(authkey|torrent_pass)=(?<secret>[^&=]+?)(?=""|&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"""?method""?\s*:\s*""(getTorrents)"",\s*""?params""?\s*:\s*\[\s*""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"getTorrents\(""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"(?<=\?|&)(authkey|torrent_pass)=(?<secret>[^&=]+?)(?=""|&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // Plex
-            new (@"(?<=\?|&)(X-Plex-Client-Identifier|X-Plex-Token)=(?<secret>[^&=]+?)(?= |&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"(?<=\?|&)(X-Plex-Client-Identifier|X-Plex-Token)=(?<secret>[^&=]+?)(?= |&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // Webhooks
             // Notifiarr
-            new (@"api/v[0-9]/notification/lidarr/(?<secret>[\w-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"api/v[0-9]/notification/lidarr/(?<secret>[\w-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // Indexer Responses
-            new (@"avistaz\.[a-z]{2,3}\\\/rss\\\/download\\\/(?<secret>[^&=]+?)\\\/(?<secret>[^&=]+?)\.torrent", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@",""info_hash"":""(?<secret>[^&=]+?)"",", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@",""pass[- _]?key"":""(?<secret>[^&=]+?)"",", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@",""rss[- _]?key"":""(?<secret>[^&=]+?)"",", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"avistaz\.[a-z]{2,3}\\\/rss\\\/download\\\/(?<secret>[^&=]+?)\\\/(?<secret>[^&=]+?)\.torrent", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@",""info_hash"":""(?<secret>[^&=]+?)"",", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@",""pass[- _]?key"":""(?<secret>[^&=]+?)"",", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@",""rss[- _]?key"":""(?<secret>[^&=]+?)"",", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // Discord
-            new (@"discord.com/api/webhooks/((?<secret>[\w-]+)/)?(?<secret>[\w-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"discord.com/api/webhooks/((?<secret>[\w-]+)/)?(?<secret>[\w-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // Telegram
-            new (@"api.telegram.org/bot(?<id>[\d]+):(?<secret>[\w-]+)/", RegexOptions.Compiled | RegexOptions.IgnoreCase)
+            new(@"api.telegram.org/bot(?<id>[\d]+):(?<secret>[\w-]+)/", RegexOptions.Compiled | RegexOptions.IgnoreCase)
         };
 
-        private static readonly Regex CleanseRemoteIPRegex = new (@"(?:Auth-\w+(?<!Failure|Unauthorized) ip|from) (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})", RegexOptions.Compiled);
+        private static readonly Regex CleanseRemoteIPRegex = new(@"(?:Auth-\w+(?<!Failure|Unauthorized) ip|from) (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})", RegexOptions.Compiled);
 
         public static string Cleanse(string message)
         {

--- a/src/NzbDrone.Common/Instrumentation/NzbDroneLogger.cs
+++ b/src/NzbDrone.Common/Instrumentation/NzbDroneLogger.cs
@@ -15,8 +15,8 @@ namespace NzbDrone.Common.Instrumentation
         private const string FileLogLayout = @"${date:format=yyyy-MM-dd HH\:mm\:ss.f}|${level}|${logger}|${message}${onexception:inner=${newline}${newline}[v${assembly-version}] ${exception:format=ToString}${newline}${exception:format=Data}${newline}}";
         private const string ConsoleFormat = "[${level}] ${logger}: ${message} ${onexception:inner=${newline}${newline}[v${assembly-version}] ${exception:format=ToString}${newline}${exception:format=Data}${newline}}";
 
-        private static readonly CleansingConsoleLogLayout CleansingConsoleLayout  = new (ConsoleFormat);
-        private static readonly CleansingClefLogLayout ClefLogLayout = new ();
+        private static readonly CleansingConsoleLogLayout CleansingConsoleLayout  = new(ConsoleFormat);
+        private static readonly CleansingClefLogLayout ClefLogLayout = new();
 
         private static bool _isConfigured;
 

--- a/src/NzbDrone.Common/PathEqualityComparer.cs
+++ b/src/NzbDrone.Common/PathEqualityComparer.cs
@@ -7,7 +7,7 @@ namespace NzbDrone.Common
 {
     public class PathEqualityComparer : IEqualityComparer<string>
     {
-        public static readonly PathEqualityComparer Instance = new ();
+        public static readonly PathEqualityComparer Instance = new();
 
         private PathEqualityComparer()
         {

--- a/src/NzbDrone.Common/TPL/LimitedConcurrencyLevelTaskScheduler.cs
+++ b/src/NzbDrone.Common/TPL/LimitedConcurrencyLevelTaskScheduler.cs
@@ -94,7 +94,8 @@ namespace NzbDrone.Common.TPL
                     {
                         _currentThreadIsProcessingItems = false;
                     }
-                }, null);
+                },
+                null);
         }
 
         /// <summary>Attempts to execute the specified task on the current thread.</summary>

--- a/src/NzbDrone.Common/TPL/TaskExtensions.cs
+++ b/src/NzbDrone.Common/TPL/TaskExtensions.cs
@@ -20,7 +20,8 @@ namespace NzbDrone.Common.TPL
                             Logger.Error(exception, "Task Error");
                         }
                     }
-                }, TaskContinuationOptions.OnlyOnFaulted);
+                },
+                TaskContinuationOptions.OnlyOnFaulted);
 
             return task;
         }

--- a/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceTests/ImportFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceTests/ImportFixture.cs
@@ -119,17 +119,21 @@ namespace NzbDrone.Core.Test.Download.CompletedDownloadServiceTests
         public void should_not_mark_as_imported_if_all_files_were_rejected()
         {
             Mocker.GetMock<IDownloadedTracksImportService>()
-                  .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<ImportMode>(), It.IsAny<Artist>(), It.IsAny<DownloadClientItem>()))
-                  .Returns(new List<ImportResult>
-                           {
-                               new ImportResult(
-                                   new ImportDecision<LocalTrack>(
-                                       new LocalTrack { Path = @"C:\TestPath\Droned.S01E01.mkv".AsOsAgnostic() }, new Rejection("Rejected!")), "Test Failure"),
+                .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<ImportMode>(), It.IsAny<Artist>(), It.IsAny<DownloadClientItem>()))
+                .Returns(new List<ImportResult>
+                {
+                    new ImportResult(
+                        new ImportDecision<LocalTrack>(
+                            new LocalTrack { Path = @"C:\TestPath\Droned.S01E01.mkv".AsOsAgnostic() },
+                            new Rejection("Rejected!")),
+                        "Test Failure"),
 
-                               new ImportResult(
-                                   new ImportDecision<LocalTrack>(
-                                       new LocalTrack { Path = @"C:\TestPath\Droned.S01E02.mkv".AsOsAgnostic() }, new Rejection("Rejected!")), "Test Failure")
-                           });
+                    new ImportResult(
+                        new ImportDecision<LocalTrack>(
+                            new LocalTrack { Path = @"C:\TestPath\Droned.S01E02.mkv".AsOsAgnostic() },
+                            new Rejection("Rejected!")),
+                        "Test Failure")
+                });
 
             Subject.Import(_trackedDownload);
 
@@ -143,17 +147,21 @@ namespace NzbDrone.Core.Test.Download.CompletedDownloadServiceTests
         public void should_not_mark_as_imported_if_no_tracks_were_parsed()
         {
             Mocker.GetMock<IDownloadedTracksImportService>()
-                  .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<ImportMode>(), It.IsAny<Artist>(), It.IsAny<DownloadClientItem>()))
-                  .Returns(new List<ImportResult>
-                           {
-                               new ImportResult(
-                                   new ImportDecision<LocalTrack>(
-                                       new LocalTrack { Path = @"C:\TestPath\Droned.S01E01.mkv".AsOsAgnostic() }, new Rejection("Rejected!")), "Test Failure"),
+                .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<ImportMode>(), It.IsAny<Artist>(), It.IsAny<DownloadClientItem>()))
+                .Returns(new List<ImportResult>
+                {
+                    new ImportResult(
+                        new ImportDecision<LocalTrack>(
+                            new LocalTrack { Path = @"C:\TestPath\Droned.S01E01.mkv".AsOsAgnostic() },
+                            new Rejection("Rejected!")),
+                        "Test Failure"),
 
-                               new ImportResult(
-                                   new ImportDecision<LocalTrack>(
-                                       new LocalTrack { Path = @"C:\TestPath\Droned.S01E02.mkv".AsOsAgnostic() }, new Rejection("Rejected!")), "Test Failure")
-                           });
+                    new ImportResult(
+                        new ImportDecision<LocalTrack>(
+                            new LocalTrack { Path = @"C:\TestPath\Droned.S01E02.mkv".AsOsAgnostic() },
+                            new Rejection("Rejected!")),
+                        "Test Failure")
+                });
 
             _trackedDownload.RemoteAlbum.Albums.Clear();
 
@@ -341,11 +349,18 @@ namespace NzbDrone.Core.Test.Download.CompletedDownloadServiceTests
                 {
                     new ImportResult(
                         new ImportDecision<LocalTrack>(
-                            new LocalTrack { Path = @"C:\TestPath\Droned.S01E01.mkv", Tracks = new List<Track> { track1 } })),
+                            new LocalTrack
+                            {
+                                Path = @"C:\TestPath\Droned.S01E01.mkv", Tracks = new List<Track> { track1 }
+                            })),
 
                     new ImportResult(
                         new ImportDecision<LocalTrack>(
-                            new LocalTrack { Path = @"C:\TestPath\Droned.S01E02.mkv", Tracks = new List<Track> { track2 } }), "Test Failure")
+                            new LocalTrack
+                            {
+                                Path = @"C:\TestPath\Droned.S01E02.mkv", Tracks = new List<Track> { track2 }
+                            }),
+                        "Test Failure")
                 });
 
             var history = Builder<EntityHistory>.CreateListOfSize(2)

--- a/src/NzbDrone.Core.Test/Download/DownloadServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadServiceFixture.cs
@@ -165,7 +165,8 @@ namespace NzbDrone.Core.Test.Download
 
             Mocker.GetMock<IIndexerStatusService>()
                 .Verify(v => v.RecordFailure(It.IsAny<int>(),
-                    It.IsInRange<TimeSpan>(TimeSpan.FromMinutes(4.9), TimeSpan.FromMinutes(5.1), Moq.Range.Inclusive)), Times.Once());
+                    It.IsInRange<TimeSpan>(TimeSpan.FromMinutes(4.9), TimeSpan.FromMinutes(5.1), Moq.Range.Inclusive)),
+                    Times.Once());
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/HealthCheck/Checks/DownloadClientRootFolderCheckFixture.cs
+++ b/src/NzbDrone.Core.Test/HealthCheck/Checks/DownloadClientRootFolderCheckFixture.cs
@@ -84,7 +84,7 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
 
             GivenRootFolder(rootFolderPath);
 
-            _clientStatus.OutputRootFolders = new List<OsPath> { new (downloadRootPath) };
+            _clientStatus.OutputRootFolders = new List<OsPath> { new(downloadRootPath) };
 
             Subject.Check().ShouldBeWarning();
         }

--- a/src/NzbDrone.Core.Test/ImportListTests/ImportListSyncServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/ImportListTests/ImportListSyncServiceFixture.cs
@@ -40,7 +40,7 @@ namespace NzbDrone.Core.Test.ImportListTests
 
             Mocker.GetMock<IImportListFactory>()
                 .Setup(v => v.All())
-                .Returns(new List<ImportListDefinition> { new () { ShouldMonitor = ImportListMonitorType.SpecificAlbum } });
+                .Returns(new List<ImportListDefinition> { new() { ShouldMonitor = ImportListMonitorType.SpecificAlbum } });
 
             Mocker.GetMock<IImportListFactory>()
                 .Setup(v => v.AutomaticAddEnabled(It.IsAny<bool>()))
@@ -148,7 +148,7 @@ namespace NzbDrone.Core.Test.ImportListTests
         {
             Mocker.GetMock<IImportListFactory>()
                 .Setup(v => v.All())
-                .Returns(new List<ImportListDefinition> { new () { ShouldMonitor = monitor, ShouldMonitorExisting = shouldMonitorExisting, ShouldSearch = shouldSearch } });
+                .Returns(new List<ImportListDefinition> { new() { ShouldMonitor = monitor, ShouldMonitorExisting = shouldMonitorExisting, ShouldSearch = shouldSearch } });
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/MediaFiles/TrackFileMovingServiceTests/MoveTrackFileFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/TrackFileMovingServiceTests/MoveTrackFileFixture.cs
@@ -94,7 +94,8 @@ namespace NzbDrone.Core.Test.MediaFiles.TrackFileMovingServiceTests
 
             Mocker.GetMock<IEventAggregator>()
                   .Verify(s => s.PublishEvent<TrackFolderCreatedEvent>(It.Is<TrackFolderCreatedEvent>(p =>
-                      p.ArtistFolder.IsNotNullOrWhiteSpace())), Times.Once());
+                      p.ArtistFolder.IsNotNullOrWhiteSpace())),
+                      Times.Once());
         }
 
         [Test]
@@ -104,7 +105,8 @@ namespace NzbDrone.Core.Test.MediaFiles.TrackFileMovingServiceTests
 
             Mocker.GetMock<IEventAggregator>()
                   .Verify(s => s.PublishEvent<TrackFolderCreatedEvent>(It.Is<TrackFolderCreatedEvent>(p =>
-                      p.AlbumFolder.IsNotNullOrWhiteSpace())), Times.Once());
+                      p.AlbumFolder.IsNotNullOrWhiteSpace())),
+                      Times.Once());
         }
 
         [Test]
@@ -118,7 +120,8 @@ namespace NzbDrone.Core.Test.MediaFiles.TrackFileMovingServiceTests
 
             Mocker.GetMock<IEventAggregator>()
                   .Verify(s => s.PublishEvent<TrackFolderCreatedEvent>(It.Is<TrackFolderCreatedEvent>(p =>
-                      p.ArtistFolder.IsNotNullOrWhiteSpace())), Times.Never());
+                      p.ArtistFolder.IsNotNullOrWhiteSpace())),
+                      Times.Never());
         }
     }
 }

--- a/src/NzbDrone.Core.Test/MediaFiles/TrackImport/Aggregation/AggregateFilenameInfoFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/TrackImport/Aggregation/AggregateFilenameInfoFixture.cs
@@ -45,7 +45,8 @@ namespace NzbDrone.Core.Test.MediaFiles.TrackImport.Aggregation.Aggregators
                     "Adele - 19 - 102 - Best for Last.mp3",
                     "Adele - 19 - 103 - Chasing Pavements.mp3",
                     "Adele - 19 - 203 - That's It, I Quit, I'm Moving On.mp3"
-            }, @"C:\incoming".AsOsAgnostic());
+            },
+                @"C:\incoming".AsOsAgnostic());
 
             Subject.Aggregate(release, true);
 

--- a/src/NzbDrone.Core.Test/MusicTests/MoveArtistServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MusicTests/MoveArtistServiceFixture.cs
@@ -139,7 +139,8 @@ namespace NzbDrone.Core.Test.MusicTests
                 .Verify(
                     v => v.TransferFolder(_command.SourcePath,
                         _command.DestinationPath,
-                        TransferMode.Move), Times.Never());
+                        TransferMode.Move),
+                    Times.Never());
 
             Mocker.GetMock<IBuildFileNames>()
                 .Verify(v => v.GetArtistFolder(It.IsAny<Artist>(), null), Times.Never());

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/ColonReplacementFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/ColonReplacementFixture.cs
@@ -37,7 +37,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
 
             _release = Builder<AlbumRelease>
                 .CreateNew()
-                .With(s => s.Media = new List<Medium> { new () { Number = 14 } })
+                .With(s => s.Media = new List<Medium> { new() { Number = 14 } })
                 .Build();
 
             _track = Builder<Track>.CreateNew()

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/TruncatedReleaseGroupFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/TruncatedReleaseGroupFixture.cs
@@ -38,7 +38,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
 
             _release = Builder<AlbumRelease>
                 .CreateNew()
-                .With(s => s.Media = new List<Medium> { new () { Number = 14 } })
+                .With(s => s.Media = new List<Medium> { new() { Number = 14 } })
                 .Build();
 
             _namingConfig = NamingConfig.Default;

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/TruncatedTrackTitlesFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/TruncatedTrackTitlesFixture.cs
@@ -36,7 +36,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
 
             _release = Builder<AlbumRelease>
                 .CreateNew()
-                .With(s => s.Media = new List<Medium> { new () { Number = 14 } })
+                .With(s => s.Media = new List<Medium> { new() { Number = 14 } })
                 .Build();
 
             _namingConfig = NamingConfig.Default;

--- a/src/NzbDrone.Core/ArtistStats/ArtistStatisticsRepository.cs
+++ b/src/NzbDrone.Core/ArtistStats/ArtistStatisticsRepository.cs
@@ -76,7 +76,8 @@ namespace NzbDrone.Core.ArtistStats
                         COUNT(""Tracks"".""Id"") AS ""TotalTrackCount"",
                         SUM(CASE WHEN ""Albums"".""ReleaseDate"" <= @currentDate OR ""Tracks"".""TrackFileId"" > 0 THEN 1 ELSE 0 END) AS ""AvailableTrackCount"",
                         SUM(CASE WHEN (""Albums"".""Monitored"" = {trueIndicator} AND ""Albums"".""ReleaseDate"" <= @currentDate) OR ""Tracks"".""TrackFileId"" > 0 THEN 1 ELSE 0 END) AS ""TrackCount"",
-                        SUM(CASE WHEN ""Tracks"".""TrackFileId"" > 0 THEN 1 ELSE 0 END) AS TrackFileCount", parameters)
+                        SUM(CASE WHEN ""Tracks"".""TrackFileId"" > 0 THEN 1 ELSE 0 END) AS TrackFileCount",
+                    parameters)
                 .Join<Track, AlbumRelease>((t, r) => t.AlbumReleaseId == r.Id)
                 .Join<AlbumRelease, Album>((r, a) => r.AlbumId == a.Id)
                 .Join<Album, Artist>((album, artist) => album.ArtistMetadataId == artist.ArtistMetadataId)

--- a/src/NzbDrone.Core/AutoTagging/Specifications/MetadataProfileSpecification.cs
+++ b/src/NzbDrone.Core/AutoTagging/Specifications/MetadataProfileSpecification.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Core.AutoTagging.Specifications
 
     public class MetadataProfileSpecification : AutoTaggingSpecificationBase
     {
-        private static readonly MetadataProfileSpecificationValidator Validator = new ();
+        private static readonly MetadataProfileSpecificationValidator Validator = new();
 
         public override int Order => 1;
         public override string ImplementationName => "Metadata Profile";

--- a/src/NzbDrone.Core/AutoTagging/Specifications/MonitoredSpecification.cs
+++ b/src/NzbDrone.Core/AutoTagging/Specifications/MonitoredSpecification.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.AutoTagging.Specifications
 
     public class MonitoredSpecification : AutoTaggingSpecificationBase
     {
-        private static readonly MonitoredSpecificationValidator Validator = new ();
+        private static readonly MonitoredSpecificationValidator Validator = new();
 
         public override int Order => 1;
         public override string ImplementationName => "Monitored";

--- a/src/NzbDrone.Core/AutoTagging/Specifications/QualityProfileSpecification.cs
+++ b/src/NzbDrone.Core/AutoTagging/Specifications/QualityProfileSpecification.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Core.AutoTagging.Specifications
 
     public class QualityProfileSpecification : AutoTaggingSpecificationBase
     {
-        private static readonly QualityProfileSpecificationValidator Validator = new ();
+        private static readonly QualityProfileSpecificationValidator Validator = new();
 
         public override int Order => 1;
         public override string ImplementationName => "Quality Profile";

--- a/src/NzbDrone.Core/AutoTagging/Specifications/StatusSpecification.cs
+++ b/src/NzbDrone.Core/AutoTagging/Specifications/StatusSpecification.cs
@@ -11,7 +11,7 @@ namespace NzbDrone.Core.AutoTagging.Specifications
 
     public class StatusSpecification : AutoTaggingSpecificationBase
     {
-        private static readonly StatusSpecificationValidator Validator = new ();
+        private static readonly StatusSpecificationValidator Validator = new();
 
         public override int Order => 1;
         public override string ImplementationName => "Status";

--- a/src/NzbDrone.Core/AutoTagging/Specifications/TagSpecification.cs
+++ b/src/NzbDrone.Core/AutoTagging/Specifications/TagSpecification.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Core.AutoTagging.Specifications
 
     public class TagSpecification : AutoTaggingSpecificationBase
     {
-        private static readonly TagSpecificationValidator Validator = new ();
+        private static readonly TagSpecificationValidator Validator = new();
 
         public override int Order => 1;
         public override string ImplementationName => "Tag";

--- a/src/NzbDrone.Core/CustomFormats/Specifications/IndexerFlagSpecification.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/IndexerFlagSpecification.cs
@@ -23,7 +23,7 @@ namespace NzbDrone.Core.CustomFormats
 
     public class IndexerFlagSpecification : CustomFormatSpecificationBase
     {
-        private static readonly IndexerFlagSpecificationValidator Validator = new ();
+        private static readonly IndexerFlagSpecificationValidator Validator = new();
 
         public override int Order => 4;
         public override string ImplementationName => "Indexer Flag";

--- a/src/NzbDrone.Core/Datastore/DatabaseVersionParser.cs
+++ b/src/NzbDrone.Core/Datastore/DatabaseVersionParser.cs
@@ -5,7 +5,7 @@ namespace NzbDrone.Core.Datastore;
 
 public static class DatabaseVersionParser
 {
-    private static readonly Regex VersionRegex = new (@"^[^ ]+", RegexOptions.Compiled);
+    private static readonly Regex VersionRegex = new(@"^[^ ]+", RegexOptions.Compiled);
 
     public static Version ParseServerVersion(string serverVersion)
     {

--- a/src/NzbDrone.Core/Datastore/Migration/072_add_alac_24_quality_in_profiles.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/072_add_alac_24_quality_in_profiles.cs
@@ -51,7 +51,7 @@ namespace NzbDrone.Core.Datastore.Migration
         private readonly IDbTransaction _transaction;
 
         private List<QualityProfile72> _profiles;
-        private HashSet<QualityProfile72> _changedProfiles = new ();
+        private HashSet<QualityProfile72> _changedProfiles = new();
 
         public QualityProfileUpdater72(IDbConnection conn, IDbTransaction tran)
         {

--- a/src/NzbDrone.Core/ImportLists/LastFm/LastFmUserSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/LastFm/LastFmUserSettings.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Core.ImportLists.LastFm
 
     public class LastFmUserSettings : IImportListSettings
     {
-        private static readonly LastFmSettingsValidator Validator = new ();
+        private static readonly LastFmSettingsValidator Validator = new();
 
         public LastFmUserSettings()
         {

--- a/src/NzbDrone.Core/Indexers/FileList/FileListSettings.cs
+++ b/src/NzbDrone.Core/Indexers/FileList/FileListSettings.cs
@@ -21,7 +21,7 @@ namespace NzbDrone.Core.Indexers.FileList
 
     public class FileListSettings : ITorrentIndexerSettings
     {
-        private static readonly FileListSettingsValidator Validator = new ();
+        private static readonly FileListSettingsValidator Validator = new();
 
         public FileListSettings()
         {
@@ -54,7 +54,7 @@ namespace NzbDrone.Core.Indexers.FileList
         public int MinimumSeeders { get; set; }
 
         [FieldDefinition(7)]
-        public SeedCriteriaSettings SeedCriteria { get; set; } = new ();
+        public SeedCriteriaSettings SeedCriteria { get; set; } = new();
 
         [FieldDefinition(8, Type = FieldType.Checkbox, Label = "IndexerSettingsRejectBlocklistedTorrentHashes", HelpText = "IndexerSettingsRejectBlocklistedTorrentHashesHelpText", Advanced = true)]
         public bool RejectBlocklistedTorrentHashesWhileGrabbing { get; set; }

--- a/src/NzbDrone.Core/Indexers/Redacted/RedactedSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Redacted/RedactedSettings.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Core.Indexers.Redacted
 
     public class RedactedSettings : ITorrentIndexerSettings
     {
-        private static readonly RedactedSettingsValidator Validator = new ();
+        private static readonly RedactedSettingsValidator Validator = new();
 
         public RedactedSettings()
         {
@@ -46,7 +46,7 @@ namespace NzbDrone.Core.Indexers.Redacted
         public int MinimumSeeders { get; set; }
 
         [FieldDefinition(6)]
-        public SeedCriteriaSettings SeedCriteria { get; set; } = new ();
+        public SeedCriteriaSettings SeedCriteria { get; set; } = new();
 
         [FieldDefinition(7, Type = FieldType.Checkbox, Label = "IndexerSettingsRejectBlocklistedTorrentHashes", HelpText = "IndexerSettingsRejectBlocklistedTorrentHashesHelpText", Advanced = true)]
         public bool RejectBlocklistedTorrentHashesWhileGrabbing { get; set; }

--- a/src/NzbDrone.Core/MediaFiles/TrackImport/Identification/CandidateService.cs
+++ b/src/NzbDrone.Core/MediaFiles/TrackImport/Identification/CandidateService.cs
@@ -135,7 +135,8 @@ namespace NzbDrone.Core.MediaFiles.TrackImport.Identification
             // getting a perfect match early on
             return GetDbCandidatesByRelease(_releaseService.GetReleasesByAlbum(album.Id)
                                           .OrderBy(x => Math.Abs(localAlbumRelease.TrackCount - x.TrackCount))
-                                          .ToList(), includeExisting);
+                                          .ToList(),
+                includeExisting);
         }
 
         private List<CandidateAlbumRelease> GetDbCandidatesByArtist(LocalAlbumRelease localAlbumRelease, Artist artist, bool includeExisting)
@@ -216,7 +217,8 @@ namespace NzbDrone.Core.MediaFiles.TrackImport.Identification
                 .ThenByDescending(x => x.CommonProportion)
                 .Select(x => x.Release)
                 .Take(10)
-                .ToList(), includeExisting);
+                .ToList(),
+                includeExisting);
         }
 
         public List<CandidateAlbumRelease> GetRemoteCandidates(LocalAlbumRelease localAlbumRelease)

--- a/src/NzbDrone.Core/MediaFiles/TrackImport/Identification/IdentificationService.cs
+++ b/src/NzbDrone.Core/MediaFiles/TrackImport/Identification/IdentificationService.cs
@@ -238,7 +238,8 @@ namespace NzbDrone.Core.MediaFiles.TrackImport.Identification
             // convert all the TrackFiles that represent extra files to List<LocalTrack>
             var allLocalTracks = ToLocalTrack(candidateReleases
                                               .SelectMany(x => x.ExistingTracks)
-                                              .DistinctBy(x => x.Path), localAlbumRelease);
+                                              .DistinctBy(x => x.Path),
+                localAlbumRelease);
 
             _logger.Debug($"Retrieved {allLocalTracks.Count} possible tracks in {watch.ElapsedMilliseconds}ms");
 

--- a/src/NzbDrone.Core/MediaFiles/TrackImport/Identification/TrackGroupingService.cs
+++ b/src/NzbDrone.Core/MediaFiles/TrackImport/Identification/TrackGroupingService.cs
@@ -22,8 +22,8 @@ namespace NzbDrone.Core.MediaFiles.TrackImport.Identification
         private const string MultiDiscPatternFormat = @"^(?<root>.*%s[\W_]*)\d";
         private static readonly Logger _logger = NzbDroneLogger.GetLogger(typeof(TrackGroupingService));
 
-        private static readonly List<string> MultiDiscMarkers = new () { @"dis[ck]", @"cd" };
-        private static readonly List<string> VariousArtistTitles = new () { "", "various artists", "various", "va", "unknown" };
+        private static readonly List<string> MultiDiscMarkers = new() { @"dis[ck]", @"cd" };
+        private static readonly List<string> VariousArtistTitles = new() { "", "various artists", "various", "va", "unknown" };
 
         public List<LocalAlbumRelease> GroupTracks(List<LocalTrack> localTracks)
         {

--- a/src/NzbDrone.Core/Messaging/Events/EventAggregator.cs
+++ b/src/NzbDrone.Core/Messaging/Events/EventAggregator.cs
@@ -108,7 +108,8 @@ namespace NzbDrone.Core.Messaging.Events
                 _taskFactory.StartNew(() =>
                 {
                     handlerLocal.HandleAsync(@event);
-                }, TaskCreationOptions.PreferFairness)
+                },
+                        TaskCreationOptions.PreferFairness)
                 .LogExceptions();
             }
 
@@ -121,7 +122,8 @@ namespace NzbDrone.Core.Messaging.Events
                     _logger.Trace("{0} ~> {1}", eventName, handlerLocal.GetType().Name);
                     handlerLocal.HandleAsync(@event);
                     _logger.Trace("{0} <~ {1}", eventName, handlerLocal.GetType().Name);
-                }, TaskCreationOptions.PreferFairness)
+                },
+                        TaskCreationOptions.PreferFairness)
                 .LogExceptions();
             }
         }

--- a/src/NzbDrone.Core/Music/Repositories/TrackRepository.cs
+++ b/src/NzbDrone.Core/Music/Repositories/TrackRepository.cs
@@ -57,7 +57,8 @@ namespace NzbDrone.Core.Music
             // this will populate the artist metadata also
             return _database.QueryJoined<Track, ArtistMetadata>(Builder()
                                .Join<Track, ArtistMetadata>((l, r) => l.ArtistMetadataId == r.Id)
-                               .Where<Track>(x => albumReleaseIds.Contains(x.AlbumReleaseId)), (track, metadata) =>
+                               .Where<Track>(x => albumReleaseIds.Contains(x.AlbumReleaseId)),
+                (track, metadata) =>
                     {
                         track.ArtistMetadata = metadata;
                         return track;

--- a/src/NzbDrone.Core/Notifications/AlbumDownloadMessage.cs
+++ b/src/NzbDrone.Core/Notifications/AlbumDownloadMessage.cs
@@ -11,8 +11,8 @@ namespace NzbDrone.Core.Notifications
         public Artist Artist { get; set; }
         public Album Album { get; set; }
         public AlbumRelease Release { get; set; }
-        public List<TrackFile> TrackFiles { get; set; } = new ();
-        public List<TrackFile> OldFiles { get; set; } = new ();
+        public List<TrackFile> TrackFiles { get; set; } = new();
+        public List<TrackFile> OldFiles { get; set; } = new();
         public DownloadClientItemClientInfo DownloadClientInfo { get; set; }
         public string DownloadId { get; set; }
 

--- a/src/NzbDrone.Core/Notifications/Apprise/AppriseSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Apprise/AppriseSettings.cs
@@ -37,7 +37,7 @@ namespace NzbDrone.Core.Notifications.Apprise
 
     public class AppriseSettings : IProviderConfig
     {
-        private static readonly AppriseSettingsValidator Validator = new ();
+        private static readonly AppriseSettingsValidator Validator = new();
 
         public AppriseSettings()
         {

--- a/src/NzbDrone.Core/Notifications/Discord/DiscordSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/DiscordSettings.cs
@@ -50,7 +50,7 @@ namespace NzbDrone.Core.Notifications.Discord
             };
         }
 
-        private static readonly DiscordSettingsValidator Validator = new ();
+        private static readonly DiscordSettingsValidator Validator = new();
 
         [FieldDefinition(0, Label = "Webhook URL", HelpText = "Discord channel webhook url")]
         public string WebHookUrl { get; set; }

--- a/src/NzbDrone.Core/Notifications/Pushcut/PushcutSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Pushcut/PushcutSettings.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.Notifications.Pushcut
 
     public class PushcutSettings : IProviderConfig
     {
-        private static readonly PushcutSettingsValidator Validator = new ();
+        private static readonly PushcutSettingsValidator Validator = new();
 
         [FieldDefinition(0, Label = "Notification name", Type = FieldType.Textbox, HelpText = "Notification name from Notifications tab of the Pushcut app.")]
         public string NotificationName { get; set; }

--- a/src/NzbDrone.Core/Notifications/Signal/SignalSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Signal/SignalSettings.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.Notifications.Signal
 
     public class SignalSettings : IProviderConfig
     {
-        private static readonly SignalSettingsValidator Validator = new ();
+        private static readonly SignalSettingsValidator Validator = new();
 
         [FieldDefinition(0, Label = "Host", Type = FieldType.Textbox, HelpText = "localhost")]
         public string Host { get; set; }

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookBase.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookBase.cs
@@ -230,7 +230,7 @@ namespace NzbDrone.Core.Notifications.Webhook
                 },
                 Albums = new List<WebhookAlbum>
                 {
-                    new ()
+                    new()
                     {
                         Id = 123,
                         Title = "Test title"

--- a/src/NzbDrone.Core/Notifications/Xbmc/XbmcSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Xbmc/XbmcSettings.cs
@@ -20,7 +20,7 @@ namespace NzbDrone.Core.Notifications.Xbmc
 
     public class XbmcSettings : IProviderConfig
     {
-        private static readonly XbmcSettingsValidator Validator = new ();
+        private static readonly XbmcSettingsValidator Validator = new();
 
         public XbmcSettings()
         {

--- a/src/NzbDrone.Core/Parser/QualityParser.cs
+++ b/src/NzbDrone.Core/Parser/QualityParser.cs
@@ -12,19 +12,19 @@ namespace NzbDrone.Core.Parser
     {
         private static readonly Logger Logger = NzbDroneLogger.GetLogger(typeof(QualityParser));
 
-        private static readonly Regex ProperRegex = new (@"\b(?<proper>proper)\b",
+        private static readonly Regex ProperRegex = new(@"\b(?<proper>proper)\b",
                                                                 RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex RepackRegex = new (@"\b(?<repack>repack\d?|rerip\d?)\b",
+        private static readonly Regex RepackRegex = new(@"\b(?<repack>repack\d?|rerip\d?)\b",
                                                                 RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex VersionRegex = new (@"(?:\d(?<!\bMP3\b))[-._ ]?v(?<version>\d)[-._ ]|\[v(?<version>\d)\]|repack(?<version>\d)|rerip(?<version>\d)",
+        private static readonly Regex VersionRegex = new(@"(?:\d(?<!\bMP3\b))[-._ ]?v(?<version>\d)[-._ ]|\[v(?<version>\d)\]|repack(?<version>\d)|rerip(?<version>\d)",
                                                                 RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex RealRegex = new (@"\b(?<real>REAL)\b",
+        private static readonly Regex RealRegex = new(@"\b(?<real>REAL)\b",
                                                                 RegexOptions.Compiled);
 
-        private static readonly Regex BitRateRegex = new (@"\b(?:(?<B096>96[ ]?kbps|96|[\[\(].*96.*[\]\)])|
+        private static readonly Regex BitRateRegex = new(@"\b(?:(?<B096>96[ ]?kbps|96|[\[\(].*96.*[\]\)])|
                                                                 (?<B128>128[ ]?kbps|128|[\[\(].*128.*[\]\)])|
                                                                 (?<B160>160[ ]?kbps|160|[\[\(].*160.*[\]\)]|q5)|
                                                                 (?<B192>192[ ]?kbps|192|[\[\(].*192.*[\]\)]|q6)|
@@ -36,12 +36,12 @@ namespace NzbDrone.Core.Parser
                                                                 (?<VBRV2>V2[ ]?kbps|V2|[\[\(].*V2.*[\]\)]))\b",
                                                                 RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
-        private static readonly Regex SampleSizeRegex = new (@"\b(?:(?<S24>24[-._ ]?bit|flac24(?:[-._ ]?bit)?|tr24|24-(?:44|48|96|192)|[\[\(].*24bit.*[\]\)]))\b", RegexOptions.Compiled);
+        private static readonly Regex SampleSizeRegex = new(@"\b(?:(?<S24>24[-._ ]?bit|flac24(?:[-._ ]?bit)?|tr24|24-(?:44|48|96|192)|[\[\(].*24bit.*[\]\)]))\b", RegexOptions.Compiled);
 
-        private static readonly Regex CodecRegex = new (@"\b(?:(?<MP1>MPEG Version \d(.5)? Audio, Layer 1|MP1)|(?<MP2>MPEG Version \d(.5)? Audio, Layer 2|MP2)|(?<MP3VBR>MP3.*VBR|MPEG Version \d(.5)? Audio, Layer 3 vbr)|(?<MP3CBR>MP3|MPEG Version \d(.5)? Audio, Layer 3)|(?<FLAC>(web)?flac(?:24(?:[-._ ]?bit)?)?|TR24)|(?<WAVPACK>wavpack|wv)|(?<ALAC>alac)|(?<WMA>WMA\d?)|(?<WAV>WAV|PCM)|(?<AAC>M4A|M4P|M4B|AAC|mp4a|MPEG-4 Audio(?!.*alac))|(?<OGG>OGG|OGA|Vorbis))\b|(?<APE>monkey's audio|[\[|\(].*\bape\b.*[\]|\)])|(?<OPUS>Opus Version \d(.5)? Audio|[\[|\(].*\bopus\b.*[\]|\)])",
+        private static readonly Regex CodecRegex = new(@"\b(?:(?<MP1>MPEG Version \d(.5)? Audio, Layer 1|MP1)|(?<MP2>MPEG Version \d(.5)? Audio, Layer 2|MP2)|(?<MP3VBR>MP3.*VBR|MPEG Version \d(.5)? Audio, Layer 3 vbr)|(?<MP3CBR>MP3|MPEG Version \d(.5)? Audio, Layer 3)|(?<FLAC>(web)?flac(?:24(?:[-._ ]?bit)?)?|TR24)|(?<WAVPACK>wavpack|wv)|(?<ALAC>alac)|(?<WMA>WMA\d?)|(?<WAV>WAV|PCM)|(?<AAC>M4A|M4P|M4B|AAC|mp4a|MPEG-4 Audio(?!.*alac))|(?<OGG>OGG|OGA|Vorbis))\b|(?<APE>monkey's audio|[\[|\(].*\bape\b.*[\]|\)])|(?<OPUS>Opus Version \d(.5)? Audio|[\[|\(].*\bopus\b.*[\]|\)])",
                                                                   RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex WebRegex = new (@"\b(?<web>WEB)(?:\b|$|[ .])",
+        private static readonly Regex WebRegex = new(@"\b(?<web>WEB)(?:\b|$|[ .])",
                                                         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         public static QualityModel ParseQuality(string name, string desc, int fileBitrate, int fileSampleSize = 0)

--- a/src/NzbDrone.Core/Queue/QueueService.cs
+++ b/src/NzbDrone.Core/Queue/QueueService.cs
@@ -20,7 +20,7 @@ namespace NzbDrone.Core.Queue
     public class QueueService : IQueueService, IHandle<TrackedDownloadRefreshedEvent>
     {
         private readonly IEventAggregator _eventAggregator;
-        private static List<Queue> _queue = new ();
+        private static List<Queue> _queue = new();
         private readonly IHistoryService _historyService;
 
         public QueueService(IEventAggregator eventAggregator,

--- a/src/NzbDrone.Core/RootFolders/RootFolder.cs
+++ b/src/NzbDrone.Core/RootFolders/RootFolder.cs
@@ -12,7 +12,7 @@ namespace NzbDrone.Core.RootFolders
         public int DefaultQualityProfileId { get; set; }
         public MonitorTypes DefaultMonitorOption { get; set; }
         public NewItemMonitorTypes DefaultNewItemMonitorOption { get; set; }
-        public HashSet<int> DefaultTags { get; set; } = new ();
+        public HashSet<int> DefaultTags { get; set; } = new();
 
         public bool Accessible { get; set; }
         public long? FreeSpace { get; set; }

--- a/src/NzbDrone.Host/Bootstrap.cs
+++ b/src/NzbDrone.Host/Bootstrap.cs
@@ -329,7 +329,7 @@ namespace NzbDrone.Host
             {
                 return new ConfigurationBuilder()
                     .AddXmlFile(configPath, optional: true, reloadOnChange: false)
-                    .AddInMemoryCollection(new List<KeyValuePair<string, string>> { new ("dataProtectionFolder", appFolder.GetDataProtectionPath()) })
+                    .AddInMemoryCollection(new List<KeyValuePair<string, string>> { new("dataProtectionFolder", appFolder.GetDataProtectionPath()) })
                     .AddEnvironmentVariables()
                     .Build();
             }

--- a/src/NzbDrone.Integration.Test/IntegrationTest.cs
+++ b/src/NzbDrone.Integration.Test/IntegrationTest.cs
@@ -23,7 +23,7 @@ namespace NzbDrone.Integration.Test
 
         protected int Port { get; private set; }
 
-        protected PostgresOptions PostgresOptions { get; set; } = new ();
+        protected PostgresOptions PostgresOptions { get; set; } = new();
 
         protected override string RootUrl => $"http://localhost:{Port}/";
 

--- a/src/NzbDrone.Mono/Disk/FindDriveType.cs
+++ b/src/NzbDrone.Mono/Disk/FindDriveType.cs
@@ -6,7 +6,7 @@ namespace NzbDrone.Mono.Disk
 {
     public static class FindDriveType
     {
-        private static readonly Dictionary<string, DriveType> DriveTypeMap = new ()
+        private static readonly Dictionary<string, DriveType> DriveTypeMap = new()
         {
             { "afpfs", DriveType.Network },
             { "apfs", DriveType.Fixed },

--- a/src/NzbDrone.Mono/EnvironmentInfo/VersionAdapters/MacOsVersionAdapter.cs
+++ b/src/NzbDrone.Mono/EnvironmentInfo/VersionAdapters/MacOsVersionAdapter.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Mono.EnvironmentInfo.VersionAdapters
     {
         private const string PLIST_DIR = "/System/Library/CoreServices/";
 
-        private static readonly Regex DarwinVersionRegex = new ("<key>ProductVersion<\\/key>\\s*<string>(?<version>1\\d\\.\\d{1,2}\\.?\\d{0,2}?)<\\/string>",
+        private static readonly Regex DarwinVersionRegex = new("<key>ProductVersion<\\/key>\\s*<string>(?<version>1\\d\\.\\d{1,2}\\.?\\d{0,2}?)<\\/string>",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private readonly IDiskProvider _diskProvider;

--- a/src/NzbDrone.Test.Common/AutoMoq/AutoMoqer.cs
+++ b/src/NzbDrone.Test.Common/AutoMoq/AutoMoqer.cs
@@ -161,7 +161,8 @@ namespace NzbDrone.Test.Common.AutoMoq
                 var mock = (Mock)r.Resolve(mockType);
                 SetMock(serviceType, mock);
                 return mock.Object;
-            }, Reuse.Singleton);
+            },
+                Reuse.Singleton);
         }
 
         private void LoadPlatformLibrary()

--- a/src/NzbDrone.Test.Common/NzbDroneRunner.cs
+++ b/src/NzbDrone.Test.Common/NzbDroneRunner.cs
@@ -143,7 +143,7 @@ namespace NzbDrone.Test.Common
 
         private void Start(string outputLidarrConsoleExe)
         {
-            StringDictionary envVars = new ();
+            StringDictionary envVars = new();
             if (PostgresOptions?.Host != null)
             {
                 envVars.Add("Lidarr__Postgres__Host", PostgresOptions.Host);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Should make it easier for cherry-picking new commits that use the new collection syntax.

Upstream:
- https://github.com/Sonarr/Sonarr/commit/5d7c94f8e9fcf7763c9326e6a34211d863e8c271
- https://github.com/Sonarr/Sonarr/commit/84fbab6ab48e50c13f817aa1bfa1d1c2f720980c
