### PR TITLE
Remove unused package references

### DIFF
--- a/src/Lidarr.Api.V1/Lidarr.Api.V1.csproj
+++ b/src/Lidarr.Api.V1/Lidarr.Api.V1.csproj
@@ -10,7 +10,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="9.0.6" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
     <PackageReference Include="FluentValidation" Version="9.5.4" />
     <PackageReference Include="Ical.Net" Version="4.3.1" />
     <PackageReference Include="NLog" Version="5.5.1" />

--- a/src/NzbDrone.Common/Lidarr.Common.csproj
+++ b/src/NzbDrone.Common/Lidarr.Common.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="System.Text.Json" Version="8.0.6" />
     <PackageReference Include="System.ValueTuple" Version="4.6.2" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.1" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="8.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NzbDrone.Core/Lidarr.Core.csproj
+++ b/src/NzbDrone.Core/Lidarr.Core.csproj
@@ -9,9 +9,7 @@
     <PackageReference Include="MailKit" Version="4.16.0" />
     <PackageReference Include="Polly" Version="8.6.6" />
     <PackageReference Include="System.Text.Json" Version="8.0.6" />
-    <PackageReference Include="System.Memory" Version="4.6.3" />
     <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="8.0.27" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
`Microsoft.Data.SqlClient`, `System.Configuration.ConfigurationManager`, `System.Memory` and `System.Reflection.TypeExtensions` are not referenced anywhere.

Lidarr only talks to SQLite and PostgreSQL: the referenced migration runners are `FluentMigrator.Runner.SQLite` and `FluentMigrator.Runner.Postgres`, with `System.Data.SQLite` and Npgsql as the providers. There is no `using Microsoft.Data`, no `SqlConnection/SqlCommand`, and no use of `ConfigurationManager` in the tree.

System.Memory is a no-op on .Net 8.0, it resolves to zero runtime files and nothing else in the graph depends on it.

`System.Reflection.TypeExtensions` is declared by `Lidarr.Api.V1`, which never uses it. The only `GetTypeInfo()` callers are in `NzbDrone.Core` (`WhereBuilderPostgres` and `WhereBuilderSqlite`), which does not reference the package at all -- the API is in-box on .Net 8.0.

`System.Configuration.ConfigurationManager` is also a transitive dependency of `Microsoft.Data.SqlClient`, so once the latter is gone nothing else requires it.

Dropping the four removes **32** files from the build output: the `SqlClient` assemblies, the `Azure.Identity/MSAL` stack it drags in (`Azure.Core`, `Azure.Identity`, `Microsoft.Identity.Client`, `Microsoft.Identity.Client.Extensions.Msal`, `System.ClientModel`, `System.Memory.Data`), the whole `Microsoft.IdentityModel` stack, `System.IdentityModel.Tokens.Jwt`, `System.Security.Cryptography.ProtectedData` and 13 localized resource directories.

Everything still builds fine, including the Windows and test projects.

#### Todos
- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)
