### PR TITLE
Fix possible NullRef for last start time for refresh artists scheduled task

### DIFF
--- a/src/NzbDrone.Core/Music/Services/RefreshAlbumService.cs
+++ b/src/NzbDrone.Core/Music/Services/RefreshAlbumService.cs
@@ -337,8 +337,8 @@ namespace NzbDrone.Core.Music
             foreach (var album in albums)
             {
                 if (forceAlbumRefresh ||
-                    (updatedMusicbrainzAlbums == null && _checkIfAlbumShouldBeRefreshed.ShouldRefresh(album)) ||
-                    (updatedMusicbrainzAlbums != null && updatedMusicbrainzAlbums.Contains(album.ForeignAlbumId)))
+                    (updatedMusicbrainzAlbums is not { Count: not 0 } && _checkIfAlbumShouldBeRefreshed.ShouldRefresh(album)) ||
+                    (updatedMusicbrainzAlbums is { Count: > 0 } && updatedMusicbrainzAlbums.Contains(album.ForeignAlbumId)))
                 {
                     try
                     {

--- a/src/NzbDrone.Core/Music/Services/RefreshArtistService.cs
+++ b/src/NzbDrone.Core/Music/Services/RefreshArtistService.cs
@@ -410,12 +410,11 @@ namespace NzbDrone.Core.Music
             else
             {
                 var updated = false;
-                var artists = _artistService.GetAllArtists().OrderBy(c => c.Name).ToList();
-                var artistIds = artists.Select(x => x.Id).ToList();
+                var artists = _artistService.GetAllArtists();
 
-                var updatedMusicbrainzArtists = new HashSet<string>();
+                HashSet<string> updatedMusicbrainzArtists = null;
 
-                if (message.LastExecutionTime.HasValue && message.LastExecutionTime.Value.AddDays(14) > DateTime.UtcNow)
+                if (message.LastStartTime.HasValue && message.LastStartTime.Value.AddDays(14) > DateTime.UtcNow)
                 {
                     updatedMusicbrainzArtists = _artistInfo.GetChangedArtists(message.LastStartTime.Value);
                 }
@@ -425,8 +424,8 @@ namespace NzbDrone.Core.Music
                     var artistLocal = artist;
                     var manualTrigger = message.Trigger == CommandTrigger.Manual;
 
-                    if ((updatedMusicbrainzArtists == null && _checkIfArtistShouldBeRefreshed.ShouldRefresh(artistLocal)) ||
-                        (updatedMusicbrainzArtists != null && updatedMusicbrainzArtists.Contains(artistLocal.ForeignArtistId)) ||
+                    if ((updatedMusicbrainzArtists is not { Count: not 0 } && _checkIfArtistShouldBeRefreshed.ShouldRefresh(artistLocal)) ||
+                        (updatedMusicbrainzArtists is { Count: > 0 } && updatedMusicbrainzArtists.Contains(artistLocal.ForeignArtistId)) ||
                         manualTrigger)
                     {
                         try


### PR DESCRIPTION
#### Database Migration
NO

#### Description
While RefreshArtistService already uses LastStartTime for GetChangedArtists, the check is being done on LastExecutionTime which might lead to a possible NRE and incorrect checking if to use changed items.

Also changing to check if the update lists are populated, not just null.