### PR TITLE
Fixed: Disable search for missing albums on changes to a different artist

### DIFF
--- a/src/NzbDrone.Core/Music/Services/RefreshAlbumService.cs
+++ b/src/NzbDrone.Core/Music/Services/RefreshAlbumService.cs
@@ -128,7 +128,19 @@ namespace NzbDrone.Core.Music
                     QualityProfileId = oldArtist.QualityProfileId,
                     RootFolderPath = _rootFolderService.GetBestRootFolderPath(oldArtist.Path),
                     Monitored = oldArtist.Monitored,
-                    Tags = oldArtist.Tags
+                    MonitorNewItems = oldArtist.MonitorNewItems,
+                    Tags = oldArtist.Tags,
+                    AddOptions = new AddArtistOptions
+                    {
+                        SearchForMissingAlbums = false,
+                        Monitored = oldArtist.Monitored,
+                        Monitor = oldArtist.MonitorNewItems switch
+                        {
+                            NewItemMonitorTypes.All => MonitorTypes.All,
+                            NewItemMonitorTypes.New => MonitorTypes.Future,
+                            _ => MonitorTypes.None
+                        },
+                    },
                 };
 
                 _logger.Info("Adding missing parent artist {0}", addArtist);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adding AddOptions with SearchForMissingAlbums disabled on changes to different artists when refresh existing albums.

#### Issues Fixed or Closed by this PR

* Fixes #5819